### PR TITLE
Update dotnet version to 5.0.405

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100'
+        dotnet-version: '5.0.405'
     - uses: actions/cache@v2
       with:
         path: ~/.nuget/packages

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.100'
+          dotnet-version: '5.0.405'
       - uses: actions/cache@v2
         with:
           path: ~/.nuget/packages
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.100'
+          dotnet-version: '5.0.405'
       - uses: actions/cache@v2
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100'
+        dotnet-version: '5.0.405'
     - uses: actions/cache@v2
       with:
         path: ~/.nuget/packages

--- a/.github/workflows/test-jobs.yml
+++ b/.github/workflows/test-jobs.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.100'
+          dotnet-version: '5.0.405'
       - uses: actions/cache@v2
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/test-jobs.yml
+++ b/.github/workflows/test-jobs.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.100'
+          dotnet-version: '5.0.405'
       - uses: actions/cache@v2
         with:
           path: ~/.nuget/packages

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "5.0.405",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   },


### PR DESCRIPTION
### Description
Update dotnet version used from 5.0.100 to 5.0.405

This change needs to be backported to 1.x and 2.x branches.

### Issues Resolved
#52 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
