### PR TITLE
Revert package version to 1.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <!-- Default Version numbers -->
   <PropertyGroup>
-    <CurrentVersion>1.0.1-alpha</CurrentVersion>
-    <CurrentAssemblyVersion>1.0.1</CurrentAssemblyVersion>
-    <CurrentAssemblyFileVersion>1.0.1</CurrentAssemblyFileVersion>
+    <CurrentVersion>1.0.0</CurrentVersion>
+    <CurrentAssemblyVersion>1.0.0</CurrentAssemblyVersion>
+    <CurrentAssemblyFileVersion>1.0.0</CurrentAssemblyFileVersion>
     <!-- Version and Informational reflect actual version -->
     <Version>$(CurrentVersion)</Version>
     <InformationalVersion>$(CurrentVersion)</InformationalVersion>


### PR DESCRIPTION
### Description
Setting version for all packages to 1.0.0 so that the first available version on nuget.org is 1.0.0 instead of 1.0.1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
