### PR TITLE
Added OSC intructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ OpenSearch .NET Client
 
 **opensearch-net** is [a community-driven, open source fork](https://aws.amazon.com/blogs/opensource/introducing-opensearch/) of elasticsearch-net licensed under the [Apache v2.0 License](LICENSE.txt). For more information, see [opensearch.org](https://opensearch.org/).
 
+**OSC** is [a community-driven, open source fork](https://aws.amazon.com/blogs/opensource/introducing-opensearch/) of elasticsearch-net high level client NEST licensed under the [Apache v2.0 License](LICENSE.txt). For more information, see [opensearch.org](https://opensearch.org/).
+
 ## Project Resources
 
 * [Project Website](https://opensearch.org/)
@@ -24,6 +26,50 @@ OpenSearch .NET Client
 * [Release Management](RELEASING.md)
 * [Admin Responsibilities](ADMINS.md)
 * [Security](SECURITY.md)
+
+# [OSC](https://github.com/opensearch-project/opensearch-net/tree/main/src/Osc)
+
+OSC is the official high-level .NET client of [OpenSearch](https://github.com/opensearch-project/OpenSearch).
+
+## Getting Started
+Include OSC in your .csproj file.
+```
+<Project>
+  ...
+  <ItemGroup>
+    <ProjectReference Include="..\opensearch-net\src\Osc\Osc.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+**Connecting to a single node**
+```csharp
+var node = new Uri("http://myserver:9200");
+var settings = new ConnectionSettings(node);
+var client = new OpenSearchClient(settings);
+```
+
+# [OpenSearch.Net](src/OpenSearch.Net)
+
+A low-level, dependency free client that has no opinions how you build and represent your requests and responses.
+
+## Getting Started
+Include OpenSearch.Net in your .csproj file.
+```
+<Project>
+  ...
+  <ItemGroup>
+    <ProjectReference Include="..\opensearch-net\src\OpenSearch.Net\OpenSearch.Net.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+**Connecting**
+```csharp
+var node = new Uri("http://myserver:9200");
+var config = new ConnectionConfiguration(node);
+var client = new OpenSearchLowLevelClient(config);
+```
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OSC is the official high-level .NET client of [OpenSearch](https://github.com/op
 
 ## Getting Started
 Include OSC in your .csproj file.
-```
+```xml
 <Project>
   ...
   <ItemGroup>
@@ -55,7 +55,7 @@ A low-level, dependency free client that has no opinions how you build and repre
 
 ## Getting Started
 Include OpenSearch.Net in your .csproj file.
-```
+```xml
 <Project>
   ...
   <ItemGroup>


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
Added OSC intructions to README and indicated that OSC is the OpenSearch version of NEST
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
