### PR TITLE
Improve License Header Check

### DIFF
--- a/.github/check-license-headers.sh
+++ b/.github/check-license-headers.sh
@@ -36,17 +36,18 @@ set -o errexit
 set -o pipefail
 
 TOP=$(cd "$(dirname "$0")/.." >/dev/null && pwd)
-NLINES=$(wc -l .github/license-header.txt | awk '{print $1}')
+NLINES_CS=$(wc -l .github/license-header.txt | awk '{print $1}')
+NLINES_FS=$(wc -l .github/license-header-fs.txt | awk '{print $1}')
 
 function check_license_header {
     local f
     f=$1
-    if [[ $f == *.fs ]] && ! diff -a --strip-trailing-cr .github/license-header-fs.txt <(head -$NLINES "$f") >/dev/null; then
+    if [[ $f == *.fs ]] && ! diff -a --strip-trailing-cr .github/license-header-fs.txt <(head -$NLINES_FS "$f") >/dev/null; then
         echo $f
-        echo "check-license-headers: error: '$f' does not have required license header, see 'diff -u .github/license-header-fs.txt <(head -$NLINES $f)'"
+        echo "check-license-headers: error: '$f' does not have required license header, see 'diff -u .github/license-header-fs.txt <(head -$NLINES_FS $f)'"
         return 1
-    elif [[ $f != *.fs ]] && ! diff -a --strip-trailing-cr .github/license-header.txt <(head -$NLINES "$f") >/dev/null; then
-        echo "check-license-headers: error: '$f' does not have required license header, see 'diff -u .github/license-header.txt <(head -$NLINES $f)'"
+    elif [[ $f != *.fs ]] && ! diff -a --strip-trailing-cr .github/license-header.txt <(head -$NLINES_CS "$f") >/dev/null; then
+        echo "check-license-headers: error: '$f' does not have required license header, see 'diff -u .github/license-header.txt <(head -$NLINES_CS $f)'"
         return 1
     else
         return 0

--- a/.github/license-header-fs.txt
+++ b/.github/license-header-fs.txt
@@ -3,24 +3,3 @@
 // The OpenSearch Contributors require contributions made to
 // this file be licensed under the Apache-2.0 license or a
 // compatible open source license.
-//
-// Modifications Copyright OpenSearch Contributors. See
-// GitHub history for details.
-//
-//  Licensed to Elasticsearch B.V. under one or more contributor
-//  license agreements. See the NOTICE file distributed with
-//  this work for additional information regarding copyright
-//  ownership. Elasticsearch B.V. licenses this file to you under
-//  the Apache License, Version 2.0 (the "License"); you may
-//  not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing,
-//  software distributed under the License is distributed on an
-//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-//  KIND, either express or implied.  See the License for the
-//  specific language governing permissions and limitations
-//  under the License.
-//

--- a/.github/license-header.txt
+++ b/.github/license-header.txt
@@ -3,24 +3,4 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
-* Modifications Copyright OpenSearch Contributors. See
-* GitHub history for details.
-*
-*  Licensed to Elasticsearch B.V. under one or more contributor
-*  license agreements. See the NOTICE file distributed with
-*  this work for additional information regarding copyright
-*  ownership. Elasticsearch B.V. licenses this file to you under
-*  the Apache License, Version 2.0 (the "License"); you may
-*  not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
-*
-* 	http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
 */

--- a/src/ApiGenerator/CodeTemplatePage.cs
+++ b/src/ApiGenerator/CodeTemplatePage.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/GeneratorLocations.cs
+++ b/src/ApiGenerator/Configuration/GeneratorLocations.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/EndpointOverridesBase.cs
+++ b/src/ApiGenerator/Configuration/Overrides/EndpointOverridesBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/DeleteByQueryOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/DeleteByQueryOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/FlushJobOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/FlushJobOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/ForecastJobOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/ForecastJobOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/GetAnomalyRecordsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/GetAnomalyRecordsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/GetBucketsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/GetBucketsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/GetCalendarEventsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/GetCalendarEventsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/GetCalendarsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/GetCalendarsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/GetCategoriesOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/GetCategoriesOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/GetInfluencersOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/GetInfluencersOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/GetModelSnapshotsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/GetModelSnapshotsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/GetOverallBucketsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/GetOverallBucketsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/IndicesStatsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/IndicesStatsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/MultiTermVectorsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/MultiTermVectorsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/NodesHotThreadsOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/NodesHotThreadsOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/PutIndexTemplateOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/PutIndexTemplateOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/ReindexOnServerOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/ReindexOnServerOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/RevertModelSnapshotOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/RevertModelSnapshotOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/ScrollOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/ScrollOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/SearchOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/SearchOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/UpdateByQueryOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/UpdateByQueryOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/Endpoints/UpdateOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/Endpoints/UpdateOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/Overrides/IEndpointOverrides.cs
+++ b/src/ApiGenerator/Configuration/Overrides/IEndpointOverrides.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Configuration/ViewLocations.cs
+++ b/src/ApiGenerator/Configuration/ViewLocations.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/ApiQueryParametersPatcher.cs
+++ b/src/ApiGenerator/Domain/ApiQueryParametersPatcher.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/CsharpNames.cs
+++ b/src/ApiGenerator/Domain/Code/CsharpNames.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/BoundFluentMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/BoundFluentMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentSyntaxBase.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentSyntaxBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentSyntaxView.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentSyntaxView.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/HighLevelModel.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/HighLevelModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/InitializerMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/InitializerMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/InitializerSyntaxView.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/InitializerSyntaxView.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/MethodSyntaxBase.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/MethodSyntaxBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/Constructor.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/Constructor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/DescriptorPartialImplementation.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/DescriptorPartialImplementation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/FluentRouteSetter.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/FluentRouteSetter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/RequestInterface.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/RequestInterface.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/RequestParameterImplementation.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/RequestParameterImplementation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/RequestPartialImplementation.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/RequestPartialImplementation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Code/LowLevel/LowLevelClientMethod.cs
+++ b/src/ApiGenerator/Domain/Code/LowLevel/LowLevelClientMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/RestApiSpec.cs
+++ b/src/ApiGenerator/Domain/RestApiSpec.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Specification/ApiEndpoint.cs
+++ b/src/ApiGenerator/Domain/Specification/ApiEndpoint.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Specification/Body.cs
+++ b/src/ApiGenerator/Domain/Specification/Body.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Specification/Documentation.cs
+++ b/src/ApiGenerator/Domain/Specification/Documentation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Specification/QueryParameters.cs
+++ b/src/ApiGenerator/Domain/Specification/QueryParameters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Specification/Stability.cs
+++ b/src/ApiGenerator/Domain/Specification/Stability.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Specification/UrlInformation.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlInformation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Specification/UrlPart.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlPart.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Domain/Specification/UrlPath.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlPath.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Extensions.cs
+++ b/src/ApiGenerator/Extensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/ApiEndpointFactory.cs
+++ b/src/ApiGenerator/Generator/ApiEndpointFactory.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/ApiGenerator.cs
+++ b/src/ApiGenerator/Generator/ApiGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/CodeGenerator.cs
+++ b/src/ApiGenerator/Generator/CodeGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/ApiUrlsLookupsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/ApiUrlsLookupsGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/DescriptorsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/DescriptorsGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/EnumsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/EnumsGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/HighLevelClientImplementationGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/HighLevelClientImplementationGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/HighLevelClientInterfaceGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/HighLevelClientInterfaceGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/LowLevelClientInterfaceGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/LowLevelClientInterfaceGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/RazorGeneratorBase.cs
+++ b/src/ApiGenerator/Generator/Razor/RazorGeneratorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/RequestParametersGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/RequestParametersGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Generator/Razor/RequestsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/RequestsGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Program.cs
+++ b/src/ApiGenerator/Program.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/RestSpecDownloader.cs
+++ b/src/ApiGenerator/RestSpecDownloader.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/ApiGenerator/Views/GeneratorNotice.cshtml
+++ b/src/ApiGenerator/Views/GeneratorNotice.cshtml
@@ -5,7 +5,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/ConnectionSettingsAwareContractResolver.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/ConnectionSettingsAwareContractResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.Customization.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.Customization.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.PropertyMappingProvider.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.PropertyMappingProvider.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.Serializer.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.Serializer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/Converters/HandleOscTypesOnSourceJsonConverter.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/Converters/HandleOscTypesOnSourceJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/Converters/TimeSpanToStringConverter.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/Converters/TimeSpanToStringConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/JTokenExtensions.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/JTokenExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/JsonNetSerializer.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/JsonNetSerializer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client.JsonNetSerializer/JsonReaderExtensions.cs
+++ b/src/OpenSearch.Client.JsonNetSerializer/JsonReaderExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Aggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Aggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/AggregateDictionary.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregateDictionary.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/AggregateDictionaryFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregateDictionaryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/AggregateFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregateFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Aggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Aggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/AggregationContainer.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregationContainer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/AdjacencyMatrix/AdjacencyMatrixAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/AdjacencyMatrix/AdjacencyMatrixAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/AutoDateHistogram/MinimumInterval.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/AutoDateHistogram/MinimumInterval.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Bucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Bucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/BucketAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/BucketAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/BucketAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/BucketAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Children/ChildrenAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Children/ChildrenAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeAggregationSource.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/GeoTileGridCompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/GeoTileGridCompositeAggregationSource.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/HistogramCompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/HistogramCompositeAggregationSource.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/TermsCompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/TermsCompositeAggregationSource.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/DateHistogram/DateHistogramBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/DateHistogram/DateHistogramBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/DateHistogram/DateInterval.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/DateHistogram/DateInterval.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/DateRange/DateRangeAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/DateRange/DateRangeAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/DateRange/DateRangeExpression.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/DateRange/DateRangeExpression.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/DiversifiedSampler/DiversifiedSamplerAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/DiversifiedSampler/DiversifiedSamplerAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/DiversifiedSampler/DiversifiedSamplerAggregationExecutionHint.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/DiversifiedSampler/DiversifiedSamplerAggregationExecutionHint.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Filter/FilterAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Filter/FilterAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Filter/FilterAggregationJsonConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Filter/FilterAggregationJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Filters/FiltersAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Filters/FiltersAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Filters/FiltersAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Filters/FiltersAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Filters/NamedFiltersContainer.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Filters/NamedFiltersContainer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/GeoDistance/GeoDistanceAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/GeoDistance/GeoDistanceAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/GeoHashGrid/GeoHashPrecision.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/GeoHashGrid/GeoHashPrecision.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/GeoTileGrid/GeoTileGridAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/GeoTileGrid/GeoTileGridAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/GeoTileGrid/GeoTilePrecision.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/GeoTileGrid/GeoTilePrecision.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Global/GlobalAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Global/GlobalAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Histogram/ExtendedBounds.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Histogram/ExtendedBounds.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Histogram/HardBounds.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Histogram/HardBounds.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Histogram/HistogramAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Histogram/HistogramAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Histogram/HistogramOrder.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Histogram/HistogramOrder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/IpRange/IpRangeAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/IpRange/IpRangeAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/IpRange/IpRangeAggregationRange.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/IpRange/IpRangeAggregationRange.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/IpRange/IpRangeBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/IpRange/IpRangeBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/KeyedBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/KeyedBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Missing/MissingAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Missing/MissingAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/MultiTermsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/MultiTermsAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/MultiTermsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/MultiTermsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/MultiTermsBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/MultiTermsBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/Term.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/Term.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Nested/NestedAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Nested/NestedAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Parent/ParentAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Parent/ParentAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Range/RangeAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Range/RangeAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Range/RangeBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Range/RangeBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/RareTerms/RareTermsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/RareTerms/RareTermsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/RareTerms/RareTermsBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/RareTerms/RareTermsBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/ReverseNested/ReverseNestedAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/ReverseNested/ReverseNestedAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Sampler/SamplerAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Sampler/SamplerAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Sampler/SamplerAggregationExecutionHint.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Sampler/SamplerAggregationExecutionHint.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/ChiSquareHeuristic.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/ChiSquareHeuristic.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/GoogleNormalizedDistanceHeuristic.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/GoogleNormalizedDistanceHeuristic.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/MutualInformationHeuristic.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/MutualInformationHeuristic.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/PercentageScoreHeuristic.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/PercentageScoreHeuristic.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/ScriptedHeuristic.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/Heuristics/ScriptedHeuristic.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/IncludeExclude.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/IncludeExclude.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/SignificantTermsBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/SignificantTermsBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantText/SignificantTextAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantText/SignificantTextAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsAggregationCollectMode.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsAggregationCollectMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsAggregationExecutionHint.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsAggregationExecutionHint.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsExclude.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsExclude.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsExcludeFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsExcludeFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsInclude.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsInclude.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsIncludeFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsIncludeFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsOrder.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsOrder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsOrderDescriptor.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsOrderDescriptor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Matrix/MatrixAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Matrix/MatrixAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Matrix/MatrixAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Matrix/MatrixAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Matrix/MatrixStats/MatrixStatsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Matrix/MatrixStats/MatrixStatsAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Matrix/MatrixStats/MatrixStatsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Matrix/MatrixStats/MatrixStatsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Matrix/MatrixStats/MatrixStatsMode.cs
+++ b/src/OpenSearch.Client/Aggregations/Matrix/MatrixStats/MatrixStatsMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Average/AverageAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Average/AverageAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Cardinality/CardinalityAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Cardinality/CardinalityAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/GeoBounds/GeoBoundsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/GeoBounds/GeoBoundsAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/GeoBounds/GeoBoundsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/GeoBounds/GeoBoundsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/GeoCentroid/GeoCentroidAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/GeoCentroid/GeoCentroidAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/GeoCentroid/GeoCentroidAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/GeoCentroid/GeoCentroidAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/GeoLine/GeoLineAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/GeoLine/GeoLineAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/GeoLine/GeoLineAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/GeoLine/GeoLineAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Max/MaxAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Max/MaxAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/MedianAbsoluteDeviation/MedianAbsoluteDeviationAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/MedianAbsoluteDeviation/MedianAbsoluteDeviationAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/MetricAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/MetricAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/MetricAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/MetricAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Min/MinAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Min/MinAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/PercentileRanks/PercentileRanksAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/PercentileRanks/PercentileRanksAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/HdrHistogramMethod.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/HdrHistogramMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/IPercentilesMethod.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/IPercentilesMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/TDigestMethod.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/TDigestMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesAggregationFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesAggregationFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesMetricAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesMetricAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Stats/StatsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Stats/StatsAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Stats/StatsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Stats/StatsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/Sum/SumAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Sum/SumAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/TopHits/TopHitsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/TopHits/TopHitsAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/TopHits/TopHitsAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/TopHits/TopHitsAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/ValueAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/ValueAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/ValueCount/ValueCountAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/ValueCount/ValueCountAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/WeightedAverage/WeightedAverageAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/WeightedAverage/WeightedAverageAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Metric/WeightedAverage/WeightedAverageValue.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/WeightedAverage/WeightedAverageValue.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/AverageBucket/AverageBucketAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/AverageBucket/AverageBucketAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/BucketScript/BucketScriptAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/BucketScript/BucketScriptAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/BucketSelector/BucketSelectorAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/BucketSelector/BucketSelectorAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/BucketSort/BucketSortAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/BucketSort/BucketSortAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/BucketsPath.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/BucketsPath.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/CumulativeSum/CumulativeSumAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/CumulativeSum/CumulativeSumAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/Derivative/DerivativeAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/Derivative/DerivativeAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/ExtendedStatsBucket/ExtendedStatsBucketAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/ExtendedStatsBucket/ExtendedStatsBucketAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/GapPolicy.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/GapPolicy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/KeyedValueAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/KeyedValueAggregate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MaxBucket/MaxBucketAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MaxBucket/MaxBucketAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MinBucket/MinBucketAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MinBucket/MinBucketAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/EwmaModel.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/EwmaModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/HoltLinearModel.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/HoltLinearModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/HoltWintersModel.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/HoltWintersModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/IMovingAverageModel.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/IMovingAverageModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/LinearModel.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/LinearModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/SimpleModel.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/SimpleModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/MovingAverageAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/MovingAverageAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/MovingAverageAggregationFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/MovingAverageAggregationFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingFunction/MovingFunctionAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingFunction/MovingFunctionAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/PercentilesBucket/PercentilesBucketAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/PercentilesBucket/PercentilesBucketAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/PipelineAggregationBase.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/PipelineAggregationBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/StatsBucket/StatsBucketAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/StatsBucket/StatsBucketAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Pipeline/SumBucket/SumBucketAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/SumBucket/SumBucketAggregation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/VerbatimDictionaryKeysFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/VerbatimDictionaryKeysFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Visitor/AggregationVisitor.cs
+++ b/src/OpenSearch.Client/Aggregations/Visitor/AggregationVisitor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Visitor/AggregationVisitorScope.cs
+++ b/src/OpenSearch.Client/Aggregations/Visitor/AggregationVisitorScope.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Aggregations/Visitor/AggregationWalker.cs
+++ b/src/OpenSearch.Client/Aggregations/Visitor/AggregationWalker.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analysis.cs
+++ b/src/OpenSearch.Client/Analysis/Analysis.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/AnalyzerBase.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/AnalyzerBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/AnalyzerFormatter.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/AnalyzerFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/Analyzers.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/Analyzers.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/CustomAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/CustomAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/FingerprintAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/FingerprintAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/KeywordAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/KeywordAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/LanguageAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/LanguageAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/NoriAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/NoriAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/PatternAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/PatternAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/SimpleAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/SimpleAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/SnowballAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/SnowballAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/StandardAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/StandardAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/StopAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/StopAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Analyzers/WhitespaceAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/WhitespaceAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/CharFilters/CharFilterBase.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/CharFilterBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/CharFilters/CharFilterFormatter.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/CharFilterFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/CharFilters/CharFilters.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/CharFilters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/CharFilters/HtmlStripCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/HtmlStripCharFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/CharFilters/MappingCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/MappingCharFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/CharFilters/PatternReplaceCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/PatternReplaceCharFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Languages/Language.cs
+++ b/src/OpenSearch.Client/Analysis/Languages/Language.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Languages/SnowballLanguage.cs
+++ b/src/OpenSearch.Client/Analysis/Languages/SnowballLanguage.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Normalizers/CustomNormalizer.cs
+++ b/src/OpenSearch.Client/Analysis/Normalizers/CustomNormalizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Normalizers/NormalizerBase.cs
+++ b/src/OpenSearch.Client/Analysis/Normalizers/NormalizerBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Normalizers/NormalizerFormatter.cs
+++ b/src/OpenSearch.Client/Analysis/Normalizers/NormalizerFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Normalizers/Normalizers.cs
+++ b/src/OpenSearch.Client/Analysis/Normalizers/Normalizers.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/Collation/IcuCollationAlternate.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/Collation/IcuCollationAlternate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/Collation/IcuCollationCaseFirst.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/Collation/IcuCollationCaseFirst.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/Collation/IcuCollationDecomposition.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/Collation/IcuCollationDecomposition.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/Collation/IcuCollationStrength.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/Collation/IcuCollationStrength.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuCollationTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuCollationTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuFoldingTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuFoldingTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuNormalizationCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuNormalizationCharFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuNormalizationTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuNormalizationTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuTransformTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuTransformTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/Normalization/IcuNormalizationMode.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/Normalization/IcuNormalizationMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/Normalization/IcuNormalizationType.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/Normalization/IcuNormalizationType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/Transform/IcuNormalizationType.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/Transform/IcuNormalizationType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiIterationMarkCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiIterationMarkCharFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiPartOfSpeechTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiPartOfSpeechTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiReadingFormTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiReadingFormTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiStemmerTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiStemmerTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiTokenizationMode.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiTokenizationMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticEncoder.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticEncoder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticLanguage.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticLanguage.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticNameType.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticNameType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticRuleType.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticRuleType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/StopWords.cs
+++ b/src/OpenSearch.Client/Analysis/StopWords.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/AsciiFoldingTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/AsciiFoldingTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/CommonGramsTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/CommonGramsTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/CompoundWord/CompoundWordTokenFilterBase.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/CompoundWord/CompoundWordTokenFilterBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/CompoundWord/DictionaryDecompounderTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/CompoundWord/DictionaryDecompounderTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/CompoundWord/HyphenationDecompounderTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/CompoundWord/HyphenationDecompounderTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/ConditionTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/ConditionTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/DelimitedPayload/DelimitedPayloadEncoding.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/DelimitedPayload/DelimitedPayloadEncoding.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/DelimitedPayload/DelimitedPayloadTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/DelimitedPayload/DelimitedPayloadTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/EdgeNGram/EdgeNGramSide.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/EdgeNGram/EdgeNGramSide.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/EdgeNGram/EdgeNGramTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/EdgeNGram/EdgeNGramTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/ElisionTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/ElisionTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/FingerprintTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/FingerprintTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/HunspellTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/HunspellTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/KStemTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/KStemTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/KeepTypesTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/KeepTypesTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/KeepWordsTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/KeepWordsTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/KeywordMarkerTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/KeywordMarkerTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/LengthTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/LengthTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/LimitTokenCountTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/LimitTokenCountTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/LowercaseTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/LowercaseTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/MultiplexerTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/MultiplexerTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/NgramTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/NgramTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/NoriPartOfSpeechTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/NoriPartOfSpeechTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/PatternCaptureTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/PatternCaptureTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/PatternReplaceTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/PatternReplaceTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/PorterStemTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/PorterStemTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/PredicateTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/PredicateTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/RemoveDuplicatesTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/RemoveDuplicatesTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/ReverseTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/ReverseTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Shingle/ShingleTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Shingle/ShingleTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/SnowballTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/SnowballTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/StemmerOverrideTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/StemmerOverrideTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/StemmerTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/StemmerTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Stop/StopTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Stop/StopTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymFormat.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymFormat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymGraphTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymGraphTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilterBase.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilterBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilterFormatter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilterFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilters.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/TrimTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/TrimTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/TruncateTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/TruncateTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/UniqueTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/UniqueTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/UppercaseTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/UppercaseTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/WordDelimiter/WordDelimiterTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/WordDelimiter/WordDelimiterTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/TokenFilters/WordDelimiterGraph/WordDelimiterGraphTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/WordDelimiterGraph/WordDelimiterGraphTokenFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/CharGroupTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/CharGroupTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/KeywordTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/KeywordTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/LetterTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/LetterTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/LowercaseTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/LowercaseTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/NGram/EdgeNGramTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/NGram/EdgeNGramTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/NGram/NGramTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/NGram/NGramTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/NGram/TokenChar.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/NGram/TokenChar.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/NoriTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/NoriTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/PathHierarchyTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/PathHierarchyTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/PatternTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/PatternTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/StandardTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/StandardTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/TokenizerBase.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/TokenizerBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/TokenizerFormatter.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/TokenizerFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/Tokenizers.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/Tokenizers.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/UaxEmailUrlTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/UaxEmailUrlTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Analysis/Tokenizers/WhitespaceTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/WhitespaceTokenizer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatAliases/CatAliasesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatAliases/CatAliasesRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatAliases/CatAliasesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatAliases/CatAliasesRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatAllocation/CatAllocationRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatAllocation/CatAllocationRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatAllocation/CatAllocationRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatAllocation/CatAllocationRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatCount/CatCountRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatCount/CatCountRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatCount/CatCountRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatCount/CatCountRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRecordJsonConverter.cs
+++ b/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRecordJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatHealth/CatHealthRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatHealth/CatHealthRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatHealth/CatHealthRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatHealth/CatHealthRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatHelp/CatHelpRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatHelp/CatHelpRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatHelp/CatHelpRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatHelp/CatHelpRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatHelpResponseBuilder.cs
+++ b/src/OpenSearch.Client/Cat/CatHelpResponseBuilder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatIndices/CatIndicesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatIndices/CatIndicesRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatIndices/CatIndicesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatIndices/CatIndicesRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatMaster/CatMasterRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatMaster/CatMasterRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatMaster/CatMasterRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatMaster/CatMasterRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatNodeAttributes/CatNodeAttributesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatNodeAttributes/CatNodeAttributesRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatNodeAttributes/CatNodeAttributesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatNodeAttributes/CatNodeAttributesRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatNodes/CatNodesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatNodes/CatNodesRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatNodes/CatNodesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatNodes/CatNodesRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatPendingTasks/CatPendingTasksRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatPendingTasks/CatPendingTasksRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatPendingTasks/CatPendingTasksRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatPendingTasks/CatPendingTasksRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatPlugins/CatPluginsRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatPlugins/CatPluginsRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatPlugins/CatPluginsRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatPlugins/CatPluginsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatRecovery/CatRecoveryRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatRecovery/CatRecoveryRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatRecovery/CatRecoveryRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatRecovery/CatRecoveryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatRepositories/CatRepositoriesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatRepositories/CatRepositoriesRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatRepositories/CatRepositoriesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatRepositories/CatRepositoriesRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatResponse.cs
+++ b/src/OpenSearch.Client/Cat/CatResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatResponseBuilder.cs
+++ b/src/OpenSearch.Client/Cat/CatResponseBuilder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatSegments/CatSegmentsRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatSegments/CatSegmentsRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatSegments/CatSegmentsRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatSegments/CatSegmentsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatShards/CatShardsRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatShards/CatShardsRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatShards/CatShardsRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatShards/CatShardsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatSnapshots/CatSnapshotsRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatSnapshots/CatSnapshotsRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatSnapshots/CatSnapshotsRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatSnapshots/CatSnapshotsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatTasks/CatTasksRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatTasks/CatTasksRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatTasks/CatTasksRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatTasks/CatTasksRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatTemplates/CatTemplatesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatTemplates/CatTemplatesRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatTemplates/CatTemplatesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatTemplates/CatTemplatesRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatThreadPool/CatThreadPoolRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatThreadPool/CatThreadPoolRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/CatThreadPool/CatThreadPoolRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatThreadPool/CatThreadPoolRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cat/ICatRecord.cs
+++ b/src/OpenSearch.Client/Cat/ICatRecord.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterAllocationExplain/ClusterAllocationExplainRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterAllocationExplain/ClusterAllocationExplainRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterAllocationExplain/ClusterAllocationExplainResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterAllocationExplain/ClusterAllocationExplainResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterHealth.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterHealth/ClusterHealthRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth/ClusterHealthRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterHealth/ClusterHealthResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth/ClusterHealthResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterHealth/IndexHealthStats.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth/IndexHealthStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterHealth/ShardHealthStats.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth/ShardHealthStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterPendingTasks/ClusterPendingTasksRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterPendingTasks/ClusterPendingTasksRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterPendingTasks/ClusterPendingTasksResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterPendingTasks/ClusterPendingTasksResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteDecision.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteDecision.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteExplanation.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteExplanation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteParameters.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteParameters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/AllocateClusterRerouteCommandBase.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/AllocateClusterRerouteCommandBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/CancelClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/CancelClusterRerouteCommand.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/ClusterRerouteCommandFormatter.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/ClusterRerouteCommandFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/IClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/IClusterRerouteCommand.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/MoveClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/MoveClusterRerouteCommand.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/RemoteClusterConfiguration.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/RemoteClusterConfiguration.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterState/ClusterStateRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterState/ClusterStateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterState/ClusterStateResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterState/ClusterStateResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterIndicesStats.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterIndicesStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterNodesStats.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterNodesStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesHotThreads/NodeHotThreadsResponseBuilder.cs
+++ b/src/OpenSearch.Client/Cluster/NodesHotThreads/NodeHotThreadsResponseBuilder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesHotThreads/NodesHotThreadsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/NodesHotThreads/NodesHotThreadsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesHotThreads/NodesHotThreadsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/NodesHotThreads/NodesHotThreadsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesInfo/NodeInfo.cs
+++ b/src/OpenSearch.Client/Cluster/NodesInfo/NodeInfo.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesInfo/NodeRole.cs
+++ b/src/OpenSearch.Client/Cluster/NodesInfo/NodeRole.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesInfo/NodesInfoRequest.cs
+++ b/src/OpenSearch.Client/Cluster/NodesInfo/NodesInfoRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesInfo/NodesInfoResponse.cs
+++ b/src/OpenSearch.Client/Cluster/NodesInfo/NodesInfoResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesResponseBase.cs
+++ b/src/OpenSearch.Client/Cluster/NodesResponseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesStats/AdaptiveSelectionStats.cs
+++ b/src/OpenSearch.Client/Cluster/NodesStats/AdaptiveSelectionStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesStats/NodeStats.cs
+++ b/src/OpenSearch.Client/Cluster/NodesStats/NodeStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesStats/NodeStatsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/NodesStats/NodeStatsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesStats/NodesStatsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/NodesStats/NodesStatsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesStats/Statistics/IngestStats.cs
+++ b/src/OpenSearch.Client/Cluster/NodesStats/Statistics/IngestStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesStats/Statistics/NodeIngestStats.cs
+++ b/src/OpenSearch.Client/Cluster/NodesStats/Statistics/NodeIngestStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesUsage/NodeUsageInformation.cs
+++ b/src/OpenSearch.Client/Cluster/NodesUsage/NodeUsageInformation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesUsage/NodeUsageResponse.cs
+++ b/src/OpenSearch.Client/Cluster/NodesUsage/NodeUsageResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/NodesUsage/NodesUsageRequest.cs
+++ b/src/OpenSearch.Client/Cluster/NodesUsage/NodesUsageRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/Ping/PingRequest.cs
+++ b/src/OpenSearch.Client/Cluster/Ping/PingRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/Ping/PingResponse.cs
+++ b/src/OpenSearch.Client/Cluster/Ping/PingResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ReloadSecureSettings/ReloadSecureSettingsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ReloadSecureSettings/ReloadSecureSettingsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/ReloadSecureSettings/ReloadSecureSettingsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ReloadSecureSettings/ReloadSecureSettingsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/RemoteInfo/RemoteInfoRequest.cs
+++ b/src/OpenSearch.Client/Cluster/RemoteInfo/RemoteInfoRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/RemoteInfo/RemoteInfoResponse.cs
+++ b/src/OpenSearch.Client/Cluster/RemoteInfo/RemoteInfoResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/RootNodeInfo/RootNodeInfoRequest.cs
+++ b/src/OpenSearch.Client/Cluster/RootNodeInfo/RootNodeInfoRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/RootNodeInfo/RootVersionInfoResponse.cs
+++ b/src/OpenSearch.Client/Cluster/RootNodeInfo/RootVersionInfoResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/TaskManagement/CancelTasks/CancelTasksRequest.cs
+++ b/src/OpenSearch.Client/Cluster/TaskManagement/CancelTasks/CancelTasksRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/TaskManagement/CancelTasks/CancelTasksResponse.cs
+++ b/src/OpenSearch.Client/Cluster/TaskManagement/CancelTasks/CancelTasksResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/TaskManagement/GetTask/GetTaskRequest.cs
+++ b/src/OpenSearch.Client/Cluster/TaskManagement/GetTask/GetTaskRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/TaskManagement/GetTask/GetTaskResponse.cs
+++ b/src/OpenSearch.Client/Cluster/TaskManagement/GetTask/GetTaskResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/TaskManagement/GetTask/TaskInfo.cs
+++ b/src/OpenSearch.Client/Cluster/TaskManagement/GetTask/TaskInfo.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/TaskManagement/ListTasks/ListTasksRequest.cs
+++ b/src/OpenSearch.Client/Cluster/TaskManagement/ListTasks/ListTasksRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/TaskManagement/ListTasks/ListTasksResponse.cs
+++ b/src/OpenSearch.Client/Cluster/TaskManagement/ListTasks/ListTasksResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/ClrPropertyMapping.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/ClrPropertyMapping.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/MemberInfoResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/MemberInfoResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsADictionary/IIsADictionary.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsADictionary/IIsADictionary.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsADictionary/IsADictionaryBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsADictionary/IsADictionaryBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsADictionary/IsADictionaryDescriptorBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsADictionary/IsADictionaryDescriptorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsAReadOnlyDictionary/IIsAReadOnlyDictionary.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsAReadOnlyDictionary/IIsAReadOnlyDictionary.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsAReadOnlyDictionary/IsADictionaryBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsAReadOnlyDictionary/IsADictionaryBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/PerFieldAnalyzer/PerFieldAnalyzer.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/PerFieldAnalyzer/PerFieldAnalyzer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Extensions/ExceptionExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Extensions/ExceptionExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Extensions/ExpressionExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Extensions/ExpressionExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Extensions/Extensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Extensions/StringExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Extensions/StringExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Extensions/SuffixExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Extensions/SuffixExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Extensions/TypeExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Extensions/TypeExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Fields/FieldValues.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Fields/FieldValues.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Fields/FieldValuesFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Fields/FieldValuesFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Fluent/DescriptorBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Fluent/DescriptorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Fluent/Fluent.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Fluent/Fluent.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Fluent/FluentDictionary.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Fluent/FluentDictionary.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Fluent/Promise/DescriptorPromiseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Fluent/Promise/DescriptorPromiseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Fluent/SelectorBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Fluent/SelectorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/ForAttribute.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/ForAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/DocumentPath/DocumentPath.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/DocumentPath/DocumentPath.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Field/Field.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldExpressionVisitor.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldExpressionVisitor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Field/ToStringExpressionVisitor.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Field/ToStringExpressionVisitor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/Fields.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/Fields.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/FieldsDescriptor.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/FieldsDescriptor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/FieldsFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/FieldsFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Id/Id.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Id/Id.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Id/IdExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Id/IdExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Id/IdFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Id/IdFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Id/IdResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Id/IdResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Id/Ids.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Id/Ids.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexName.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexName.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexNameExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexNameExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexNameFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexNameFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/IndexUuid/IndexUuid.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/IndexUuid/IndexUuid.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/Indices.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/Indices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesMultiSyntaxFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesMultiSyntaxFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Inferrer.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Inferrer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/Routing.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/Routing.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/RoutingFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/RoutingFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/RoutingResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/RoutingResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/LongId/LongId.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/LongId/LongId.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Metrics/IndexMetrics.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Metrics/IndexMetrics.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Metrics/Metrics.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Metrics/Metrics.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Name/Name.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Name/Name.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Name/Names.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Name/Names.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/NodeId/NodeIds.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/NodeId/NodeIds.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/PropertyName/PropertyName.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/PropertyName/PropertyName.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/PropertyName/PropertyNameExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/PropertyName/PropertyNameExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/PropertyName/PropertyNameFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/PropertyName/PropertyNameFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationName.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationName.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationNameExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationNameExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationNameFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationNameFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationNameResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationNameResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/TaskId/TaskId.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/TaskId/TaskId.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Timestamp/Timestamp.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Timestamp/Timestamp.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/LazyDocument/LazyDocument.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/LazyDocument/LazyDocument.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/LazyDocument/LazyDocumentFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/LazyDocument/LazyDocumentFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Reactive/BlockingSubscribeExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Reactive/BlockingSubscribeExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Reactive/CoordinatedRequestObserverBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Reactive/CoordinatedRequestObserverBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Reactive/GetEnumerator.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Reactive/GetEnumerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Reactive/PartitionHelper.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Reactive/PartitionHelper.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Reactive/ProducerConsumerBackPressure.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Reactive/ProducerConsumerBackPressure.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Request/ApiUrls.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Request/ApiUrls.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Request/IProxyRequest.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Request/IProxyRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Request/RequestBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Request/RequestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Request/RouteValues.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Request/RouteValues.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Request/UrlLookup.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Request/UrlLookup.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Response/AcknowledgedResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/AcknowledgedResponseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Response/DictionaryResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/DictionaryResponseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Response/DynamicResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/DynamicResponseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Response/IndicesResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/IndicesResponseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Response/OpenSearchVersionInfo.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/OpenSearchVersionInfo.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Response/ResolvableDictionaryProxy.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/ResolvableDictionaryProxy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Response/ResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/ResponseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Response/ShardsOperationResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/ShardsOperationResponseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/EpochDateTimeAttribute.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/EpochDateTimeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/IgnoreAttribute.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/IgnoreAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/PropertyNameAttribute.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/PropertyNameAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/StringTimeSpanAttribute.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/StringTimeSpanAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/CompositeFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/CompositeFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DateTimeEpochMillisecondsFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DateTimeEpochMillisecondsFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DateTimeOffsetEpochMillisecondsFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DateTimeOffsetEpochMillisecondsFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IndicesBoostFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IndicesBoostFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IntStringFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IntStringFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/InterfaceGenericDictionaryResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/InterfaceGenericDictionaryResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IsADictionaryFormatterResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IsADictionaryFormatterResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/JsonFormatterResolverExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/JsonFormatterResolverExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/JsonNetCompatibleUriFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/JsonNetCompatibleUriFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/NullableDateTimeOffsetEpochSecondsFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/NullableDateTimeOffsetEpochSecondsFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/NullableStringBooleanFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/NullableStringBooleanFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/NullableTimeSpanTicksFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/NullableTimeSpanTicksFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/OpenSearchClientFormatterResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/OpenSearchClientFormatterResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ProxyRequestFormatterBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ProxyRequestFormatterBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ReadAsAttribute.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ReadAsAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ReadAsFormatterResolver.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ReadAsFormatterResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SingleOrEnumerableFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SingleOrEnumerableFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SortOrderFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SortOrderFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/TimeSpanTicksFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/TimeSpanTicksFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/UnionListFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/UnionListFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/Utf8JsonReaderExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/Utf8JsonReaderExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/VerbatimDictionaryKeysFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/VerbatimDictionaryKeysFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/PropertyMapping.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/PropertyMapping.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/SourceValueWriteConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/SourceValueWriteConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/StatefulSerializerExtensions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/StatefulSerializerExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Static/Infer.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Static/Infer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Union/Union.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Union/Union.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonAbstractions/Union/UnionFormatter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Union/UnionFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Attributes/AlternativeEnumMemberAttribute.cs
+++ b/src/OpenSearch.Client/CommonOptions/Attributes/AlternativeEnumMemberAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/DateFormat/DateFormat.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateFormat/DateFormat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/DateMath/DateMath.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateMath/DateMath.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/DateMath/DateMathExpression.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateMath/DateMathExpression.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/DateMath/DateMathOperation.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateMath/DateMathOperation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/DateMath/DateMathTime.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateMath/DateMathTime.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/DateMath/DateMathTimeUnit.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateMath/DateMathTimeUnit.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Fuzziness/Fuzziness.cs
+++ b/src/OpenSearch.Client/CommonOptions/Fuzziness/Fuzziness.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Fuzziness/FuzzinessFormatter.cs
+++ b/src/OpenSearch.Client/CommonOptions/Fuzziness/FuzzinessFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Fuzziness/IFuzziness.cs
+++ b/src/OpenSearch.Client/CommonOptions/Fuzziness/IFuzziness.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Geo/Distance.cs
+++ b/src/OpenSearch.Client/CommonOptions/Geo/Distance.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Geo/DistanceFormatter.cs
+++ b/src/OpenSearch.Client/CommonOptions/Geo/DistanceFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Geo/DistanceUnit.cs
+++ b/src/OpenSearch.Client/CommonOptions/Geo/DistanceUnit.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Geo/GeoDistanceType.cs
+++ b/src/OpenSearch.Client/CommonOptions/Geo/GeoDistanceType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Geo/GeoShapeRelation.cs
+++ b/src/OpenSearch.Client/CommonOptions/Geo/GeoShapeRelation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Hit/ShardStatistics.cs
+++ b/src/OpenSearch.Client/CommonOptions/Hit/ShardStatistics.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/MinimumShouldMatch/MinimumShouldMatch.cs
+++ b/src/OpenSearch.Client/CommonOptions/MinimumShouldMatch/MinimumShouldMatch.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/MinimumShouldMatch/MinimumShouldMatchFormatter.cs
+++ b/src/OpenSearch.Client/CommonOptions/MinimumShouldMatch/MinimumShouldMatchFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Range/AggregationRange.cs
+++ b/src/OpenSearch.Client/CommonOptions/Range/AggregationRange.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Range/Ranges.cs
+++ b/src/OpenSearch.Client/CommonOptions/Range/Ranges.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Scripting/IndexedScript.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/IndexedScript.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Scripting/InlineScript.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/InlineScript.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Scripting/ScriptBase.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/ScriptBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Scripting/ScriptFields.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/ScriptFields.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Scripting/ScriptFormatter.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/ScriptFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Shape/ShapeRelation.cs
+++ b/src/OpenSearch.Client/CommonOptions/Shape/ShapeRelation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Sorting/SortFormatter.cs
+++ b/src/OpenSearch.Client/CommonOptions/Sorting/SortFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/CompletionStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/CompletionStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/DocStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/DocStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/FieldDataStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/FieldDataStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/FlushStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/FlushStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/GetStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/GetStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/IndexingStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/IndexingStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/MergesStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/MergesStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/PluginStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/PluginStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/QueryCacheStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/QueryCacheStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/RecoveryStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/RecoveryStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/RefreshStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/RefreshStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/RequestCacheStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/RequestCacheStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/SearchStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/SearchStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/SegmentsStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/SegmentsStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/StoreStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/StoreStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/TranslogStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/TranslogStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/Stats/WarmerStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/WarmerStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/TimeUnit/Time.cs
+++ b/src/OpenSearch.Client/CommonOptions/TimeUnit/Time.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/TimeUnit/TimeFormatter.cs
+++ b/src/OpenSearch.Client/CommonOptions/TimeUnit/TimeFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CommonOptions/TimeUnit/TimeUnit.cs
+++ b/src/OpenSearch.Client/CommonOptions/TimeUnit/TimeUnit.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CrossPlatform/NativeMethods.cs
+++ b/src/OpenSearch.Client/CrossPlatform/NativeMethods.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CrossPlatform/RuntimeInformation.cs
+++ b/src/OpenSearch.Client/CrossPlatform/RuntimeInformation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/CrossPlatform/TypeExtensions.cs
+++ b/src/OpenSearch.Client/CrossPlatform/TypeExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/DanglingIndices/Delete/DeleteDanglingIndexRequest.cs
+++ b/src/OpenSearch.Client/DanglingIndices/Delete/DeleteDanglingIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/DanglingIndices/Delete/DeleteDanglingIndexResponse.cs
+++ b/src/OpenSearch.Client/DanglingIndices/Delete/DeleteDanglingIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/DanglingIndices/Import/ImportDanglingIndexRequest.cs
+++ b/src/OpenSearch.Client/DanglingIndices/Import/ImportDanglingIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/DanglingIndices/Import/ImportDanglingIndexResponse.cs
+++ b/src/OpenSearch.Client/DanglingIndices/Import/ImportDanglingIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/DanglingIndices/List/ListDanglingIndicesRequest.cs
+++ b/src/OpenSearch.Client/DanglingIndices/List/ListDanglingIndicesRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/DanglingIndices/List/ListDanglingIndicesResponse.cs
+++ b/src/OpenSearch.Client/DanglingIndices/List/ListDanglingIndicesResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.Cat.cs
+++ b/src/OpenSearch.Client/Descriptors.Cat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.Cluster.cs
+++ b/src/OpenSearch.Client/Descriptors.Cluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.DanglingIndices.cs
+++ b/src/OpenSearch.Client/Descriptors.DanglingIndices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.Indices.cs
+++ b/src/OpenSearch.Client/Descriptors.Indices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.Ingest.cs
+++ b/src/OpenSearch.Client/Descriptors.Ingest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.NoNamespace.cs
+++ b/src/OpenSearch.Client/Descriptors.NoNamespace.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.Nodes.cs
+++ b/src/OpenSearch.Client/Descriptors.Nodes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.Snapshot.cs
+++ b/src/OpenSearch.Client/Descriptors.Snapshot.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.Tasks.cs
+++ b/src/OpenSearch.Client/Descriptors.Tasks.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Descriptors.cs
+++ b/src/OpenSearch.Client/Descriptors.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkCreate.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkCreate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkDelete.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkDelete.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkIndex.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkIndex.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkOperationBase.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkOperationBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkOperationsCollection.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkOperationsCollection.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkUpdate.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkUpdate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/IBulkOperation.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/IBulkOperation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkRequestFormatter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkRequestFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkCreateResponseItem.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkCreateResponseItem.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkDeleteResponseItem.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkDeleteResponseItem.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkIndexResponseItem.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkIndexResponseItem.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemFormatter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkUpdateResponseItem.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkUpdateResponseItem.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/ConcreteBulkIndexResponseItemFormatter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/ConcreteBulkIndexResponseItemFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/OpenSearchClient-DeleteMany.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/OpenSearchClient-DeleteMany.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/OpenSearchClient-IndexMany.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/OpenSearchClient-IndexMany.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/OpenSearch.Client/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/BulkAll/BulkAllObserver.cs
+++ b/src/OpenSearch.Client/Document/Multiple/BulkAll/BulkAllObserver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/BulkAll/BulkAllRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/BulkAll/BulkAllRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/BulkAll/BulkAllResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/BulkAll/BulkAllResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/BulkAll/OpenSearchClient-BulkAll.cs
+++ b/src/OpenSearch.Client/Document/Multiple/BulkAll/OpenSearchClient-BulkAll.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/BulkIndexByScrollFailure.cs
+++ b/src/OpenSearch.Client/Document/Multiple/BulkIndexByScrollFailure.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/DeleteByQuery/DeleteByQueryRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/DeleteByQuery/DeleteByQueryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/DeleteByQuery/DeleteByQueryResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/DeleteByQuery/DeleteByQueryResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/DeleteByQueryRethrottle/DeleteByQueryRethrottleRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/DeleteByQueryRethrottle/DeleteByQueryRethrottleRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/OpenSearchClient-GetMany.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/OpenSearchClient-GetMany.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/OpenSearchClient-SourceMany.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/OpenSearchClient-SourceMany.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/IMultiGetOperation.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/IMultiGetOperation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetOperation.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetOperation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetRequestFormatter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetRequestFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetResponseBuilder.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetResponseBuilder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Response/MultiGetHit.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Response/MultiGetHit.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Response/MultiGetHitJsonConverter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Response/MultiGetHitJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiTermVectors/MultiTermVectorOperation.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiTermVectors/MultiTermVectorOperation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiTermVectors/MultiTermVectorsRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiTermVectors/MultiTermVectorsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/MultiTermVectors/MultiTermVectorsResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiTermVectors/MultiTermVectorsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Reindex/OpenSearchClient-Reindex.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Reindex/OpenSearchClient-Reindex.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Reindex/ReindexObservable.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Reindex/ReindexObservable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Reindex/ReindexObserver.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Reindex/ReindexObserver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Reindex/ReindexRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Reindex/ReindexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexDestination.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexDestination.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexOnServerRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexOnServerRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexOnServerResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexOnServerResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexRouting.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexRouting.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexRoutingJsonConverter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexRoutingJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexSource.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexSource.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/RemoteSource.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/RemoteSource.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexRethrottle/ReindexNode.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexRethrottle/ReindexNode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexRethrottle/ReindexRethrottleRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexRethrottle/ReindexRethrottleRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ReindexRethrottle/ReindexRethrottleResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexRethrottle/ReindexRethrottleResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/Retries.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Retries.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ScrollAll/OpenSearchClient-ScrollAll.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ScrollAll/OpenSearchClient-ScrollAll.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ScrollAll/ScrollAllObservable.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ScrollAll/ScrollAllObservable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ScrollAll/ScrollAllObserver.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ScrollAll/ScrollAllObserver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ScrollAll/ScrollAllRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ScrollAll/ScrollAllRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/ScrollAll/ScrollAllResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ScrollAll/ScrollAllResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/UpdateByQuery/UpdateByQueryRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/UpdateByQuery/UpdateByQueryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/UpdateByQuery/UpdateByQueryResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/UpdateByQuery/UpdateByQueryResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Multiple/UpdateByQueryRethrottle/UpdateByQueryRethrottleRequest.cs
+++ b/src/OpenSearch.Client/Document/Multiple/UpdateByQueryRethrottle/UpdateByQueryRethrottleRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Result.cs
+++ b/src/OpenSearch.Client/Document/Result.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Create/CreateJsonConverter.cs
+++ b/src/OpenSearch.Client/Document/Single/Create/CreateJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Create/CreateRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/Create/CreateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Create/CreateResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/Create/CreateResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Create/OpenSearchClient-Create.cs
+++ b/src/OpenSearch.Client/Document/Single/Create/OpenSearchClient-Create.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Delete/DeleteRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/Delete/DeleteRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Delete/DeleteResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/Delete/DeleteResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Exists/DocumentExistsRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/Exists/DocumentExistsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Get/GetRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/Get/GetRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Get/GetResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/Get/GetResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Index/IndexJsonConverter.cs
+++ b/src/OpenSearch.Client/Document/Single/Index/IndexJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Index/IndexRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/Index/IndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Index/IndexResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/Index/IndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Index/OpenSearchClient-Index.cs
+++ b/src/OpenSearch.Client/Document/Single/Index/OpenSearchClient-Index.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Source/SourceRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/Source/SourceRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Source/SourceRequestResponseBuilder.cs
+++ b/src/OpenSearch.Client/Document/Single/Source/SourceRequestResponseBuilder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Source/SourceResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/Source/SourceResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/SourceExists/SourceExistsRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/SourceExists/SourceExistsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/TermVectors/FieldStatistics.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/FieldStatistics.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/TermVectors/TermVector.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/TermVector.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/TermVectors/TermVectorFilter.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/TermVectorFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/TermVectors/TermVectorTerm.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/TermVectorTerm.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/TermVectors/TermVectors.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/TermVectors.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/TermVectors/TermVectorsRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/TermVectorsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/TermVectors/TermVectorsResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/TermVectorsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/TermVectors/Token.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/Token.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Update/UpdateRequest.cs
+++ b/src/OpenSearch.Client/Document/Single/Update/UpdateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/Update/UpdateResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/Update/UpdateResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Document/Single/WriteResponseBase.cs
+++ b/src/OpenSearch.Client/Document/Single/WriteResponseBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Helpers/HelperIdentifiers.cs
+++ b/src/OpenSearch.Client/Helpers/HelperIdentifiers.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Helpers/IHelperCallable.cs
+++ b/src/OpenSearch.Client/Helpers/IHelperCallable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Helpers/RequestMetaDataExtensions.cs
+++ b/src/OpenSearch.Client/Helpers/RequestMetaDataExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IOpenSearchClient.Generated.cs
+++ b/src/OpenSearch.Client/IOpenSearchClient.Generated.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IOpenSearchClient.cs
+++ b/src/OpenSearch.Client/IOpenSearchClient.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/IndexState.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/IndexState.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Merge/MergePolicySettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Merge/MergePolicySettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Merge/MergeSchedulerSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Merge/MergeSchedulerSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Merge/MergeSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Merge/MergeSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Queries/IQueriesCacheSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Queries/IQueriesCacheSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Queries/IQueriesSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Queries/IQueriesSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/AutoExpandReplicas.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/AutoExpandReplicas.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/FixedIndexSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/FixedIndexSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/IndexSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/IndexSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/RecoveryInitialShards.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/RecoveryInitialShards.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/UpdatableIndexSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Settings/UpdatableIndexSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLog.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLog.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLogIndexing.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLogIndexing.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLogSearch.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLogSearch.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLogSearchFetch.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLogSearchFetch.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLogSearchQuery.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/ISlowLogSearchQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/LogLevel.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/SlowLog/LogLevel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/SoftDeletes/ISoftDeleteRetentionSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/SoftDeletes/ISoftDeleteRetentionSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/SoftDeletes/ISoftDeleteSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/SoftDeletes/ISoftDeleteSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Sorting/ISortingSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Sorting/ISortingSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Store/FileSystemStorageImplementation.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Store/FileSystemStorageImplementation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Translog/TranslogDurability.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Translog/TranslogDurability.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Translog/TranslogFlushSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Translog/TranslogFlushSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/IndexSettings/Translog/TranslogSettings.cs
+++ b/src/OpenSearch.Client/IndexModules/IndexSettings/Translog/TranslogSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/BM25Similarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/BM25Similarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/CustomSimilarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/CustomSimilarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/DFI/DFIIndependenceMeasure.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/DFI/DFIIndependenceMeasure.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/DFI/DFISimilarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/DFI/DFISimilarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/DFR/DFRAfterEffect.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/DFR/DFRAfterEffect.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/DFR/DFRBasicModel.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/DFR/DFRBasicModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/DFR/DFRSimilarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/DFR/DFRSimilarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/IB/IBDistribution.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/IB/IBDistribution.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/IB/IBLambda.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/IB/IBLambda.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/IB/IBSimilarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/IB/IBSimilarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/LMDirichletSimilarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/LMDirichletSimilarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/LMJelinekMercerSimilarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/LMJelinekMercerSimilarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/Normalization.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/Normalization.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/ScriptedSimilarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/ScriptedSimilarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/Similarities.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/Similarities.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/Similarity.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/Similarity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/IndexModules/Similarity/SimilarityFormatter.cs
+++ b/src/OpenSearch.Client/IndexModules/Similarity/SimilarityFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasAdd.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasAdd.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasAddOperation.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasAddOperation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemove.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemove.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveIndex.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveIndex.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveIndexOperation.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveIndexOperation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveOperation.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveOperation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/IAliasAction.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/IAliasAction.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/BulkAliasRequest.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/BulkAliasRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/BulkAliasResponse.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/BulkAliasResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/AliasDefinition.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/AliasDefinition.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/AliasExists/AliasExistsRequest.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/AliasExists/AliasExistsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/Aliases.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Aliases.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/DeleteAlias/DeleteAliasRequest.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/DeleteAlias/DeleteAliasRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/DeleteAlias/DeleteAliasResponse.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/DeleteAlias/DeleteAliasResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/GetAlias/GetAliasRequest.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/GetAlias/GetAliasRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/GetAlias/GetAliasResponse.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/GetAlias/GetAliasResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/GetAlias/OpenSearchClient-GetAliasesPointingToIndex.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/GetAlias/OpenSearchClient-GetAliasesPointingToIndex.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/GetAlias/OpenSearchClient-GetIndicesPointingToAlias.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/GetAlias/OpenSearchClient-GetIndicesPointingToAlias.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/PutAlias/PutAliasRequest.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/PutAlias/PutAliasRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/AliasManagement/PutAlias/PutAliasResponse.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/PutAlias/PutAliasResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/Analyze/AnalyzeCharFilters.cs
+++ b/src/OpenSearch.Client/Indices/Analyze/AnalyzeCharFilters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/Analyze/AnalyzeRequest.cs
+++ b/src/OpenSearch.Client/Indices/Analyze/AnalyzeRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/Analyze/AnalyzeResponse.cs
+++ b/src/OpenSearch.Client/Indices/Analyze/AnalyzeResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/Analyze/AnalyzeToken.cs
+++ b/src/OpenSearch.Client/Indices/Analyze/AnalyzeToken.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/Analyze/AnalyzeTokenFilters.cs
+++ b/src/OpenSearch.Client/Indices/Analyze/AnalyzeTokenFilters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/Analyze/AnalyzeTokenizersDescriptor.cs
+++ b/src/OpenSearch.Client/Indices/Analyze/AnalyzeTokenizersDescriptor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/AddBlock/AddIndexBlockRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/AddBlock/AddIndexBlockRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/AddBlock/AddIndexBlockResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/AddBlock/AddIndexBlockResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/AddBlock/IndexBlock.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/AddBlock/IndexBlock.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/CloneIndex/CloneIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/CloneIndex/CloneIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/CloneIndex/CloneIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/CloneIndex/CloneIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/CreateIndex/CreateIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/CreateIndex/CreateIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/CreateIndex/CreateIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/CreateIndex/CreateIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/DeleteIndex/DeleteIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/DeleteIndex/DeleteIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/DeleteIndex/DeleteIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/DeleteIndex/DeleteIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/GetIndex/GetIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/GetIndex/GetIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/GetIndex/GetIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/GetIndex/GetIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/IndicesExists/ExistsResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/IndicesExists/ExistsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/IndicesExists/IndexExistsRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/IndicesExists/IndexExistsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/OpenCloseIndex/CloseIndex/CloseIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/OpenCloseIndex/CloseIndex/CloseIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/OpenCloseIndex/CloseIndex/CloseIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/OpenCloseIndex/CloseIndex/CloseIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/OpenCloseIndex/OpenIndex/OpenIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/OpenCloseIndex/OpenIndex/OpenIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/OpenCloseIndex/OpenIndex/OpenIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/OpenCloseIndex/OpenIndex/OpenIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/ResolveIndex/ResolveIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/ResolveIndex/ResolveIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/ResolveIndex/ResolveIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/ResolveIndex/ResolveIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/RolloverIndex/RolloverConditions.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/RolloverIndex/RolloverConditions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/RolloverIndex/RolloverIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/RolloverIndex/RolloverIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/RolloverIndex/RolloverIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/RolloverIndex/RolloverIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/ShrinkIndex/ShrinkIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/ShrinkIndex/ShrinkIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/ShrinkIndex/ShrinkIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/ShrinkIndex/ShrinkIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/SplitIndex/SplitIndexRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/SplitIndex/SplitIndexRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/SplitIndex/SplitIndexResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/SplitIndex/SplitIndexResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexManagement/TypesExists/TypeExistsRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexManagement/TypesExists/TypeExistsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/GetIndexSettings/GetIndexSettingsRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/GetIndexSettings/GetIndexSettingsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/GetIndexSettings/GetIndexSettingsResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/GetIndexSettings/GetIndexSettingsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/DeleteIndexTemplate/DeleteIndexTemplateRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/DeleteIndexTemplate/DeleteIndexTemplateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/DeleteIndexTemplate/DeleteIndexTemplateResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/DeleteIndexTemplate/DeleteIndexTemplateResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/GetIndexTemplateRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/GetIndexTemplateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/GetIndexTemplateResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/GetIndexTemplateResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/TemplateMapping.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/TemplateMapping.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/IndexTemplateExists/IndexTemplateExistsRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/IndexTemplateExists/IndexTemplateExistsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/UpdateIndexSettings/UpdateIndexSettingsRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/UpdateIndexSettings/UpdateIndexSettingsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/IndexSettings/UpdateIndexSettings/UpdateIndexSettingsResponse.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/UpdateIndexSettings/UpdateIndexSettingsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/MappingManagement/GetFieldMapping/FieldMappingFormatter.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/GetFieldMapping/FieldMappingFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/MappingManagement/GetFieldMapping/GetFieldMappingRequest.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/GetFieldMapping/GetFieldMappingRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/MappingManagement/GetFieldMapping/GetFieldMappingResponse.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/GetFieldMapping/GetFieldMappingResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/MappingManagement/GetMapping/GetMappingRequest.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/GetMapping/GetMappingRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/MappingManagement/GetMapping/GetMappingResponse.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/GetMapping/GetMappingResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/MappingManagement/PutMapping/OpenSearchClient-Map.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/PutMapping/OpenSearchClient-Map.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/MappingManagement/PutMapping/PutMappingRequest.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/PutMapping/PutMappingRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/MappingManagement/PutMapping/PutMappingResponse.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/PutMapping/PutMappingResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/StatusManagement/ClearCache/ClearCacheRequest.cs
+++ b/src/OpenSearch.Client/Indices/StatusManagement/ClearCache/ClearCacheRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/StatusManagement/ClearCache/ClearCacheResponse.cs
+++ b/src/OpenSearch.Client/Indices/StatusManagement/ClearCache/ClearCacheResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/StatusManagement/Flush/FlushRequest.cs
+++ b/src/OpenSearch.Client/Indices/StatusManagement/Flush/FlushRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/StatusManagement/Flush/FlushResponse.cs
+++ b/src/OpenSearch.Client/Indices/StatusManagement/Flush/FlushResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/StatusManagement/ForceMerge/ForceMergeRequest.cs
+++ b/src/OpenSearch.Client/Indices/StatusManagement/ForceMerge/ForceMergeRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/StatusManagement/ForceMerge/ForceMergeResponse.cs
+++ b/src/OpenSearch.Client/Indices/StatusManagement/ForceMerge/ForceMergeResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/StatusManagement/Refresh/RefreshRequest.cs
+++ b/src/OpenSearch.Client/Indices/StatusManagement/Refresh/RefreshRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Indices/StatusManagement/Refresh/RefreshResponse.cs
+++ b/src/OpenSearch.Client/Indices/StatusManagement/Refresh/RefreshResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/DeletePipeline/DeletePipelineRequest.cs
+++ b/src/OpenSearch.Client/Ingest/DeletePipeline/DeletePipelineRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/DeletePipeline/DeletePipelineResponse.cs
+++ b/src/OpenSearch.Client/Ingest/DeletePipeline/DeletePipelineResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/GetPipeline/GetPipelineRequest.cs
+++ b/src/OpenSearch.Client/Ingest/GetPipeline/GetPipelineRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/GetPipeline/GetPipelineResponse.cs
+++ b/src/OpenSearch.Client/Ingest/GetPipeline/GetPipelineResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Pipeline.cs
+++ b/src/OpenSearch.Client/Ingest/Pipeline.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processor.cs
+++ b/src/OpenSearch.Client/Ingest/Processor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processor/GrokProcessorPatternsRequest.cs
+++ b/src/OpenSearch.Client/Ingest/Processor/GrokProcessorPatternsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processor/GrokProcessorPatternsResponse.cs
+++ b/src/OpenSearch.Client/Ingest/Processor/GrokProcessorPatternsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/ProcessorFormatter.cs
+++ b/src/OpenSearch.Client/Ingest/ProcessorFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/AppendProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/AppendProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/BytesProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/BytesProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/ConvertProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/ConvertProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/CsvProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/CsvProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/DateIndexNameProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DateIndexNameProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/DateProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DateProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/DissectProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DissectProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/DotExpanderProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DotExpanderProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/DropProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DropProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/FailProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/FailProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/FingerprintProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/FingerprintProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/ForeachProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/ForeachProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/GrokProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/GrokProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/GsubProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/GsubProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/JoinProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/JoinProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/JsonProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/JsonProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/KeyValueProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/KeyValueProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/LowercaseProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/LowercaseProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/NetworkCommunityIdProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/NetworkCommunityIdProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/NetworkDirectionProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/NetworkDirectionProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/PipelineProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/PipelineProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/AttachmentProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/AttachmentProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/GeoIpProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/GeoIpProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/UserAgent/UserAgentProperty.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/UserAgent/UserAgentProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/UserAgentProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/UserAgentProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/RemoveProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/RemoveProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/RenameProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/RenameProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/ScriptProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/ScriptProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/SetProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/SetProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/SortProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/SortProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/SplitProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/SplitProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/TrimProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/TrimProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/UppercaseProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/UppercaseProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/UriPartsProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/UriPartsProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/Processors/UrlDecodeProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/UrlDecodeProcessor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/ProcessorsDescriptor.cs
+++ b/src/OpenSearch.Client/Ingest/ProcessorsDescriptor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/PutPipeline/PutPipelineRequest.cs
+++ b/src/OpenSearch.Client/Ingest/PutPipeline/PutPipelineRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/PutPipeline/PutPipelineResponse.cs
+++ b/src/OpenSearch.Client/Ingest/PutPipeline/PutPipelineResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/SimulatePipeline/SimulatePipelineDocument.cs
+++ b/src/OpenSearch.Client/Ingest/SimulatePipeline/SimulatePipelineDocument.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/SimulatePipeline/SimulatePipelineRequest.cs
+++ b/src/OpenSearch.Client/Ingest/SimulatePipeline/SimulatePipelineRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Ingest/SimulatePipeline/SimulatePipelineResponse.cs
+++ b/src/OpenSearch.Client/Ingest/SimulatePipeline/SimulatePipelineResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchCorePropertyAttributeBase.cs
+++ b/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchCorePropertyAttributeBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchDocValuesPropertyAttributeBase.cs
+++ b/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchDocValuesPropertyAttributeBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchPropertyAttributeBase.cs
+++ b/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchPropertyAttributeBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchTypeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchTypeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/DynamicMapping.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicMapping.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplate.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplateContainer.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplateContainer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplatesFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplatesFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicTemplate/SingleMapping.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Mappings.cs
+++ b/src/OpenSearch.Client/Mapping/Mappings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/MetaFields/FieldNames/FieldNamesField.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/FieldNames/FieldNamesField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/MetaFields/IFieldMapping.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/IFieldMapping.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/MetaFields/Routing/RoutingField.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/Routing/RoutingField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/MetaFields/Size/SizeField.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/Size/SizeField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/MetaFields/Source/SourceField.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/Source/SourceField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/PropertyMapping.cs
+++ b/src/OpenSearch.Client/Mapping/PropertyMapping.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/RuntimeFields/RuntimeField.cs
+++ b/src/OpenSearch.Client/Mapping/RuntimeFields/RuntimeField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/RuntimeFields/RuntimeFields.cs
+++ b/src/OpenSearch.Client/Mapping/RuntimeFields/RuntimeFields.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/TermVectorOption.cs
+++ b/src/OpenSearch.Client/Mapping/TermVectorOption.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/TypeMapping.cs
+++ b/src/OpenSearch.Client/Mapping/TypeMapping.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Complex/Nested/NestedAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Complex/Nested/NestedAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Complex/Nested/NestedProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Complex/Nested/NestedProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Complex/Object/ObjectAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Complex/Object/ObjectAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Complex/Object/ObjectProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Complex/Object/ObjectProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Binary/BinaryAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Binary/BinaryAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Binary/BinaryProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Binary/BinaryProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Boolean/BooleanAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Boolean/BooleanAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Boolean/BooleanProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Boolean/BooleanProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Date/DateAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Date/DateAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Date/DateProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Date/DateProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/DateNanos/DateNanosAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/DateNanos/DateNanosAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/DateNanos/DateNanosProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/DateNanos/DateNanosProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/Children.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/Children.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/ChildrenFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/ChildrenFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinField.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinFieldFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinFieldFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/Relations.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/Relations.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Keyword/KeywordAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Keyword/KeywordAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Keyword/KeywordProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Keyword/KeywordProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Number/NumberAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Number/NumberAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Number/NumberProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Number/NumberProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Number/NumberType.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Number/NumberType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Percolator/PercolatorAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Percolator/PercolatorAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Percolator/PercolatorProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Percolator/PercolatorProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/DateRange/DateRangeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/DateRange/DateRangeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/DateRange/DateRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/DateRange/DateRangeProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/DoubleRange/DoubleRangeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/DoubleRange/DoubleRangeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/DoubleRange/DoubleRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/DoubleRange/DoubleRangeProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/FloatRange/FloatRangeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/FloatRange/FloatRangeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/FloatRange/FloatRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/FloatRange/FloatRangeProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/IntegerRange/IntegerRangeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/IntegerRange/IntegerRangeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/IntegerRange/IntegerRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/IntegerRange/IntegerRangeProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/IpRange/IpRangeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/IpRange/IpRangeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/IpRange/IpRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/IpRange/IpRangeProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/LongRange/LongRangeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/LongRange/LongRangeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/LongRange/LongRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/LongRange/LongRangeProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/RangePropertyAttributeBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/RangePropertyAttributeBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/RangePropertyBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/RangePropertyBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/RangeType.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/RangeType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/RankFeature/RankFeatureAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/RankFeature/RankFeatureAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/RankFeature/RankFeatureProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/RankFeature/RankFeatureProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/RankFeatures/RankFeaturesAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/RankFeatures/RankFeaturesAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/RankFeatures/RankFeaturesProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/RankFeatures/RankFeaturesProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Text/IndexOptions.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Text/IndexOptions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Text/TextAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Text/TextAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Text/TextIndexPrefixes.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Text/TextIndexPrefixes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Core/Text/TextProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Text/TextProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/CorePropertyBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/CorePropertyBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/CorePropertyDescriptorBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/CorePropertyDescriptorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/DocValuesPropertyBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/DocValuesPropertyBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/DocValuesPropertyDescriptorBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/DocValuesPropertyDescriptorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/FieldType.cs
+++ b/src/OpenSearch.Client/Mapping/Types/FieldType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoPoint/GeoPointAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoPoint/GeoPointAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoPoint/GeoPointProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoPoint/GeoPointProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoShapeAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoShapeAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoShapeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoShapeProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoStrategy.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoStrategy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoTree.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoTree.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Properties-Scalar.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Properties-Scalar.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Properties.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Properties.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/PropertiesFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertiesFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/PropertyBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertyBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/PropertyDescriptorBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertyDescriptorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/PropertyFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertyFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Attachment/Attachment.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Attachment/Attachment.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/CategorySuggestContext.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/CategorySuggestContext.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/CompletionAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/CompletionAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/CompletionProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/CompletionProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/GeoSuggestContext.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/GeoSuggestContext.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/ISuggestContext.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/ISuggestContext.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/SuggestContextFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/SuggestContextFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/SuggestContextsDescriptor.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/SuggestContextsDescriptor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/FieldAlias/FieldAliasProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/FieldAlias/FieldAliasProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Generic/GenericProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Generic/GenericProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Ip/IpAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Ip/IpAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Ip/IpProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Ip/IpProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Shape/ShapeOrientation.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Shape/ShapeOrientation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/TokenCount/TokenCountAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/TokenCount/TokenCountAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Visitor/IMappingVisitor.cs
+++ b/src/OpenSearch.Client/Mapping/Visitor/IMappingVisitor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/OpenSearch.Client/Mapping/Visitor/IPropertyVisitor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Visitor/MappingWalker.cs
+++ b/src/OpenSearch.Client/Mapping/Visitor/MappingWalker.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/OpenSearch.Client/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Mapping/Visitor/PropertyWalker.cs
+++ b/src/OpenSearch.Client/Mapping/Visitor/PropertyWalker.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/AllocationAttribute.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/AllocationAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/AllocationAwareness/AllocationAwarenessSettings.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/AllocationAwareness/AllocationAwarenessSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/AllocationFiltering/AllocationFilteringSettings.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/AllocationFiltering/AllocationFilteringSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/ClusterModuleSettings.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/ClusterModuleSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/DiskBasedShardAllocation/DiskbasedShardAllocationSettings.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/DiskBasedShardAllocation/DiskbasedShardAllocationSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/AllocationEnable.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/AllocationEnable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/AllowRebalance.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/AllowRebalance.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/RebalanceEnable.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/RebalanceEnable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/ShardAllocationSettings.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/ShardAllocationSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/ShardBalancingHeuristicsSettings.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/ShardBalancingHeuristicsSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/ShardRebalancingSettings.cs
+++ b/src/OpenSearch.Client/Modules/Cluster/ShardAllocation/ShardRebalancingSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Gateway/GatewaySettings.cs
+++ b/src/OpenSearch.Client/Modules/Gateway/GatewaySettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/CircuitBreaker/CircuitBreakerSettings.cs
+++ b/src/OpenSearch.Client/Modules/Indices/CircuitBreaker/CircuitBreakerSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataBase.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataFilter.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataFrequencyFilter.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataFrequencyFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataLoading.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataLoading.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataRegexFilter.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataRegexFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataSettings.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/FielddataSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/GeoPoint/GeoPointFielddata.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/GeoPoint/GeoPointFielddata.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/GeoPoint/GeoPointFielddataFormat.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/GeoPoint/GeoPointFielddataFormat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/Numeric/NumericFielddata.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/Numeric/NumericFielddata.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/Numeric/NumericFielddataFormat.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/Numeric/NumericFielddataFormat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/String/StringFielddata.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/String/StringFielddata.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Fielddata/String/StringFielddataFormat.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Fielddata/String/StringFielddataFormat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/IndexingBuffer/IndexingBufferSettings.cs
+++ b/src/OpenSearch.Client/Modules/Indices/IndexingBuffer/IndexingBufferSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/IndicesModuleSettings.cs
+++ b/src/OpenSearch.Client/Modules/Indices/IndicesModuleSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Indices/Recovery/IndicesRecoverySettings.cs
+++ b/src/OpenSearch.Client/Modules/Indices/Recovery/IndicesRecoverySettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/DeleteScript/DeleteScriptRequest.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/DeleteScript/DeleteScriptRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/DeleteScript/DeleteScriptResponse.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/DeleteScript/DeleteScriptResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/ExecutePainlessScript/ExecutePainlessScriptRequest.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/ExecutePainlessScript/ExecutePainlessScriptRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/ExecutePainlessScript/ExecutePainlessScriptResponse.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/ExecutePainlessScript/ExecutePainlessScriptResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/ExecutePainlessScript/PainlessContextSetup.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/ExecutePainlessScript/PainlessContextSetup.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/GetScript/GetScriptRequest.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/GetScript/GetScriptRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/GetScript/GetScriptResponse.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/GetScript/GetScriptResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/IStoredScript.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/IStoredScript.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/PutScript/PutScriptRequest.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/PutScript/PutScriptRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/PutScript/PutScriptResponse.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/PutScript/PutScriptResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/Scripting/ScriptLang.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/ScriptLang.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/AzureRepository.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/AzureRepository.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CleanupRepository/CleanupRepositoryRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CleanupRepository/CleanupRepositoryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CleanupRepository/CleanupRepositoryResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CleanupRepository/CleanupRepositoryResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryFormatter.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/DeleteRepository/DeleteRepositoryRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/DeleteRepository/DeleteRepositoryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/DeleteRepository/DeleteRepositoryResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/DeleteRepository/DeleteRepositoryResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/FileSystemRepository.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/FileSystemRepository.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryResponseFormatter.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryResponseFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/HdfsRepository.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/HdfsRepository.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/ISnapshotRepository.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/ISnapshotRepository.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/ReadOnlyUrlRepository.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/ReadOnlyUrlRepository.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/SourceOnlyRepository.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/SourceOnlyRepository.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/VerifyRepository/CompactNodeInfo.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/VerifyRepository/CompactNodeInfo.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Restore/RestoreObservable/RestoreObservable.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Restore/RestoreObservable/RestoreObservable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Restore/RestoreRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Restore/RestoreRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Restore/RestoreResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Restore/RestoreResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Restore/SnapshotRestore.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Restore/SnapshotRestore.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Clone/CloneSnapshotRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Clone/CloneSnapshotRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Clone/CloneSnapshotResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Clone/CloneSnapshotResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/DeleteSnapshot/DeleteSnapshotRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/DeleteSnapshot/DeleteSnapshotRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/DeleteSnapshot/DeleteSnapshotResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/DeleteSnapshot/DeleteSnapshotResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/GetSnapshot/GetSnapshotRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/GetSnapshot/GetSnapshotRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/GetSnapshot/GetSnapshotResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/GetSnapshot/GetSnapshotResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Snapshot.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Snapshot.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Snapshot/SnapshotRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Snapshot/SnapshotRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Snapshot/SnapshotResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/Snapshot/SnapshotResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotObservable/SnapshotObservable.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotObservable/SnapshotObservable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotObservable/SnapshotObserver.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotObservable/SnapshotObserver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotShardFailure.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotShardFailure.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusRequest.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusResponse.cs
+++ b/src/OpenSearch.Client/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.Cat.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Cat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.Cluster.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Cluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.DanglingIndices.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.DanglingIndices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.Indices.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Indices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.Ingest.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Ingest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.NoNamespace.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.NoNamespace.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.Nodes.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Nodes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.Snapshot.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Snapshot.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.Tasks.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Tasks.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/OpenSearchClient.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Properties/ClsCompliancy.cs
+++ b/src/OpenSearch.Client/Properties/ClsCompliancy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/IQueryContainer.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/IQueryContainer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainer-Dsl.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainer-Dsl.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainerFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainerFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/FieldLookup/FieldLookup.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/FieldLookup/FieldLookup.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/FieldLookup/FieldLookupExtensions.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/FieldLookup/FieldLookupExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/FieldName/FieldNameQueryBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/FieldName/FieldNameQueryBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/FieldName/FieldNameQueryDescriptorBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/FieldName/FieldNameQueryDescriptorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/FieldName/FieldNameQueryFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/FieldName/FieldNameQueryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Query/BoolQueryAndExtensions.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Query/BoolQueryAndExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Query/BoolQueryExtensions.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Query/BoolQueryExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Query/BoolQueryOrExtensions.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Query/BoolQueryOrExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Query/QueryBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Query/QueryBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Query/QueryDescriptorBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Query/QueryDescriptorBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/Bool/BoolQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/Bool/BoolQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/Boosting/BoostingQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/Boosting/BoostingQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/ConstantScore/ConstantScoreQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/ConstantScore/ConstantScoreQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/Dismax/DismaxQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/Dismax/DismaxQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/FunctionScoreQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/FunctionScoreQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/DecayFunctionBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/DecayFunctionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/ExponentialDecayFunctionBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/ExponentialDecayFunctionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/GaussDecayFunctionBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/GaussDecayFunctionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/LinearDecayFunctionBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/LinearDecayFunctionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/MultiValueMode.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/MultiValueMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FieldValue/FieldValueFactorFunction.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FieldValue/FieldValueFactorFunction.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FieldValue/FieldValueFactorModifier.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FieldValue/FieldValueFactorModifier.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FunctionBoostMode.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FunctionBoostMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FunctionScoreMode.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FunctionScoreMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/IScoreFunction.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/IScoreFunction.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Random/RandomScoreFunction.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Random/RandomScoreFunction.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctionJsonFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctionJsonFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctions.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScriptScore/ScriptScoreFunction.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScriptScore/ScriptScoreFunction.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Weight/WeightFunction.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Weight/WeightFunction.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsAllOf.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsAllOf.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsAnyOf.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsAnyOf.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsFilter.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsFuzzy.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsFuzzy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsMatch.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsMatch.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/Match/MatchQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Match/MatchQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/MatchBoolPrefix/MatchBoolPrefixQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MatchBoolPrefix/MatchBoolPrefixQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/MatchPhrase/MatchPhraseQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MatchPhrase/MatchPhraseQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/MatchPhrasePrefix/MatchPhrasePrefixQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MatchPhrasePrefix/MatchPhrasePrefixQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/MultiMatch/MultiMatchQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MultiMatch/MultiMatchQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/MultiMatch/TextQueryType.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MultiMatch/TextQueryType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/MultiMatch/ZeroTermsQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MultiMatch/ZeroTermsQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/QueryString/QueryStringQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/QueryString/QueryStringQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringFlags.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringFlags.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/BoundingBox.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/BoundingBox.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/GeoExecution.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/GeoExecution.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Distance/GeoDistanceQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Distance/GeoDistanceQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/GeoCoordinateFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/GeoCoordinateFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/GeoLocation.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/GeoLocation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/GeoLocationFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/GeoLocationFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/GeoValidationMethod.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/GeoValidationMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/LatLon.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/LatLon.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Polygon/GeoPolygonQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Polygon/GeoPolygonQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/CircleGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/CircleGeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/EnvelopeGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/EnvelopeGeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeQueryFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeQueryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeometryCollection.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeometryCollection.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/IGeoShapeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/IGeoShapeQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/LineStringGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/LineStringGeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiLineStringGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiLineStringGeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiPointGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiPointGeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiPolygonGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiPolygonGeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/PointGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/PointGeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/PolygonGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/PolygonGeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/WKT/GeoWKTException.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/WKT/GeoWKTException.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/WKT/GeoWKTReader.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/WKT/GeoWKTReader.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Geo/WKT/GeoWKTWriter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/WKT/GeoWKTWriter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Joining/HasChild/ChildScoreMode.cs
+++ b/src/OpenSearch.Client/QueryDsl/Joining/HasChild/ChildScoreMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Joining/HasChild/HasChildQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Joining/HasChild/HasChildQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Joining/HasParent/HasParentQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Joining/HasParent/HasParentQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Joining/Nested/NestedQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Joining/Nested/NestedQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Joining/Nested/NestedScoreMode.cs
+++ b/src/OpenSearch.Client/QueryDsl/Joining/Nested/NestedScoreMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Joining/ParentId/ParentIdQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Joining/ParentId/ParentIdQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/MatchAllQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/MatchAllQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/MatchNoneQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/MatchNoneQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/MultiTermQueryRewrite/MultiTermQueryRewriteFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/MultiTermQueryRewrite/MultiTermQueryRewriteFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/MultiTermQueryRewrite/RewriteMultiTerm.cs
+++ b/src/OpenSearch.Client/QueryDsl/MultiTermQueryRewrite/RewriteMultiTerm.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Operator.cs
+++ b/src/OpenSearch.Client/QueryDsl/Operator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/OscSpecific/ConditionlessQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/OscSpecific/ConditionlessQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/OscSpecific/RawQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/OscSpecific/RawQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Query.cs
+++ b/src/OpenSearch.Client/QueryDsl/Query.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/Containing/SpanContainingQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Containing/SpanContainingQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/FieldMasking/SpanFieldMaskingQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/FieldMasking/SpanFieldMaskingQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/First/SpanFirstQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/First/SpanFirstQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/Gap/SpanGapQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Gap/SpanGapQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/ISpanSubQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/ISpanSubQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/MultiTerm/SpanMultiTermQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/MultiTerm/SpanMultiTermQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/Near/SpanNearQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Near/SpanNearQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/Not/SpanNotQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Not/SpanNotQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/Or/SpanOrQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Or/SpanOrQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/SpanQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/SpanQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/Term/SpanTermQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Term/SpanTermQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Span/Within/SpanWithinQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Within/SpanWithinQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/DistanceFeature/DistanceFeatureQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/DistanceFeature/DistanceFeatureQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/Like/Like.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/Like/Like.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Percolate/PercolateQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Percolate/PercolateQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/RankFeature/RankFeatureQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/RankFeature/RankFeatureQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Script/ScriptQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Script/ScriptQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Shape/CartesianPoint.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Shape/CartesianPoint.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Shape/IShapeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Shape/IShapeQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Shape/ShapeQueryFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Shape/ShapeQueryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Exists/ExistsQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Exists/ExistsQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueries.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueries.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueryBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueryBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueryFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Ids/IdsQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Ids/IdsQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/DateRangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/DateRangeQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/LongRangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/LongRangeQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/NumericRangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/NumericRangeQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeQueryFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeQueryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeRelation.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeRelation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/TermRangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/TermRangeQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Regexp/RegexpQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Regexp/RegexpQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Term/TermQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Term/TermQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Terms/TermsQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Terms/TermsQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Terms/TermsQueryFormatter.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Terms/TermsQueryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/TermsSet/TermsSetQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/TermsSet/TermsSetQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/OpenSearch.Client/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Visitor/QueryVisitor.cs
+++ b/src/OpenSearch.Client/QueryDsl/Visitor/QueryVisitor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Visitor/QueryWalker.cs
+++ b/src/OpenSearch.Client/QueryDsl/Visitor/QueryWalker.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/QueryDsl/Visitor/VisitorScope.cs
+++ b/src/OpenSearch.Client/QueryDsl/Visitor/VisitorScope.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.Cat.cs
+++ b/src/OpenSearch.Client/Requests.Cat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.Cluster.cs
+++ b/src/OpenSearch.Client/Requests.Cluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.DanglingIndices.cs
+++ b/src/OpenSearch.Client/Requests.DanglingIndices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.Indices.cs
+++ b/src/OpenSearch.Client/Requests.Indices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.Ingest.cs
+++ b/src/OpenSearch.Client/Requests.Ingest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.NoNamespace.cs
+++ b/src/OpenSearch.Client/Requests.NoNamespace.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.Nodes.cs
+++ b/src/OpenSearch.Client/Requests.Nodes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.Snapshot.cs
+++ b/src/OpenSearch.Client/Requests.Snapshot.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.Tasks.cs
+++ b/src/OpenSearch.Client/Requests.Tasks.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Requests.cs
+++ b/src/OpenSearch.Client/Requests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Count/CountRequest.cs
+++ b/src/OpenSearch.Client/Search/Count/CountRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Count/CountResponse.cs
+++ b/src/OpenSearch.Client/Search/Count/CountResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Explain/ExplainGet.cs
+++ b/src/OpenSearch.Client/Search/Explain/ExplainGet.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Explain/ExplainRequest.cs
+++ b/src/OpenSearch.Client/Search/Explain/ExplainRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Explain/ExplainResponse.cs
+++ b/src/OpenSearch.Client/Search/Explain/ExplainResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Explain/Explanation.cs
+++ b/src/OpenSearch.Client/Search/Explain/Explanation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Explain/ExplanationDetail.cs
+++ b/src/OpenSearch.Client/Search/Explain/ExplanationDetail.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/FieldCapabilities/FieldCapabilitiesRequest.cs
+++ b/src/OpenSearch.Client/Search/FieldCapabilities/FieldCapabilitiesRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/FieldCapabilities/FieldCapabilitiesResponse.cs
+++ b/src/OpenSearch.Client/Search/FieldCapabilities/FieldCapabilitiesResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/ITypedSearchRequest.cs
+++ b/src/OpenSearch.Client/Search/ITypedSearchRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/MultiSearch/MultiSearchFormatter.cs
+++ b/src/OpenSearch.Client/Search/MultiSearch/MultiSearchFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/MultiSearch/MultiSearchRequest.cs
+++ b/src/OpenSearch.Client/Search/MultiSearch/MultiSearchRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/MultiSearch/MultiSearchResponse.cs
+++ b/src/OpenSearch.Client/Search/MultiSearch/MultiSearchResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/MultiSearch/MultiSearchResponseBuilder.cs
+++ b/src/OpenSearch.Client/Search/MultiSearch/MultiSearchResponseBuilder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/MultiSearch/MultiSearchResponseFormatter.cs
+++ b/src/OpenSearch.Client/Search/MultiSearch/MultiSearchResponseFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/MultiSearchTemplate/MultiSearchTemplateJsonConverter.cs
+++ b/src/OpenSearch.Client/Search/MultiSearchTemplate/MultiSearchTemplateJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/MultiSearchTemplate/MultiSearchTemplateRequest.cs
+++ b/src/OpenSearch.Client/Search/MultiSearchTemplate/MultiSearchTemplateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Scroll/ClearScroll/ClearScrollRequest.cs
+++ b/src/OpenSearch.Client/Search/Scroll/ClearScroll/ClearScrollRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Scroll/ClearScroll/ClearScrollResponse.cs
+++ b/src/OpenSearch.Client/Search/Scroll/ClearScroll/ClearScrollResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Scroll/Scroll/ScrollRequest.cs
+++ b/src/OpenSearch.Client/Search/Scroll/Scroll/ScrollRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Scroll/Scroll/SlicedScroll.cs
+++ b/src/OpenSearch.Client/Search/Scroll/Scroll/SlicedScroll.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Collapsing/FieldCollapse.cs
+++ b/src/OpenSearch.Client/Search/Search/Collapsing/FieldCollapse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Highlighting/BoundaryScanner.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/BoundaryScanner.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Highlighting/Highlight.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/Highlight.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Highlighting/HighlightField.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/HighlightField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterEncoder.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterEncoder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterFragmenter.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterFragmenter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterOrder.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterOrder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterTagsSchema.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterTagsSchema.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterType.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/HighlighterType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Hits/Hit.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/Hit.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Hits/HitsMetaData.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/HitsMetaData.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Hits/InnerHitsMetaData.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/InnerHitsMetaData.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Hits/InnerHitsResult.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/InnerHitsResult.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Hits/NestedIdentity.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/NestedIdentity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Hits/TotalHits.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/TotalHits.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/InnerHits/InnerHits.cs
+++ b/src/OpenSearch.Client/Search/Search/InnerHits/InnerHits.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Profile/AggregationBreakdown.cs
+++ b/src/OpenSearch.Client/Search/Search/Profile/AggregationBreakdown.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Profile/AggregationProfile.cs
+++ b/src/OpenSearch.Client/Search/Search/Profile/AggregationProfile.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Profile/Collector.cs
+++ b/src/OpenSearch.Client/Search/Search/Profile/Collector.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Profile/Profile.cs
+++ b/src/OpenSearch.Client/Search/Search/Profile/Profile.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Profile/QueryBreakdown.cs
+++ b/src/OpenSearch.Client/Search/Search/Profile/QueryBreakdown.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Profile/QueryProfile.cs
+++ b/src/OpenSearch.Client/Search/Search/Profile/QueryProfile.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Profile/SearchProfile.cs
+++ b/src/OpenSearch.Client/Search/Search/Profile/SearchProfile.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Profile/ShardProfile.cs
+++ b/src/OpenSearch.Client/Search/Search/Profile/ShardProfile.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Rescoring/Rescore.cs
+++ b/src/OpenSearch.Client/Search/Search/Rescoring/Rescore.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Rescoring/RescoreQuery.cs
+++ b/src/OpenSearch.Client/Search/Search/Rescoring/RescoreQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Rescoring/ScoreMode.cs
+++ b/src/OpenSearch.Client/Search/Search/Rescoring/ScoreMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/SearchRequest.cs
+++ b/src/OpenSearch.Client/Search/Search/SearchRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/SearchResponse.cs
+++ b/src/OpenSearch.Client/Search/Search/SearchResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/FieldSort.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/FieldSort.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/GeoDistanceSort.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/GeoDistanceSort.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/NestedSort.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/NestedSort.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/NumericType.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/NumericType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/ScriptSort.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/ScriptSort.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/SortBase.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/SortBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/SortDescriptor.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/SortDescriptor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/SortMode.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/SortMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/SortOrder.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/SortOrder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/Sort/SortSpecialField.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/SortSpecialField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/SourceFiltering/SourceFilter.cs
+++ b/src/OpenSearch.Client/Search/Search/SourceFiltering/SourceFilter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Search/SourceFiltering/SourceFilterJsonConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/SourceFiltering/SourceFilterJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/SearchShards/SearchShardsRequest.cs
+++ b/src/OpenSearch.Client/Search/SearchShards/SearchShardsRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/SearchShards/SearchShardsResponse.cs
+++ b/src/OpenSearch.Client/Search/SearchShards/SearchShardsResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateRequest.cs
+++ b/src/OpenSearch.Client/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateResponse.cs
+++ b/src/OpenSearch.Client/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/SearchTemplate/SearchTemplateRequest.cs
+++ b/src/OpenSearch.Client/Search/SearchTemplate/SearchTemplateRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/CompletionSuggester/CompletionField.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/CompletionSuggester/CompletionField.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/CompletionSuggester/CompletionSuggester.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/CompletionSuggester/CompletionSuggester.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/CompletionSuggester/SuggestFuzziness.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/CompletionSuggester/SuggestFuzziness.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/ContextSuggester/Context.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/ContextSuggester/Context.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/ContextSuggester/SuggestContextQuery.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/ContextSuggester/SuggestContextQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/DirectGenerator.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/DirectGenerator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/PhraseSuggestCollate.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/PhraseSuggestCollate.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/PhraseSuggestCollateQuery.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/PhraseSuggestCollateQuery.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/PhraseSuggestHighlight.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/PhraseSuggestHighlight.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/PhraseSuggester.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/PhraseSuggester.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/LaplaceSmoothingModel.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/LaplaceSmoothingModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/LinearInterpolationSmoothingModel.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/LinearInterpolationSmoothingModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/SmoothingModelBase.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/SmoothingModelBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/SmoothingModelContainer.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/SmoothingModelContainer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/StupidBackoffSmoothingModel.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/SmoothingModel/StupidBackoffSmoothingModel.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/Suggest.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/Suggest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/SuggestBucket.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggestBucket.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/SuggestContainer.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggestContainer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/SuggestDictionary.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggestDictionary.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/SuggestOption.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggestOption.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/SuggesterBase.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggesterBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/TermSuggester/StringDistance.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/TermSuggester/StringDistance.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/TermSuggester/SuggestSort.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/TermSuggester/SuggestSort.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Suggesters/TermSuggester/TermSuggester.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/TermSuggester/TermSuggester.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Validate/ValidateQueryRequest.cs
+++ b/src/OpenSearch.Client/Search/Validate/ValidateQueryRequest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Validate/ValidateQueryResponse.cs
+++ b/src/OpenSearch.Client/Search/Validate/ValidateQueryResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/Search/Validate/ValidationExplanation.cs
+++ b/src/OpenSearch.Client/Search/Validate/ValidationExplanation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Client/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/OpenSearch.Client/_Generated/ApiUrlsLookup.generated.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Audit/Auditor.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Audit/Auditor.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Audit/Audits.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Audit/Audits.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Extensions/NumericExtensions.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Extensions/NumericExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/FixedPipelineFactory.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/FixedPipelineFactory.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/MockResponses/SniffResponseBytes.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/MockResponses/SniffResponseBytes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Providers/TestableDateTimeProvider.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Providers/TestableDateTimeProvider.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Rules/ClientCallRule.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Rules/ClientCallRule.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Rules/PingRule.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Rules/PingRule.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Rules/RuleBase.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Rules/RuleBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Rules/RuleOption.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Rules/RuleOption.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Rules/SniffRule.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Rules/SniffRule.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/Rules/TimesHelper.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/Rules/TimesHelper.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/SealedVirtualCluster.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/SealedVirtualCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/VirtualCluster.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/VirtualCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/VirtualClusterConnection.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/VirtualClusterConnection.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/VirtualClusterWith.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/VirtualClusterWith.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net.VirtualizedCluster/VirtualizedCluster.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/VirtualizedCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/Enums.Generated.cs
+++ b/src/OpenSearch.Net/Api/Enums.Generated.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/NativeMethods.cs
+++ b/src/OpenSearch.Net/Api/NativeMethods.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/IRequestParameters.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/IRequestParameters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.DanglingIndices.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.DanglingIndices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Features.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Features.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Ingest.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Ingest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Nodes.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Nodes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Snapshot.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Snapshot.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Tasks.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Tasks.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParametersExtensions.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParametersExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Api/RuntimeInformation.cs
+++ b/src/OpenSearch.Net/Api/RuntimeInformation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Auditing/Audit.cs
+++ b/src/OpenSearch.Net/Auditing/Audit.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Auditing/AuditEvent.cs
+++ b/src/OpenSearch.Net/Auditing/AuditEvent.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Auditing/Auditable.cs
+++ b/src/OpenSearch.Net/Auditing/Auditable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/OpenSearch.Net/Configuration/ConnectionConfiguration.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/OpenSearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Configuration/RequestConfiguration.cs
+++ b/src/OpenSearch.Net/Configuration/RequestConfiguration.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Configuration/RequestConfigurationExtensions.cs
+++ b/src/OpenSearch.Net/Configuration/RequestConfigurationExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Configuration/RequestMetaData.cs
+++ b/src/OpenSearch.Net/Configuration/RequestMetaData.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Configuration/Security/ApiKeyAuthenticationCredentials.cs
+++ b/src/OpenSearch.Net/Configuration/Security/ApiKeyAuthenticationCredentials.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
+++ b/src/OpenSearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/CertificateValidations.cs
+++ b/src/OpenSearch.Net/Connection/CertificateValidations.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/ConnectionInfo.cs
+++ b/src/OpenSearch.Net/Connection/ConnectionInfo.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/Content/RequestDataContent.cs
+++ b/src/OpenSearch.Net/Connection/Content/RequestDataContent.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HandlerTracking/ActiveHandlerTrackingEntry.cs
+++ b/src/OpenSearch.Net/Connection/HandlerTracking/ActiveHandlerTrackingEntry.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HandlerTracking/ExpiredHandlerTrackingEntry.cs
+++ b/src/OpenSearch.Net/Connection/HandlerTracking/ExpiredHandlerTrackingEntry.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HandlerTracking/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/OpenSearch.Net/Connection/HandlerTracking/LifetimeTrackingHttpMessageHandler.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
+++ b/src/OpenSearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HandlerTracking/ValueStopWatch.cs
+++ b/src/OpenSearch.Net/Connection/HandlerTracking/ValueStopWatch.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HttpConnection-FullFramework.cs
+++ b/src/OpenSearch.Net/Connection/HttpConnection-FullFramework.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HttpConnection.cs
+++ b/src/OpenSearch.Net/Connection/HttpConnection.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HttpMethod.cs
+++ b/src/OpenSearch.Net/Connection/HttpMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/OpenSearch.Net/Connection/HttpWebRequestConnection.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/IConnection.cs
+++ b/src/OpenSearch.Net/Connection/IConnection.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/InMemoryConnection.cs
+++ b/src/OpenSearch.Net/Connection/InMemoryConnection.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/MetaData/ClientVersionInfo.cs
+++ b/src/OpenSearch.Net/Connection/MetaData/ClientVersionInfo.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/MetaData/MetaDataHeader.cs
+++ b/src/OpenSearch.Net/Connection/MetaData/MetaDataHeader.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/MetaData/MetaHeaderProvider.cs
+++ b/src/OpenSearch.Net/Connection/MetaData/MetaHeaderProvider.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/MetaData/RuntimeVersionInfo.cs
+++ b/src/OpenSearch.Net/Connection/MetaData/RuntimeVersionInfo.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/MetaData/VersionInfo.cs
+++ b/src/OpenSearch.Net/Connection/MetaData/VersionInfo.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Connection/SecureStrings.cs
+++ b/src/OpenSearch.Net/Connection/SecureStrings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/ConnectionPool/CloudConnectionPool.cs
+++ b/src/OpenSearch.Net/ConnectionPool/CloudConnectionPool.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/ConnectionPool/IConnectionPool.cs
+++ b/src/OpenSearch.Net/ConnectionPool/IConnectionPool.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/ConnectionPool/Node.cs
+++ b/src/OpenSearch.Net/ConnectionPool/Node.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
+++ b/src/OpenSearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/ConnectionPool/SniffingConnectionPool.cs
+++ b/src/OpenSearch.Net/ConnectionPool/SniffingConnectionPool.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/ConnectionPool/StaticConnectionPool.cs
+++ b/src/OpenSearch.Net/ConnectionPool/StaticConnectionPool.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/ConnectionPool/StickyConnectionPool.cs
+++ b/src/OpenSearch.Net/ConnectionPool/StickyConnectionPool.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/ConnectionPool/StickySniffingConnectionPool.cs
+++ b/src/OpenSearch.Net/ConnectionPool/StickySniffingConnectionPool.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/AuditDiagnosticObserver.cs
+++ b/src/OpenSearch.Net/Diagnostics/AuditDiagnosticObserver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/Diagnostic.cs
+++ b/src/OpenSearch.Net/Diagnostics/Diagnostic.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/DiagnosticSources.cs
+++ b/src/OpenSearch.Net/Diagnostics/DiagnosticSources.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/HttpConnectionDiagnosticObserver.cs
+++ b/src/OpenSearch.Net/Diagnostics/HttpConnectionDiagnosticObserver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/RequestPipelineDiagnosticObserver.cs
+++ b/src/OpenSearch.Net/Diagnostics/RequestPipelineDiagnosticObserver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/SerializerDiagnosticObserver.cs
+++ b/src/OpenSearch.Net/Diagnostics/SerializerDiagnosticObserver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/TcpStats.cs
+++ b/src/OpenSearch.Net/Diagnostics/TcpStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/ThreadpoolStats.cs
+++ b/src/OpenSearch.Net/Diagnostics/ThreadpoolStats.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Diagnostics/TypedDiagnosticObserverBase.cs
+++ b/src/OpenSearch.Net/Diagnostics/TypedDiagnosticObserverBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Exceptions/OpenSearchClientException.cs
+++ b/src/OpenSearch.Net/Exceptions/OpenSearchClientException.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Exceptions/UnexpectedOpenSearchClientException.cs
+++ b/src/OpenSearch.Net/Exceptions/UnexpectedOpenSearchClientException.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/ArraySegmentBytesExtensions.cs
+++ b/src/OpenSearch.Net/Extensions/ArraySegmentBytesExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/CharUtils.cs
+++ b/src/OpenSearch.Net/Extensions/CharUtils.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/DateTimeUtil.cs
+++ b/src/OpenSearch.Net/Extensions/DateTimeUtil.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/EmptyReadonly.cs
+++ b/src/OpenSearch.Net/Extensions/EmptyReadonly.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/EnumExtensions.cs
+++ b/src/OpenSearch.Net/Extensions/EnumExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/Fluent.cs
+++ b/src/OpenSearch.Net/Extensions/Fluent.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/MapsApiAttribute.cs
+++ b/src/OpenSearch.Net/Extensions/MapsApiAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/NameValueCollectionExtensions.cs
+++ b/src/OpenSearch.Net/Extensions/NameValueCollectionExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/StringBuilderCache.cs
+++ b/src/OpenSearch.Net/Extensions/StringBuilderCache.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/TypeExtensions.cs
+++ b/src/OpenSearch.Net/Extensions/TypeExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/UtilExtensions.cs
+++ b/src/OpenSearch.Net/Extensions/UtilExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Extensions/X509CertificateExtensions.cs
+++ b/src/OpenSearch.Net/Extensions/X509CertificateExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/GlobalSuppressions.cs
+++ b/src/OpenSearch.Net/GlobalSuppressions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/IOpenSearchLowLevelClient.Generated.cs
+++ b/src/OpenSearch.Net/IOpenSearchLowLevelClient.Generated.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/IOpenSearchLowLevelClient.cs
+++ b/src/OpenSearch.Net/IOpenSearchLowLevelClient.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/NamespacedClientProxy.cs
+++ b/src/OpenSearch.Net/NamespacedClientProxy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Cat.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Cat.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Cluster.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Cluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.DanglingIndices.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.DanglingIndices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Features.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Features.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Indices.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Indices.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Ingest.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Ingest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.NoNamespace.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.NoNamespace.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Nodes.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Nodes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Snapshot.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Snapshot.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Tasks.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Tasks.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/OpenSearchUrlFormatter.cs
+++ b/src/OpenSearch.Net/OpenSearchUrlFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Patch.IOpenSearchLowLevelClient.cs
+++ b/src/OpenSearch.Net/Patch.IOpenSearchLowLevelClient.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Patch.OpenSearchLowLevelClient.Nodes.cs
+++ b/src/OpenSearch.Net/Patch.OpenSearchLowLevelClient.Nodes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Patch.OpenSearchLowLevelClient.cs
+++ b/src/OpenSearch.Net/Patch.OpenSearchLowLevelClient.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Properties/ClsCompliancy.cs
+++ b/src/OpenSearch.Net/Properties/ClsCompliancy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/DateTimeProvider.cs
+++ b/src/OpenSearch.Net/Providers/DateTimeProvider.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/IDateTimeProvider.cs
+++ b/src/OpenSearch.Net/Providers/IDateTimeProvider.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/IMemoryStreamFactory.cs
+++ b/src/OpenSearch.Net/Providers/IMemoryStreamFactory.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/IRequestPipelineFactory.cs
+++ b/src/OpenSearch.Net/Providers/IRequestPipelineFactory.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/MemoryStreamFactory.cs
+++ b/src/OpenSearch.Net/Providers/MemoryStreamFactory.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/RecyclableMemoryStream.cs
+++ b/src/OpenSearch.Net/Providers/RecyclableMemoryStream.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/RecyclableMemoryStreamFactory.cs
+++ b/src/OpenSearch.Net/Providers/RecyclableMemoryStreamFactory.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/RecyclableMemoryStreamManager-Events.cs
+++ b/src/OpenSearch.Net/Providers/RecyclableMemoryStreamManager-Events.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Providers/RecyclableMemoryStreamManager.cs
+++ b/src/OpenSearch.Net/Providers/RecyclableMemoryStreamManager.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/Dynamic/DynamicDictionary.cs
+++ b/src/OpenSearch.Net/Responses/Dynamic/DynamicDictionary.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/Dynamic/DynamicResponse.cs
+++ b/src/OpenSearch.Net/Responses/Dynamic/DynamicResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/Dynamic/DynamicValue.cs
+++ b/src/OpenSearch.Net/Responses/Dynamic/DynamicValue.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/HttpDetails/ApiCallDetails.cs
+++ b/src/OpenSearch.Net/Responses/HttpDetails/ApiCallDetails.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/HttpDetails/IApiCallDetails.cs
+++ b/src/OpenSearch.Net/Responses/HttpDetails/IApiCallDetails.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/IOpenSearchResponse.cs
+++ b/src/OpenSearch.Net/Responses/IOpenSearchResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/OpenSearchResponse.cs
+++ b/src/OpenSearch.Net/Responses/OpenSearchResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/ResponseStatics.cs
+++ b/src/OpenSearch.Net/Responses/ResponseStatics.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/ServerException/Error.cs
+++ b/src/OpenSearch.Net/Responses/ServerException/Error.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/ServerException/ErrorCause.cs
+++ b/src/OpenSearch.Net/Responses/ServerException/ErrorCause.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/ServerException/ServerError.cs
+++ b/src/OpenSearch.Net/Responses/ServerException/ServerError.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/ServerException/ShardFailure.cs
+++ b/src/OpenSearch.Net/Responses/ServerException/ShardFailure.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/Sniff/SniffResponse.cs
+++ b/src/OpenSearch.Net/Responses/Sniff/SniffResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/Special/BytesResponse.cs
+++ b/src/OpenSearch.Net/Responses/Special/BytesResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/Special/StringResponse.cs
+++ b/src/OpenSearch.Net/Responses/Special/StringResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Responses/Special/VoidResponse.cs
+++ b/src/OpenSearch.Net/Responses/Special/VoidResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/CustomResponseBuilderBase.cs
+++ b/src/OpenSearch.Net/Serialization/CustomResponseBuilderBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/DiagnosticsSerializerProxy.cs
+++ b/src/OpenSearch.Net/Serialization/DiagnosticsSerializerProxy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/Formatters/DynamicDictionaryFormatter.cs
+++ b/src/OpenSearch.Net/Serialization/Formatters/DynamicDictionaryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/Formatters/ExceptionFormatter.cs
+++ b/src/OpenSearch.Net/Serialization/Formatters/ExceptionFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/Formatters/InterfaceReadOnlyCollectionSingleOrEnumerableFormatter.cs
+++ b/src/OpenSearch.Net/Serialization/Formatters/InterfaceReadOnlyCollectionSingleOrEnumerableFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/Formatters/NullableStringIntFormatter.cs
+++ b/src/OpenSearch.Net/Serialization/Formatters/NullableStringIntFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/Formatters/OpenSearchNetEnumResolver.cs
+++ b/src/OpenSearch.Net/Serialization/Formatters/OpenSearchNetEnumResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/IInternalSerializerWithFormatter.cs
+++ b/src/OpenSearch.Net/Serialization/IInternalSerializerWithFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/IOpenSearchSerializer.cs
+++ b/src/OpenSearch.Net/Serialization/IOpenSearchSerializer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/IUrlParameter.cs
+++ b/src/OpenSearch.Net/Serialization/IUrlParameter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
+++ b/src/OpenSearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/OpenSearchSerializerExtensions.cs
+++ b/src/OpenSearch.Net/Serialization/OpenSearchSerializerExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/Resolvers/OpenSearchNetFormatterResolver.cs
+++ b/src/OpenSearch.Net/Serialization/Resolvers/OpenSearchNetFormatterResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/SerializationFormatting.cs
+++ b/src/OpenSearch.Net/Serialization/SerializationFormatting.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Serialization/StringEnumAttribute.cs
+++ b/src/OpenSearch.Net/Serialization/StringEnumAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/ITransport.cs
+++ b/src/OpenSearch.Net/Transport/ITransport.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/Pipeline/IRequestPipeline.cs
+++ b/src/OpenSearch.Net/Transport/Pipeline/IRequestPipeline.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/Pipeline/PipelineException.cs
+++ b/src/OpenSearch.Net/Transport/Pipeline/PipelineException.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/Pipeline/PipelineFailure.cs
+++ b/src/OpenSearch.Net/Transport/Pipeline/PipelineFailure.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/OpenSearch.Net/Transport/Pipeline/RequestData.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/OpenSearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/OpenSearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/PostData.cs
+++ b/src/OpenSearch.Net/Transport/PostData.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/SerializableData.cs
+++ b/src/OpenSearch.Net/Transport/SerializableData.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/StreamableData.cs
+++ b/src/OpenSearch.Net/Transport/StreamableData.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Transport/Transport.cs
+++ b/src/OpenSearch.Net/Transport/Transport.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Attributes.cs
+++ b/src/OpenSearch.Net/Utf8Json/Attributes.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/AnonymousFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/AnonymousFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/CollectionFormatters.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/CollectionFormatters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/DateTimeFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/DateTimeFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/DictionaryFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/DictionaryFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/DynamicObjectTypeFallbackFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/DynamicObjectTypeFallbackFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/EnumFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/EnumFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/MultiDimensionalArrayFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/MultiDimensionalArrayFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/NullableFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/NullableFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/PrimitiveFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/PrimitiveFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/PrimitiveObjectFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/PrimitiveObjectFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/StandardClassLibraryFormatters.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/StandardClassLibraryFormatters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/TupleFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/TupleFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Formatters/ValueTupleFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Formatters/ValueTupleFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/IJsonFormatter.cs
+++ b/src/OpenSearch.Net/Utf8Json/IJsonFormatter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/IJsonFormatterResolver.cs
+++ b/src/OpenSearch.Net/Utf8Json/IJsonFormatterResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/IJsonProperty.cs
+++ b/src/OpenSearch.Net/Utf8Json/IJsonProperty.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/ArrayBuffer.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/ArrayBuffer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/ArrayPool.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/ArrayPool.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/AutomataDictionary.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/AutomataDictionary.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/BinaryUtil.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/BinaryUtil.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/ByteArrayComparer.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/ByteArrayComparer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/ByteArrayStringHashTable.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/ByteArrayStringHashTable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/DiyFp.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/DiyFp.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/DoubleToStringConverter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/DoubleToStringConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/IEEE.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/IEEE.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/PowersOfTenCache.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/PowersOfTenCache.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/StringToDouble.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/StringToDouble.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/StringToDoubleConverter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/DoubleConversion/StringToDoubleConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/Emit/DynamicAssembly.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/Emit/DynamicAssembly.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/Emit/ExpressionUtility.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/Emit/ExpressionUtility.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/Emit/ILGeneratorExtensions.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/Emit/ILGeneratorExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/Emit/ILViewer.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/Emit/ILViewer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/Emit/MetaMember.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/Emit/MetaMember.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/Emit/MetaType.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/Emit/MetaType.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/FarmHash.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/FarmHash.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/FuncExtensions.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/FuncExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/GuidBits.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/GuidBits.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/NumberConverter.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/NumberConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/ReflectionExtensions.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/ReflectionExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/StringEncoding.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/StringEncoding.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/StringMutator.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/StringMutator.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Internal/UnsafeMemory.cs
+++ b/src/OpenSearch.Net/Utf8Json/Internal/UnsafeMemory.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/JsonReader.cs
+++ b/src/OpenSearch.Net/Utf8Json/JsonReader.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/JsonSerializer.NonGeneric.cs
+++ b/src/OpenSearch.Net/Utf8Json/JsonSerializer.NonGeneric.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/JsonSerializer.cs
+++ b/src/OpenSearch.Net/Utf8Json/JsonSerializer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/JsonToken.cs
+++ b/src/OpenSearch.Net/Utf8Json/JsonToken.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/JsonWriter.cs
+++ b/src/OpenSearch.Net/Utf8Json/JsonWriter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Resolvers/AttributeFormatterResolver.cs
+++ b/src/OpenSearch.Net/Utf8Json/Resolvers/AttributeFormatterResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Resolvers/BuiltinResolver.cs
+++ b/src/OpenSearch.Net/Utf8Json/Resolvers/BuiltinResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Resolvers/CompositeResolver.cs
+++ b/src/OpenSearch.Net/Utf8Json/Resolvers/CompositeResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Resolvers/DynamicGenericResolver.cs
+++ b/src/OpenSearch.Net/Utf8Json/Resolvers/DynamicGenericResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Resolvers/DynamicObjectResolver.cs
+++ b/src/OpenSearch.Net/Utf8Json/Resolvers/DynamicObjectResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Resolvers/EnumResolver.cs
+++ b/src/OpenSearch.Net/Utf8Json/Resolvers/EnumResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/src/OpenSearch.Net/Utf8Json/Resolvers/StandardResolver.cs
+++ b/src/OpenSearch.Net/Utf8Json/Resolvers/StandardResolver.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Reproduce/GithubIssue3311.cs
+++ b/tests/Reproduce/GithubIssue3311.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ClusterLauncher/ClusterLaunchProgram.cs
+++ b/tests/Tests.ClusterLauncher/ClusterLaunchProgram.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Configuration/ConfigurationLoader.cs
+++ b/tests/Tests.Configuration/ConfigurationLoader.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Configuration/EnvironmentConfiguration.cs
+++ b/tests/Tests.Configuration/EnvironmentConfiguration.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Configuration/TestConfigurationBase.cs
+++ b/tests/Tests.Configuration/TestConfigurationBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Configuration/TestConfigurationExtensions.cs
+++ b/tests/Tests.Configuration/TestConfigurationExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Configuration/TestMode.cs
+++ b/tests/Tests.Configuration/TestMode.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Configuration/YamlConfiguration.cs
+++ b/tests/Tests.Configuration/YamlConfiguration.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Client/FixedResponseClient.cs
+++ b/tests/Tests.Core/Client/FixedResponseClient.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Client/Serializers/TestSourceSerializerBase.cs
+++ b/tests/Tests.Core/Client/Serializers/TestSourceSerializerBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Client/Settings/AlwaysInMemoryConnectionSettings.cs
+++ b/tests/Tests.Core/Client/Settings/AlwaysInMemoryConnectionSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
+++ b/tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Client/TestClient.cs
+++ b/tests/Tests.Core/Client/TestClient.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/ClientExtensions.cs
+++ b/tests/Tests.Core/Extensions/ClientExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/DiffExtensions.cs
+++ b/tests/Tests.Core/Extensions/DiffExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/EnumerableExtensions.cs
+++ b/tests/Tests.Core/Extensions/EnumerableExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/EphemeralClusterExtensions.cs
+++ b/tests/Tests.Core/Extensions/EphemeralClusterExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/NumericExtensions.cs
+++ b/tests/Tests.Core/Extensions/NumericExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/ReadOnlyDictionaryAssertions.cs
+++ b/tests/Tests.Core/Extensions/ReadOnlyDictionaryAssertions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/SerializationTesterAssertionExtensions.cs
+++ b/tests/Tests.Core/Extensions/SerializationTesterAssertionExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/ShouldExtensions.cs
+++ b/tests/Tests.Core/Extensions/ShouldExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
+++ b/tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/ClusterTestClassBase.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/ClusterTestClassBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/ClientTestClusterBase.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/ClientTestClusterBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/ConnectionReuseCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/ConnectionReuseCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/CrossCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/CrossCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/IOpenSearchClientTestCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/IOpenSearchClientTestCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/IntrusiveOperationCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/IntrusiveOperationCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/ReadOnlyCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/ReadOnlyCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/UnbalancedCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/UnbalancedCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/WritableCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/WritableCluster.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/NodeSeeders/DefaultSeeder.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/NodeSeeders/DefaultSeeder.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/ManagedOpenSearch/Tasks/WriteAnalysisFiles.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Tasks/WriteAnalysisFiles.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Serialization/ExpectJsonTestBase.cs
+++ b/tests/Tests.Core/Serialization/ExpectJsonTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Serialization/GeoCoordinateJsonConverter.cs
+++ b/tests/Tests.Core/Serialization/GeoCoordinateJsonConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Serialization/IntermediateChangedSettings.cs
+++ b/tests/Tests.Core/Serialization/IntermediateChangedSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Serialization/RoundtripperDsl.cs
+++ b/tests/Tests.Core/Serialization/RoundtripperDsl.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Serialization/SerializationTestHelper.cs
+++ b/tests/Tests.Core/Serialization/SerializationTestHelper.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Serialization/SerializationTester.cs
+++ b/tests/Tests.Core/Serialization/SerializationTester.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Xunit/Generators.cs
+++ b/tests/Tests.Core/Xunit/Generators.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Xunit/IntegrationOnlyAttribute.cs
+++ b/tests/Tests.Core/Xunit/IntegrationOnlyAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Xunit/JsonNetSerializerOnlyAttribute.cs
+++ b/tests/Tests.Core/Xunit/JsonNetSerializerOnlyAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Xunit/NeedsTypedKeysAttribute.cs
+++ b/tests/Tests.Core/Xunit/NeedsTypedKeysAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Xunit/OpenSearchClientXunitRunOptions.cs
+++ b/tests/Tests.Core/Xunit/OpenSearchClientXunitRunOptions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Xunit/ProjectReferenceOnlyAttribute.cs
+++ b/tests/Tests.Core/Xunit/ProjectReferenceOnlyAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Xunit/SkipOnCiAttribute.cs
+++ b/tests/Tests.Core/Xunit/SkipOnCiAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Core/Xunit/XunitRunState.cs
+++ b/tests/Tests.Core/Xunit/XunitRunState.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/CommitActivity.cs
+++ b/tests/Tests.Domain/CommitActivity.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Developer.cs
+++ b/tests/Tests.Domain/Developer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Extensions/AnonymizerExtensions.cs
+++ b/tests/Tests.Domain/Extensions/AnonymizerExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Extensions/ConnectionSettingsExtensions.cs
+++ b/tests/Tests.Domain/Extensions/ConnectionSettingsExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Extensions/DateTimeExtensions.cs
+++ b/tests/Tests.Domain/Extensions/DateTimeExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Gender.cs
+++ b/tests/Tests.Domain/Gender.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/GeoIp.cs
+++ b/tests/Tests.Domain/GeoIp.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/GeoShape.cs
+++ b/tests/Tests.Domain/GeoShape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Helpers/Gimme.cs
+++ b/tests/Tests.Domain/Helpers/Gimme.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Helpers/TestValueHelper.cs
+++ b/tests/Tests.Domain/Helpers/TestValueHelper.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/JsonConverters/DateTimeConverter.cs
+++ b/tests/Tests.Domain/JsonConverters/DateTimeConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/JsonConverters/StringTimeSpanConverter.cs
+++ b/tests/Tests.Domain/JsonConverters/StringTimeSpanConverter.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Log.cs
+++ b/tests/Tests.Domain/Log.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Metric.cs
+++ b/tests/Tests.Domain/Metric.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Person.cs
+++ b/tests/Tests.Domain/Person.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Project.cs
+++ b/tests/Tests.Domain/Project.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/ProjectPercolation.cs
+++ b/tests/Tests.Domain/ProjectPercolation.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Ranges.cs
+++ b/tests/Tests.Domain/Ranges.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Shape.cs
+++ b/tests/Tests.Domain/Shape.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/SimpleGeoPoint.cs
+++ b/tests/Tests.Domain/SimpleGeoPoint.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/SourceOnlyObject.cs
+++ b/tests/Tests.Domain/SourceOnlyObject.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Domain/Tag.cs
+++ b/tests/Tests.Domain/Tag.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/DateSerialization.cs
+++ b/tests/Tests.Reproduce/DateSerialization.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/Discuss179634.cs
+++ b/tests/Tests.Reproduce/Discuss179634.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue3719.cs
+++ b/tests/Tests.Reproduce/GitHubIssue3719.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue3819.cs
+++ b/tests/Tests.Reproduce/GitHubIssue3819.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue3926.cs
+++ b/tests/Tests.Reproduce/GitHubIssue3926.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue3981.cs
+++ b/tests/Tests.Reproduce/GitHubIssue3981.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4103.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4103.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4285.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4285.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4294.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4294.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4333.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4333.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4382.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4382.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4462.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4462.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4487.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4487.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4537.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4537.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4573.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4573.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4797.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4797.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4817.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4817.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4818.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4818.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4876.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4876.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue4958.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4958.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue5363.cs
+++ b/tests/Tests.Reproduce/GitHubIssue5363.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GitHubIssue5432.cs
+++ b/tests/Tests.Reproduce/GitHubIssue5432.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue1901.cs
+++ b/tests/Tests.Reproduce/GithubIssue1901.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue1906.cs
+++ b/tests/Tests.Reproduce/GithubIssue1906.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2052.cs
+++ b/tests/Tests.Reproduce/GithubIssue2052.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2101.cs
+++ b/tests/Tests.Reproduce/GithubIssue2101.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2152.cs
+++ b/tests/Tests.Reproduce/GithubIssue2152.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2173.cs
+++ b/tests/Tests.Reproduce/GithubIssue2173.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2306.cs
+++ b/tests/Tests.Reproduce/GithubIssue2306.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2309.cs
+++ b/tests/Tests.Reproduce/GithubIssue2309.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2323.cs
+++ b/tests/Tests.Reproduce/GithubIssue2323.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2409.cs
+++ b/tests/Tests.Reproduce/GithubIssue2409.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2503.cs
+++ b/tests/Tests.Reproduce/GithubIssue2503.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2690.cs
+++ b/tests/Tests.Reproduce/GithubIssue2690.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2788.cs
+++ b/tests/Tests.Reproduce/GithubIssue2788.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2871.cs
+++ b/tests/Tests.Reproduce/GithubIssue2871.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2875.cs
+++ b/tests/Tests.Reproduce/GithubIssue2875.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2886.cs
+++ b/tests/Tests.Reproduce/GithubIssue2886.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue2985.cs
+++ b/tests/Tests.Reproduce/GithubIssue2985.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3084.cs
+++ b/tests/Tests.Reproduce/GithubIssue3084.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3107.cs
+++ b/tests/Tests.Reproduce/GithubIssue3107.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3164.cs
+++ b/tests/Tests.Reproduce/GithubIssue3164.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3210.cs
+++ b/tests/Tests.Reproduce/GithubIssue3210.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3220.cs
+++ b/tests/Tests.Reproduce/GithubIssue3220.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3231.cs
+++ b/tests/Tests.Reproduce/GithubIssue3231.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3262.cs
+++ b/tests/Tests.Reproduce/GithubIssue3262.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3356.cs
+++ b/tests/Tests.Reproduce/GithubIssue3356.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3411.cs
+++ b/tests/Tests.Reproduce/GithubIssue3411.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3673.cs
+++ b/tests/Tests.Reproduce/GithubIssue3673.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3715.cs
+++ b/tests/Tests.Reproduce/GithubIssue3715.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3717.cs
+++ b/tests/Tests.Reproduce/GithubIssue3717.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3743.cs
+++ b/tests/Tests.Reproduce/GithubIssue3743.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3745.cs
+++ b/tests/Tests.Reproduce/GithubIssue3745.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue3907.cs
+++ b/tests/Tests.Reproduce/GithubIssue3907.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4041.cs
+++ b/tests/Tests.Reproduce/GithubIssue4041.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4044.cs
+++ b/tests/Tests.Reproduce/GithubIssue4044.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4057.cs
+++ b/tests/Tests.Reproduce/GithubIssue4057.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4078.cs
+++ b/tests/Tests.Reproduce/GithubIssue4078.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4197.cs
+++ b/tests/Tests.Reproduce/GithubIssue4197.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4228.cs
+++ b/tests/Tests.Reproduce/GithubIssue4228.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4243.cs
+++ b/tests/Tests.Reproduce/GithubIssue4243.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4467.cs
+++ b/tests/Tests.Reproduce/GithubIssue4467.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4582.cs
+++ b/tests/Tests.Reproduce/GithubIssue4582.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4703.cs
+++ b/tests/Tests.Reproduce/GithubIssue4703.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubIssue4787.cs
+++ b/tests/Tests.Reproduce/GithubIssue4787.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/GithubPR5039.cs
+++ b/tests/Tests.Reproduce/GithubPR5039.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/JsonNetSerializerConverters.cs
+++ b/tests/Tests.Reproduce/JsonNetSerializerConverters.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/TimeSpanSerialization.cs
+++ b/tests/Tests.Reproduce/TimeSpanSerialization.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/UseCultureAttribute.cs
+++ b/tests/Tests.Reproduce/UseCultureAttribute.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/Utf8JsonTest.cs
+++ b/tests/Tests.Reproduce/Utf8JsonTest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.Reproduce/XunitBootstrap.cs
+++ b/tests/Tests.Reproduce/XunitBootstrap.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ScratchPad/DoNothingRunner.cs
+++ b/tests/Tests.ScratchPad/DoNothingRunner.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ScratchPad/Program.cs
+++ b/tests/Tests.ScratchPad/Program.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ScratchPad/RunBase.cs
+++ b/tests/Tests.ScratchPad/RunBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ScratchPad/Runners/ApiCalls/IndexDocumentRunner.cs
+++ b/tests/Tests.ScratchPad/Runners/ApiCalls/IndexDocumentRunner.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ScratchPad/Runners/Inferrence/ExpressionCreationRunner.cs
+++ b/tests/Tests.ScratchPad/Runners/Inferrence/ExpressionCreationRunner.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ScratchPad/Runners/Inferrence/FieldInferenceRunner.cs
+++ b/tests/Tests.ScratchPad/Runners/Inferrence/FieldInferenceRunner.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ScratchPad/Runners/Inferrence/IdInferenceRunner.cs
+++ b/tests/Tests.ScratchPad/Runners/Inferrence/IdInferenceRunner.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests.ScratchPad/Runners/Inferrence/PropertyNameInferenceRunner.cs
+++ b/tests/Tests.ScratchPad/Runners/Inferrence/PropertyNameInferenceRunner.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/AggregationMetaUsageTests.cs
+++ b/tests/Tests/Aggregations/AggregationMetaUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/AggregationUsageTestBase.cs
+++ b/tests/Tests/Aggregations/AggregationUsageTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/AggregationVisitorTests.cs
+++ b/tests/Tests/Aggregations/AggregationVisitorTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/AdjacencyMatrix/AdjacencyMatrixUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/AdjacencyMatrix/AdjacencyMatrixUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Children/ChildrenAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Children/ChildrenAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/DiversifiedSampler/DiversifiedSamplerAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DiversifiedSampler/DiversifiedSamplerAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Filter/FilterAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Filter/FilterAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Filters/FiltersAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Filters/FiltersAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/GeoDistance/GeoDistanceAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/GeoDistance/GeoDistanceAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/GeoTileGrid/GeoTileGridAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/GeoTileGrid/GeoTileGridAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Global/GlobalAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Global/GlobalAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/IpRange/IpRangeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/IpRange/IpRangeAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Missing/MissingAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Missing/MissingAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Nested/NestedAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Nested/NestedAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Parent/ParentAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Parent/ParentAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Range/RangeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Range/RangeAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/RareTerms/RareTermsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/RareTerms/RareTermsAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/ReverseNested/ReverseNestedAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/ReverseNested/ReverseNestedAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Sampler/SamplerAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Sampler/SamplerAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/SignificantText/SignificantTextAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/SignificantText/SignificantTextAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Bucket/Terms/TermsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Terms/TermsAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Matrix/MatrixStats/MatrixStatsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Matrix/MatrixStats/MatrixStatsAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/Average/AverageAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Average/AverageAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/Cardinality/CardinalityAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Cardinality/CardinalityAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/GeoBounds/GeoBoundsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/GeoBounds/GeoBoundsAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/Max/MaxAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Max/MaxAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/MedianAbsoluteDeviation/MedianAbsoluteDeviationAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/MedianAbsoluteDeviation/MedianAbsoluteDeviationAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/Min/MinAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Min/MinAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/Percentiles/PercentilesAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Percentiles/PercentilesAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/Stats/StatsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Stats/StatsAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/Sum/SumAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Sum/SumAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/ValueCount/ValueCountAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/ValueCount/ValueCountAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Metric/WeightedAverage/WeightedAverageAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/WeightedAverage/WeightedAverageAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/AverageBucket/AverageBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/AverageBucket/AverageBucketAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/BucketScript/BucketScriptAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/BucketScript/BucketScriptAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/BucketSelector/BucketSelectorAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/BucketSelector/BucketSelectorAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/BucketSort/BucketSortAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/BucketSort/BucketSortAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/CumulativeSum/CumulativeSumAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/CumulativeSum/CumulativeSumAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/Derivative/DerivativeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/Derivative/DerivativeAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/ExtendedStatsBucket/ExtendedStatsBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/ExtendedStatsBucket/ExtendedStatsBucketAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/MaxBucket/MaxBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MaxBucket/MaxBucketAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/MinBucket/MinBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MinBucket/MinBucketAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageEwmaAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageEwmaAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltLinearAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltLinearAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageLinearAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageLinearAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageSimpleAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageSimpleAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/MovingFunction/MovingFunctionAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingFunction/MovingFunctionAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/PercentilesBucket/PercentilesBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/PercentilesBucket/PercentilesBucketAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/StatsBucket/StatsBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/StatsBucket/StatsBucketAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/Pipeline/SumBucket/SumBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/SumBucket/SumBucketAggregationUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/ReservedAggregationNames.doc.cs
+++ b/tests/Tests/Aggregations/ReservedAggregationNames.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Aggregations/WritingAggregations.doc.cs
+++ b/tests/Tests/Aggregations/WritingAggregations.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/AnalysisComponentTestBase.cs
+++ b/tests/Tests/Analysis/AnalysisComponentTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/AnalysisCrudTests.cs
+++ b/tests/Tests/Analysis/AnalysisCrudTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/AnalysisUsageTests.cs
+++ b/tests/Tests/Analysis/AnalysisUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/AnalysisWithNormalizerCrudTests.cs
+++ b/tests/Tests/Analysis/AnalysisWithNormalizerCrudTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/Analyzers/AnalyzerAssertionBase.cs
+++ b/tests/Tests/Analysis/Analyzers/AnalyzerAssertionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/Analyzers/AnalyzerTests.cs
+++ b/tests/Tests/Analysis/Analyzers/AnalyzerTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/CharFilters/CharFilterAssertionBase.cs
+++ b/tests/Tests/Analysis/CharFilters/CharFilterAssertionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/CharFilters/CharFilterTests.cs
+++ b/tests/Tests/Analysis/CharFilters/CharFilterTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/Normalizers/NormalizerAssertionBase.cs
+++ b/tests/Tests/Analysis/Normalizers/NormalizerAssertionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/Normalizers/NormalizerTests.cs
+++ b/tests/Tests/Analysis/Normalizers/NormalizerTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/TokenFilters/TokenFilterAssertionBase.cs
+++ b/tests/Tests/Analysis/TokenFilters/TokenFilterAssertionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
+++ b/tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/TokenFilters/TokenFilterUsageTests.cs
+++ b/tests/Tests/Analysis/TokenFilters/TokenFilterUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/Tokenizers/TokenizerAssertionBase.cs
+++ b/tests/Tests/Analysis/Tokenizers/TokenizerAssertionBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Analysis/Tokenizers/TokenizerTests.cs
+++ b/tests/Tests/Analysis/Tokenizers/TokenizerTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatAliases/CatAliasesApiTests.cs
+++ b/tests/Tests/Cat/CatAliases/CatAliasesApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatAliases/CatAliasesUrlTests.cs
+++ b/tests/Tests/Cat/CatAliases/CatAliasesUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatAllocation/CatAllocationApiTests.cs
+++ b/tests/Tests/Cat/CatAllocation/CatAllocationApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatAllocation/CatAllocationUrlTests.cs
+++ b/tests/Tests/Cat/CatAllocation/CatAllocationUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatCount/CatCountApiTests.cs
+++ b/tests/Tests/Cat/CatCount/CatCountApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatCount/CatCountUrlTests.cs
+++ b/tests/Tests/Cat/CatCount/CatCountUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatFielddata/CatFielddataApiTests.cs
+++ b/tests/Tests/Cat/CatFielddata/CatFielddataApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatFielddata/CatFielddataUrlTests.cs
+++ b/tests/Tests/Cat/CatFielddata/CatFielddataUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatHealth/CatHealthApiTests.cs
+++ b/tests/Tests/Cat/CatHealth/CatHealthApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatHealth/CatHealthUrlTests.cs
+++ b/tests/Tests/Cat/CatHealth/CatHealthUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatHelp/CatHelpApiTests.cs
+++ b/tests/Tests/Cat/CatHelp/CatHelpApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatHelp/CatHelpUrlTests.cs
+++ b/tests/Tests/Cat/CatHelp/CatHelpUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatIndices/CatIndicesApiTests.cs
+++ b/tests/Tests/Cat/CatIndices/CatIndicesApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatIndices/CatIndicesUrlTests.cs
+++ b/tests/Tests/Cat/CatIndices/CatIndicesUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatMaster/CatMasterApiTests.cs
+++ b/tests/Tests/Cat/CatMaster/CatMasterApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatMaster/CatMasterUrlTests.cs
+++ b/tests/Tests/Cat/CatMaster/CatMasterUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatNodeAttributes/CatAliasesUrlTests.cs
+++ b/tests/Tests/Cat/CatNodeAttributes/CatAliasesUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatNodeAttributes/CatNodeAttributesApiTests.cs
+++ b/tests/Tests/Cat/CatNodeAttributes/CatNodeAttributesApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatNodes/CatNodesApiTests.cs
+++ b/tests/Tests/Cat/CatNodes/CatNodesApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatNodes/CatNodesUrlTests.cs
+++ b/tests/Tests/Cat/CatNodes/CatNodesUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatPendingTasks/CatPendingTasksApiTests.cs
+++ b/tests/Tests/Cat/CatPendingTasks/CatPendingTasksApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatPendingTasks/CatPendingTasksUrlTests.cs
+++ b/tests/Tests/Cat/CatPendingTasks/CatPendingTasksUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatPlugins/CatPluginsApiTests.cs
+++ b/tests/Tests/Cat/CatPlugins/CatPluginsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatPlugins/CatPluginsUrlTests.cs
+++ b/tests/Tests/Cat/CatPlugins/CatPluginsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatRecovery/CatRecoveryApiTests.cs
+++ b/tests/Tests/Cat/CatRecovery/CatRecoveryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatRecovery/CatRecoveryUrlTests.cs
+++ b/tests/Tests/Cat/CatRecovery/CatRecoveryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatRepositories/CatRepositoriesApiTests.cs
+++ b/tests/Tests/Cat/CatRepositories/CatRepositoriesApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatRepositories/CatRepositoriesUrlTests.cs
+++ b/tests/Tests/Cat/CatRepositories/CatRepositoriesUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatSegments/CatSegmentsApiTests.cs
+++ b/tests/Tests/Cat/CatSegments/CatSegmentsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatSegments/CatSegmentsUrlTests.cs
+++ b/tests/Tests/Cat/CatSegments/CatSegmentsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatShards/CatShardsApiTests.cs
+++ b/tests/Tests/Cat/CatShards/CatShardsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatShards/CatShardsUrlTests.cs
+++ b/tests/Tests/Cat/CatShards/CatShardsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatSnapshots/CatSnapshotsApiTests.cs
+++ b/tests/Tests/Cat/CatSnapshots/CatSnapshotsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatSnapshots/CatSnapshotsUrlTests.cs
+++ b/tests/Tests/Cat/CatSnapshots/CatSnapshotsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatTasks/CatTasksApiTests.cs
+++ b/tests/Tests/Cat/CatTasks/CatTasksApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatTasks/CatTasksUrlTests.cs
+++ b/tests/Tests/Cat/CatTasks/CatTasksUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatTemplates/CatTemplatesApiTests.cs
+++ b/tests/Tests/Cat/CatTemplates/CatTemplatesApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatTemplates/CatTemplatesUrlTests.cs
+++ b/tests/Tests/Cat/CatTemplates/CatTemplatesUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatThreadPool/CatThreadPoolUrlTests.cs
+++ b/tests/Tests/Cat/CatThreadPool/CatThreadPoolUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cat/CatThreadPool/CatThreadpoolApiTests.cs
+++ b/tests/Tests/Cat/CatThreadPool/CatThreadpoolApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
+++ b/tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Connection/ConnectionReuseAndBalancing.cs
+++ b/tests/Tests/ClientConcepts/Connection/ConnectionReuseAndBalancing.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Connection/HttpWebRequestConnectionTests.cs
+++ b/tests/Tests/ClientConcepts/Connection/HttpWebRequestConnectionTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Connection/ModifyingDefaultConnection.doc.cs
+++ b/tests/Tests/ClientConcepts/Connection/ModifyingDefaultConnection.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Connection/SecureStringsTests.cs
+++ b/tests/Tests/ClientConcepts/Connection/SecureStringsTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/DateTimeProviders.Doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/DateTimeProviders.Doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/KeepingTrackOfNodes.Doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/KeepingTrackOfNodes.Doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/RequestPipelines.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/RequestPipelines.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/Transports.Doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/Transports.Doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/WaitingInMemoryConnection.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/WaitingInMemoryConnection.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnexpectedExceptions.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnexpectedExceptions.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnrecoverableExceptions.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnrecoverableExceptions.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Failover/FallingOver.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Failover/FallingOver.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/MaxRetries/RespectsMaxRetry.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/MaxRetries/RespectsMaxRetry.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Pinging/FirstUsage.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Pinging/FirstUsage.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Pinging/PingTests.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Pinging/PingTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Pinging/Revival.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Pinging/Revival.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/DisableSniffPingPerRequest.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/DisableSniffPingPerRequest.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RequestTimeoutsOverrides.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RequestTimeoutsOverrides.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsAllowedStatusCode.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsAllowedStatusCode.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsForceNode.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsForceNode.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsMaxRetryOverrides.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsMaxRetryOverrides.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/RoundRobin.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/RoundRobin.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/SkipDeadNodes.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/SkipDeadNodes.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/VolatileUpdates.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/VolatileUpdates.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnConnectionFailure.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnConnectionFailure.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStaleClusterState.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStaleClusterState.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStartup.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStartup.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Sticky/SkipDeadNodes.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Sticky/SkipDeadNodes.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Sticky/Sticky.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Sticky/Sticky.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ConnectionPooling/Sticky/StickySniffingConnectionPool.doc.cs
+++ b/tests/Tests/ClientConcepts/ConnectionPooling/Sticky/StickySniffingConnectionPool.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Exceptions/ExceptionTests.cs
+++ b/tests/Tests/ClientConcepts/Exceptions/ExceptionTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Analysis/TestingAnalyzers.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Analysis/TestingAnalyzers.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Analysis/WritingAnalyzers.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Analysis/WritingAnalyzers.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Caching/FieldResolverCacheTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Caching/FieldResolverCacheTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/CovariantHits/CovariantSearchResults.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/CovariantHits/CovariantSearchResults.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/GettingStarted.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/GettingStarted.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Indexing/IndexingDocuments.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Indexing/IndexingDocuments.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Indexing/IngestNodes.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Indexing/IngestNodes.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Indexing/Pipelines.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Indexing/Pipelines.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Indexing/ReindexingDocuments.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Indexing/ReindexingDocuments.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/DocumentPaths.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/DocumentPaths.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/DocumentPathEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/DocumentPathEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldsEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldsEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IdEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IdEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IdsEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IdsEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IndexMetricsEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IndexMetricsEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IndexNameEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IndexNameEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IndicesEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/IndicesEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/LongIdEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/LongIdEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/MetricsEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/MetricsEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/NameEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/NameEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/NamesEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/NamesEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/NodeIdsEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/NodeIdsEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/PropertyNameEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/PropertyNameEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/RelationNameEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/RelationNameEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/RoutingEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/RoutingEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/TaskIdEqualityTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/Equality/TaskIdEqualityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/IdsInference.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/IdsInference.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/ImplicitConversionTests.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/ImplicitConversionTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/IndicesPaths.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/IndicesPaths.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/PropertyInference.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/PropertyInference.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/RoutingInference.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/RoutingInference.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Mapping/AttributeMapping.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Mapping/AttributeMapping.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Mapping/FluentMapping.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Mapping/FluentMapping.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Mapping/IgnoringProperties.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Mapping/IgnoringProperties.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Mapping/MultiFields.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Mapping/MultiFields.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Mapping/VisitorPatternMapping.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Mapping/VisitorPatternMapping.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Serialization/ExtendingOscTypes.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Serialization/ExtendingOscTypes.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Serialization/ModellingDocumentsWithTypes.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Serialization/ModellingDocumentsWithTypes.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/HighLevel/Serialization/SendsUsingSourceSerializer.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/Serialization/SendsUsingSourceSerializer.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/LowLevel/DirectStreaming.cs
+++ b/tests/Tests/ClientConcepts/LowLevel/DirectStreaming.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/LowLevel/GettingStarted.doc.cs
+++ b/tests/Tests/ClientConcepts/LowLevel/GettingStarted.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/LowLevel/Lifetimes.doc.cs
+++ b/tests/Tests/ClientConcepts/LowLevel/Lifetimes.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/LowLevel/LowLevelResponseTypes.doc.cs
+++ b/tests/Tests/ClientConcepts/LowLevel/LowLevelResponseTypes.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/LowLevel/PostData.doc.cs
+++ b/tests/Tests/ClientConcepts/LowLevel/PostData.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ServerError/ComplexErrorTests.cs
+++ b/tests/Tests/ClientConcepts/ServerError/ComplexErrorTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ServerError/ErrorWithMultipleRootCausesTests.cs
+++ b/tests/Tests/ClientConcepts/ServerError/ErrorWithMultipleRootCausesTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ServerError/ErrorWithNullRootCausesTests.cs
+++ b/tests/Tests/ClientConcepts/ServerError/ErrorWithNullRootCausesTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ServerError/ErrorWithRootCauseTests.cs
+++ b/tests/Tests/ClientConcepts/ServerError/ErrorWithRootCauseTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ServerError/ServerErrorTestsBase.cs
+++ b/tests/Tests/ClientConcepts/ServerError/ServerErrorTestsBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/ServerError/StringErrrorTests.cs
+++ b/tests/Tests/ClientConcepts/ServerError/StringErrrorTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Troubleshooting/DebugMode.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebugMode.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Troubleshooting/DebuggerDisplayTests.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebuggerDisplayTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Troubleshooting/DeprecationLogging.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DeprecationLogging.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Troubleshooting/DiagnosticSource.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DiagnosticSource.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Troubleshooting/LoggingWithFiddler.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/LoggingWithFiddler.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/Troubleshooting/LoggingWithOnRequestCompleted.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/LoggingWithOnRequestCompleted.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/ClientConcepts/VirtualClusterTests.cs
+++ b/tests/Tests/ClientConcepts/VirtualClusterTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainApiTests.cs
+++ b/tests/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterHealth/ClusterHealthApiTests.cs
+++ b/tests/Tests/Cluster/ClusterHealth/ClusterHealthApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterHealth/ClusterHealthUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterHealth/ClusterHealthUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterPendingTasks/ClusterPendingTasksApiTests.cs
+++ b/tests/Tests/Cluster/ClusterPendingTasks/ClusterPendingTasksApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterPendingTasks/ClusterPendingTasksUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterPendingTasks/ClusterPendingTasksUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterReroute/ClusterRerouteApiTests.cs
+++ b/tests/Tests/Cluster/ClusterReroute/ClusterRerouteApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterReroute/ClusterRerouteUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterReroute/ClusterRerouteUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsApiTests.cs
+++ b/tests/Tests/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsApiTests.cs
+++ b/tests/Tests/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
+++ b/tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterState/ClusterStateUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterState/ClusterStateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
+++ b/tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ClusterStats/ClusterStatsUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterStats/ClusterStatsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesHotThreads/NodesHotThreadsApiTests.cs
+++ b/tests/Tests/Cluster/NodesHotThreads/NodesHotThreadsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesHotThreads/NodesHotThreadsUrlTests.cs
+++ b/tests/Tests/Cluster/NodesHotThreads/NodesHotThreadsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesInfo/NodesInfoApiTests.cs
+++ b/tests/Tests/Cluster/NodesInfo/NodesInfoApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesInfo/NodesInfoUrlTests.cs
+++ b/tests/Tests/Cluster/NodesInfo/NodesInfoUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
+++ b/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesStats/NodesStatsUrlTests.cs
+++ b/tests/Tests/Cluster/NodesStats/NodesStatsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesUsage/NodesUsageApiTests.cs
+++ b/tests/Tests/Cluster/NodesUsage/NodesUsageApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesUsage/NodesUsageUnitTests.cs
+++ b/tests/Tests/Cluster/NodesUsage/NodesUsageUnitTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/NodesUsage/NodesUsageUrlTests.cs
+++ b/tests/Tests/Cluster/NodesUsage/NodesUsageUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/Ping/PingApiTests.cs
+++ b/tests/Tests/Cluster/Ping/PingApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/Ping/PingUrlTests.cs
+++ b/tests/Tests/Cluster/Ping/PingUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ReloadSecureSettings/ReloadSecureSettingsApiTests.cs
+++ b/tests/Tests/Cluster/ReloadSecureSettings/ReloadSecureSettingsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/ReloadSecureSettings/ReloadSecureSettingsUrlTests.cs
+++ b/tests/Tests/Cluster/ReloadSecureSettings/ReloadSecureSettingsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/RemoteInfo/RemoteInfoApiTests.cs
+++ b/tests/Tests/Cluster/RemoteInfo/RemoteInfoApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/RemoteInfo/RemoteInfoUrlTests.cs
+++ b/tests/Tests/Cluster/RemoteInfo/RemoteInfoUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/RootNodeInfo/RootNodeInfoApiTests.cs
+++ b/tests/Tests/Cluster/RootNodeInfo/RootNodeInfoApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/RootNodeInfo/RootNodeInfoUrlTests.cs
+++ b/tests/Tests/Cluster/RootNodeInfo/RootNodeInfoUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/TaskManagement/GetTask/GetTaskApiTests.cs
+++ b/tests/Tests/Cluster/TaskManagement/GetTask/GetTaskApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/TaskManagement/GetTask/GetTaskUrlTests.cs
+++ b/tests/Tests/Cluster/TaskManagement/GetTask/GetTaskUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelApiTests.cs
+++ b/tests/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelUrlTests.cs
+++ b/tests/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/TaskManagement/TasksList/TasksListApiTests.cs
+++ b/tests/Tests/Cluster/TaskManagement/TasksList/TasksListApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/TaskManagement/TasksList/TasksListUrlTests.cs
+++ b/tests/Tests/Cluster/TaskManagement/TasksList/TasksListUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsApiTests.cs
+++ b/tests/Tests/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteingVotingConfigExclusionsTests.cs
+++ b/tests/Tests/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteingVotingConfigExclusionsTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsApiTests.cs
+++ b/tests/Tests/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostingVotingConfigExclusionsTests.cs
+++ b/tests/Tests/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostingVotingConfigExclusionsTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Analysis.cs
+++ b/tests/Tests/CodeStandards/Analysis.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Descriptors.doc.cs
+++ b/tests/Tests/CodeStandards/Descriptors.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/NamingConventions.doc.cs
+++ b/tests/Tests/CodeStandards/NamingConventions.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/OpenSearchClient.doc.cs
+++ b/tests/Tests/CodeStandards/OpenSearchClient.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Parity/ParityTests.cs
+++ b/tests/Tests/CodeStandards/Parity/ParityTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Queries.doc.cs
+++ b/tests/Tests/CodeStandards/Queries.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Requests.doc.cs
+++ b/tests/Tests/CodeStandards/Requests.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Responses.doc.cs
+++ b/tests/Tests/CodeStandards/Responses.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Serialization/Enums.cs
+++ b/tests/Tests/CodeStandards/Serialization/Enums.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Serialization/Formatters.doc.cs
+++ b/tests/Tests/CodeStandards/Serialization/Formatters.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Serialization/FractionalNumbers.cs
+++ b/tests/Tests/CodeStandards/Serialization/FractionalNumbers.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Serialization/GeoLocationTests.cs
+++ b/tests/Tests/CodeStandards/Serialization/GeoLocationTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Serialization/PrimitiveObjectFormatterTests.cs
+++ b/tests/Tests/CodeStandards/Serialization/PrimitiveObjectFormatterTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CodeStandards/Serialization/Properties.doc.cs
+++ b/tests/Tests/CodeStandards/Serialization/Properties.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CommonOptions/AutoExpandReplicas/AutoExpandReplicasTests.cs
+++ b/tests/Tests/CommonOptions/AutoExpandReplicas/AutoExpandReplicasTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
+++ b/tests/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CommonOptions/DateMath/DateMathTests.cs
+++ b/tests/Tests/CommonOptions/DateMath/DateMathTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CommonOptions/DistanceUnit/DistanceUnits.doc.cs
+++ b/tests/Tests/CommonOptions/DistanceUnit/DistanceUnits.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs
+++ b/tests/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/CommonOptions/Union/Union.doc.cs
+++ b/tests/Tests/CommonOptions/Union/Union.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Connection/MetaData/MetaHeaderProviderTests.cs
+++ b/tests/Tests/Connection/MetaData/MetaHeaderProviderTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Connection/MetaData/VersionInfoTests.cs
+++ b/tests/Tests/Connection/MetaData/VersionInfoTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/DanglingIndices/Delete/DeleteDanglingIndexApiTests.cs
+++ b/tests/Tests/DanglingIndices/Delete/DeleteDanglingIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/DanglingIndices/Delete/DeleteDanglingIndexUrlTests.cs
+++ b/tests/Tests/DanglingIndices/Delete/DeleteDanglingIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/DanglingIndices/Import/ImportDanglingIndexApiTests.cs
+++ b/tests/Tests/DanglingIndices/Import/ImportDanglingIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/DanglingIndices/Import/ImportDanglingIndexUrlTests.cs
+++ b/tests/Tests/DanglingIndices/Import/ImportDanglingIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/DanglingIndices/List/ListDanglingIndicesApiTests.cs
+++ b/tests/Tests/DanglingIndices/List/ListDanglingIndicesApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/DanglingIndices/List/ListDanglingIndicesUrlTests.cs
+++ b/tests/Tests/DanglingIndices/List/ListDanglingIndicesUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/Bulk/BulkApiTests.cs
+++ b/tests/Tests/Document/Multiple/Bulk/BulkApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/Bulk/BulkInvalidApiTests.cs
+++ b/tests/Tests/Document/Multiple/Bulk/BulkInvalidApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/Bulk/BulkInvalidVersionApiTests.cs
+++ b/tests/Tests/Document/Multiple/Bulk/BulkInvalidVersionApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/Bulk/BulkResponseParsingTests.cs
+++ b/tests/Tests/Document/Multiple/Bulk/BulkResponseParsingTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/Bulk/BulkSourceDeserialize.cs
+++ b/tests/Tests/Document/Multiple/Bulk/BulkSourceDeserialize.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/Bulk/BulkUpdateManyTests.cs
+++ b/tests/Tests/Document/Multiple/Bulk/BulkUpdateManyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/Bulk/BulkUrlTests.cs
+++ b/tests/Tests/Document/Multiple/Bulk/BulkUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/BulkAll/BulkAllApiTestsBase.cs
+++ b/tests/Tests/Document/Multiple/BulkAll/BulkAllApiTestsBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/BulkAll/BulkAllCancellationTokenApiTests.cs
+++ b/tests/Tests/Document/Multiple/BulkAll/BulkAllCancellationTokenApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/BulkAll/BulkAllDeallocationApiTests.cs
+++ b/tests/Tests/Document/Multiple/BulkAll/BulkAllDeallocationApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/BulkAll/BulkAllDisposeApiTests.cs
+++ b/tests/Tests/Document/Multiple/BulkAll/BulkAllDisposeApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/BulkAll/BulkAllExceptionApiTests.cs
+++ b/tests/Tests/Document/Multiple/BulkAll/BulkAllExceptionApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/BulkAll/BulkAllForEachAsyncApiTests.cs
+++ b/tests/Tests/Document/Multiple/BulkAll/BulkAllForEachAsyncApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/BulkAll/BulkAndScrollApiTests.cs
+++ b/tests/Tests/Document/Multiple/BulkAll/BulkAndScrollApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/BulkAll/BulkOnErrorApiTests.cs
+++ b/tests/Tests/Document/Multiple/BulkAll/BulkOnErrorApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/DeleteByQuery/DeleteByQueryApiTests.cs
+++ b/tests/Tests/Document/Multiple/DeleteByQuery/DeleteByQueryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/DeleteByQuery/DeleteByQueryUrlTests.cs
+++ b/tests/Tests/Document/Multiple/DeleteByQuery/DeleteByQueryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/DeleteByQueryRethrottle/DeleteByQueryRethrottleApiTests.cs
+++ b/tests/Tests/Document/Multiple/DeleteByQueryRethrottle/DeleteByQueryRethrottleApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/DeleteByQueryRethrottle/DeleteByQueryRethrottleUrlTests.cs
+++ b/tests/Tests/Document/Multiple/DeleteByQueryRethrottle/DeleteByQueryRethrottleUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/MultiGet/GetManyApiTests.cs
+++ b/tests/Tests/Document/Multiple/MultiGet/GetManyApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
+++ b/tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/MultiGet/MultiGetUrlTests.cs
+++ b/tests/Tests/Document/Multiple/MultiGet/MultiGetUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsApiTests.cs
+++ b/tests/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsIdsApiTests.cs
+++ b/tests/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsIdsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsIdsNotFoundApiTests.cs
+++ b/tests/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsIdsNotFoundApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsUrlTests.cs
+++ b/tests/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
+++ b/tests/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerInvalidApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerInvalidApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerPipelineApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerPipelineApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerRemoteApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerRemoteApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSliceApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSliceApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSourceApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSourceApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerUrlTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexRethrottle/ReindexRethrottleApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexRethrottle/ReindexRethrottleApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/ReindexRethrottle/ReindexRethrottleUrlTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexRethrottle/ReindexRethrottleUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/UpdateByQuery/UpdateByQueryApiTests.cs
+++ b/tests/Tests/Document/Multiple/UpdateByQuery/UpdateByQueryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/UpdateByQuery/UpdateByQueryUrlTests.cs
+++ b/tests/Tests/Document/Multiple/UpdateByQuery/UpdateByQueryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/UpdateByQueryRethrottle/UpdateByQueryRethrottleApiTests.cs
+++ b/tests/Tests/Document/Multiple/UpdateByQueryRethrottle/UpdateByQueryRethrottleApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Multiple/UpdateByQueryRethrottle/UpdateByQueryRethrottleUrlTests.cs
+++ b/tests/Tests/Document/Multiple/UpdateByQueryRethrottle/UpdateByQueryRethrottleUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Create/CreateApiTests.cs
+++ b/tests/Tests/Document/Single/Create/CreateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Create/CreateUrlTests.cs
+++ b/tests/Tests/Document/Single/Create/CreateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Delete/DeleteApiTests.cs
+++ b/tests/Tests/Document/Single/Delete/DeleteApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Delete/DeleteUrlTests.cs
+++ b/tests/Tests/Document/Single/Delete/DeleteUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/DocumentCrudTests.cs
+++ b/tests/Tests/Document/Single/DocumentCrudTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Exists/DocumentExistsApiTests.cs
+++ b/tests/Tests/Document/Single/Exists/DocumentExistsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Exists/DocumentExistsNotFoundApiTests.cs
+++ b/tests/Tests/Document/Single/Exists/DocumentExistsNotFoundApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Exists/DocumentExistsUrlTests.cs
+++ b/tests/Tests/Document/Single/Exists/DocumentExistsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Get/GetApiTests.cs
+++ b/tests/Tests/Document/Single/Get/GetApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Get/GetUrlTests.cs
+++ b/tests/Tests/Document/Single/Get/GetUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Index/IndexApiTests.cs
+++ b/tests/Tests/Document/Single/Index/IndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Index/IndexIngestApiTests.cs
+++ b/tests/Tests/Document/Single/Index/IndexIngestApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Index/IndexIngestAttachmentApiTests.cs
+++ b/tests/Tests/Document/Single/Index/IndexIngestAttachmentApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Index/IndexUrlTests.cs
+++ b/tests/Tests/Document/Single/Index/IndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Source/SourceApiTests.cs
+++ b/tests/Tests/Document/Single/Source/SourceApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/SourceExists/SourceExistsApiTests.cs
+++ b/tests/Tests/Document/Single/SourceExists/SourceExistsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/TermVectors/TermVectorsApiTests.cs
+++ b/tests/Tests/Document/Single/TermVectors/TermVectorsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/TermVectors/TermVectorsNotFoundApiTests.cs
+++ b/tests/Tests/Document/Single/TermVectors/TermVectorsNotFoundApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/TermVectors/TermVectorsUrlTests.cs
+++ b/tests/Tests/Document/Single/TermVectors/TermVectorsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Update/UpdateApiTests.cs
+++ b/tests/Tests/Document/Single/Update/UpdateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Update/UpdateUrlTests.cs
+++ b/tests/Tests/Document/Single/Update/UpdateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Update/UpdateWithScriptApiTests.cs
+++ b/tests/Tests/Document/Single/Update/UpdateWithScriptApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Document/Single/Update/UpdateWithSourceApiTests.cs
+++ b/tests/Tests/Document/Single/Update/UpdateWithSourceApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/DocumentationTests/IntegrationDocumentationTestBase.cs
+++ b/tests/Tests/Framework/DocumentationTests/IntegrationDocumentationTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/ApiIntegrationAgainstNewIndexTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/ApiIntegrationAgainstNewIndexTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/ApiTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/ApiTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/CanConnectTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/CanConnectTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/ConnectionErrorTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/ConnectionErrorTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/CoordinatedIntegrationTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/CoordinatedIntegrationTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/CrudTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/CrudTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/RequestResponseApiTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/RequestResponseApiTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/TestState/AsyncLazy.cs
+++ b/tests/Tests/Framework/EndpointTests/TestState/AsyncLazy.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/TestState/CallUniqueValues.cs
+++ b/tests/Tests/Framework/EndpointTests/TestState/CallUniqueValues.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/TestState/ClientMethod.cs
+++ b/tests/Tests/Framework/EndpointTests/TestState/ClientMethod.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/TestState/CoordinatedUsage.cs
+++ b/tests/Tests/Framework/EndpointTests/TestState/CoordinatedUsage.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/TestState/EndpointUsage.cs
+++ b/tests/Tests/Framework/EndpointTests/TestState/EndpointUsage.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/TestState/LazyResponses.cs
+++ b/tests/Tests/Framework/EndpointTests/TestState/LazyResponses.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/EndpointTests/UrlTests.cs
+++ b/tests/Tests/Framework/EndpointTests/UrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/Extensions/FullFrameworkExtensions.cs
+++ b/tests/Tests/Framework/Extensions/FullFrameworkExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/Extensions/Numeric.cs
+++ b/tests/Tests/Framework/Extensions/Numeric.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/Extensions/Promisify.cs
+++ b/tests/Tests/Framework/Extensions/Promisify.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/Extensions/UriExtensions.cs
+++ b/tests/Tests/Framework/Extensions/UriExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/SerializationTests/BytesResponseTests.cs
+++ b/tests/Tests/Framework/SerializationTests/BytesResponseTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/SerializationTests/CompositeKeySerializationTests.cs
+++ b/tests/Tests/Framework/SerializationTests/CompositeKeySerializationTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/SerializationTests/DictionarySerializationTests.cs
+++ b/tests/Tests/Framework/SerializationTests/DictionarySerializationTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/SerializationTests/ExceptionSerializationTests.cs
+++ b/tests/Tests/Framework/SerializationTests/ExceptionSerializationTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/SerializationTests/StringResponseTests.cs
+++ b/tests/Tests/Framework/SerializationTests/StringResponseTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Framework/SerializationTests/StubResponse.cs
+++ b/tests/Tests/Framework/SerializationTests/StubResponse.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/GlobalSuppressions.cs
+++ b/tests/Tests/GlobalSuppressions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/IndexModules/IndexSettings/Merge/MergeSettings.cs
+++ b/tests/Tests/IndexModules/IndexSettings/Merge/MergeSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/IndexModules/IndexSettings/Settings/RoutingPartitionSizeIndexSettings.cs
+++ b/tests/Tests/IndexModules/IndexSettings/Settings/RoutingPartitionSizeIndexSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/IndexModules/IndexSettings/Settings/TypedIndexSettings.cs
+++ b/tests/Tests/IndexModules/IndexSettings/Settings/TypedIndexSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/IndexModules/IndexSettings/SlowLog/SlowLogSettings.cs
+++ b/tests/Tests/IndexModules/IndexSettings/SlowLog/SlowLogSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/IndexModules/IndexSettings/Sorting/SortingSettingsSingleItem.cs
+++ b/tests/Tests/IndexModules/IndexSettings/Sorting/SortingSettingsSingleItem.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/IndexModules/IndexSettings/Translog/TranslogSettings.cs
+++ b/tests/Tests/IndexModules/IndexSettings/Translog/TranslogSettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/IndexModules/Similarity/SimilaritySettings.cs
+++ b/tests/Tests/IndexModules/Similarity/SimilaritySettings.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/IndexModules/UsageTestBase.cs
+++ b/tests/Tests/IndexModules/UsageTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/Alias/AliasApiRemoveIndexTests.cs
+++ b/tests/Tests/Indices/AliasManagement/Alias/AliasApiRemoveIndexTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/Alias/AliasApiTests.cs
+++ b/tests/Tests/Indices/AliasManagement/Alias/AliasApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/Alias/AliasUrlTests.cs
+++ b/tests/Tests/Indices/AliasManagement/Alias/AliasUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/AliasExists/AliasExistsApiTests.cs
+++ b/tests/Tests/Indices/AliasManagement/AliasExists/AliasExistsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/AliasExists/AliasExistsUrlTests.cs
+++ b/tests/Tests/Indices/AliasManagement/AliasExists/AliasExistsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/DeleteAlias/AliasDeleteApiTests.cs
+++ b/tests/Tests/Indices/AliasManagement/DeleteAlias/AliasDeleteApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/DeleteAlias/DeleteAliasUrlTests.cs
+++ b/tests/Tests/Indices/AliasManagement/DeleteAlias/DeleteAliasUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/GetAlias/GetAliasApiTests.cs
+++ b/tests/Tests/Indices/AliasManagement/GetAlias/GetAliasApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/GetAlias/GetAliasUrlTests.cs
+++ b/tests/Tests/Indices/AliasManagement/GetAlias/GetAliasUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/GetAliasesPointingToIndex/GetAliasesPointingToIndexTests.cs
+++ b/tests/Tests/Indices/AliasManagement/GetAliasesPointingToIndex/GetAliasesPointingToIndexTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/GetIndicesPointingToAlias/GetIndicesPointingToAliasTests.cs
+++ b/tests/Tests/Indices/AliasManagement/GetIndicesPointingToAlias/GetIndicesPointingToAliasTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/PutAlias/PutAliasApiTests.cs
+++ b/tests/Tests/Indices/AliasManagement/PutAlias/PutAliasApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/AliasManagement/PutAlias/PutAliasUrlTests.cs
+++ b/tests/Tests/Indices/AliasManagement/PutAlias/PutAliasUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/Analyze/AnalyzeApiTests.cs
+++ b/tests/Tests/Indices/Analyze/AnalyzeApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/Analyze/AnalyzeUrlTests.cs
+++ b/tests/Tests/Indices/Analyze/AnalyzeUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/AddBlock/AddIndexBlockApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/AddBlock/AddIndexBlockApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/AddBlock/AddIndexBlockUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/AddBlock/AddIndexBlockUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/CloneIndex/CloneIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/CloneIndex/CloneIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/CloneIndex/CloneIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/CloneIndex/CloneIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/DeleteIndex/DeleteIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/DeleteIndex/DeleteIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/DeleteIndex/DeleteIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/DeleteIndex/DeleteIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/GetIndex/GetIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/GetIndex/GetIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/GetIndex/GetIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/GetIndex/GetIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/IndicesExists/IndexExistsApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/IndicesExists/IndexExistsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/IndicesExists/IndexExistsUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/IndicesExists/IndexExistsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/OpenCloseIndex/CloseIndex/CloseIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/OpenCloseIndex/CloseIndex/CloseIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/OpenCloseIndex/CloseIndex/CloseIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/OpenCloseIndex/CloseIndex/CloseIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/OpenCloseIndex/OpenIndex/OpenIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/OpenCloseIndex/OpenIndex/OpenIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/OpenCloseIndex/OpenIndex/OpenIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/OpenCloseIndex/OpenIndex/OpenIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/ResolveIndex/ResolveIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/ResolveIndex/ResolveIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/ResolveIndex/ResolveIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/ResolveIndex/ResolveIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/RolloverIndex/RolloverIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/RolloverIndex/RolloverIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/RolloverIndex/RolloverIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/RolloverIndex/RolloverIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/ShrinkIndex/ShrinkIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/ShrinkIndex/ShrinkIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/ShrinkIndex/ShrinkIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/ShrinkIndex/ShrinkIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/SplitIndex/SplitIndexApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/SplitIndex/SplitIndexApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/SplitIndex/SplitIndexUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/SplitIndex/SplitIndexUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/TypesExists/TypeExistsApiTests.cs
+++ b/tests/Tests/Indices/IndexManagement/TypesExists/TypeExistsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexManagement/TypesExists/TypeExistsUrlTests.cs
+++ b/tests/Tests/Indices/IndexManagement/TypesExists/TypeExistsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/GetIndexSettings/GetIndexSettingsApiTests.cs
+++ b/tests/Tests/Indices/IndexSettings/GetIndexSettings/GetIndexSettingsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/GetIndexSettings/GetIndexSettingsUrlTests.cs
+++ b/tests/Tests/Indices/IndexSettings/GetIndexSettings/GetIndexSettingsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/DeleteIndexTemplate/DeleteIndexTemplateApiTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/DeleteIndexTemplate/DeleteIndexTemplateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/DeleteIndexTemplate/DeleteIndexTemplateUrlTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/DeleteIndexTemplate/DeleteIndexTemplateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/GetIndexTemplateApiTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/GetIndexTemplateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/GetIndexTemplateUrlTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/GetIndexTemplateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/IndexTemplateCrudTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/IndexTemplateCrudTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/IndexTemplateExists/IndexTemplateExistsApiTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/IndexTemplateExists/IndexTemplateExistsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/IndexTemplateExists/IndexTemplateExistsUrlTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/IndexTemplateExists/IndexTemplateExistsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateApiTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateUrlTests.cs
+++ b/tests/Tests/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/UpdateIndicesSettings/UpdateIndexSettingsApiTests.cs
+++ b/tests/Tests/Indices/IndexSettings/UpdateIndicesSettings/UpdateIndexSettingsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/IndexSettings/UpdateIndicesSettings/UpdateIndexSettingsUrlTests.cs
+++ b/tests/Tests/Indices/IndexSettings/UpdateIndicesSettings/UpdateIndexSettingsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/MappingManagement/GetFieldMapping/GetFieldMappingApiTests.cs
+++ b/tests/Tests/Indices/MappingManagement/GetFieldMapping/GetFieldMappingApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/MappingManagement/GetFieldMapping/GetFieldMappingUrlTests.cs
+++ b/tests/Tests/Indices/MappingManagement/GetFieldMapping/GetFieldMappingUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingUrlTests.cs
+++ b/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
+++ b/tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/MappingManagement/PutMapping/PutMappingUrlTests.cs
+++ b/tests/Tests/Indices/MappingManagement/PutMapping/PutMappingUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/StatusManagement/ClearCache/ClearCacheApiTests.cs
+++ b/tests/Tests/Indices/StatusManagement/ClearCache/ClearCacheApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/StatusManagement/ClearCache/ClearCacheUrlTests.cs
+++ b/tests/Tests/Indices/StatusManagement/ClearCache/ClearCacheUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/StatusManagement/Flush/FlushApiTests.cs
+++ b/tests/Tests/Indices/StatusManagement/Flush/FlushApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/StatusManagement/Flush/FlushUrlTests.cs
+++ b/tests/Tests/Indices/StatusManagement/Flush/FlushUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/StatusManagement/ForceMerge/ForceMergeApiTests.cs
+++ b/tests/Tests/Indices/StatusManagement/ForceMerge/ForceMergeApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/StatusManagement/ForceMerge/ForceMergeUrlTests.cs
+++ b/tests/Tests/Indices/StatusManagement/ForceMerge/ForceMergeUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/StatusManagement/Refresh/RefreshApiTests.cs
+++ b/tests/Tests/Indices/StatusManagement/Refresh/RefreshApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Indices/StatusManagement/Refresh/RefreshUrlTests.cs
+++ b/tests/Tests/Indices/StatusManagement/Refresh/RefreshUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/DeletePipeline/DeletePipelineApiTests.cs
+++ b/tests/Tests/Ingest/DeletePipeline/DeletePipelineApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/DeletePipeline/DeletePipelineUrlTests.cs
+++ b/tests/Tests/Ingest/DeletePipeline/DeletePipelineUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/GetPipeline/GetPipelineApiTests.cs
+++ b/tests/Tests/Ingest/GetPipeline/GetPipelineApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/GetPipeline/GetPipelineUrlTests.cs
+++ b/tests/Tests/Ingest/GetPipeline/GetPipelineUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/GrokProcessorPatterns/GrokProcessorPatternsApiTests.cs
+++ b/tests/Tests/Ingest/GrokProcessorPatterns/GrokProcessorPatternsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/GrokProcessorPatterns/GrokProcessorPatternsTests.cs
+++ b/tests/Tests/Ingest/GrokProcessorPatterns/GrokProcessorPatternsTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/GrokProcessorPatterns/GrokProcessorPatternsUnitTests.cs
+++ b/tests/Tests/Ingest/GrokProcessorPatterns/GrokProcessorPatternsUnitTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/PipelineCrudTests.cs
+++ b/tests/Tests/Ingest/PipelineCrudTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/ProcessorAssertions.cs
+++ b/tests/Tests/Ingest/ProcessorAssertions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/ProcessorSerializationTests.cs
+++ b/tests/Tests/Ingest/ProcessorSerializationTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/PutPipeline/PutPipelineApiTests.cs
+++ b/tests/Tests/Ingest/PutPipeline/PutPipelineApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/PutPipeline/PutPipelineUrlTests.cs
+++ b/tests/Tests/Ingest/PutPipeline/PutPipelineUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/SimulatePipeline/SimulatePipelineApiTests.cs
+++ b/tests/Tests/Ingest/SimulatePipeline/SimulatePipelineApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Ingest/SimulatePipeline/SimulatePipelineUrlTests.cs
+++ b/tests/Tests/Ingest/SimulatePipeline/SimulatePipelineUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/LocalMetadata/LocalMetadataUsageTests.cs
+++ b/tests/Tests/Mapping/LocalMetadata/LocalMetadataUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/LocalMetadata/LocalMetadataVisitorTests.cs
+++ b/tests/Tests/Mapping/LocalMetadata/LocalMetadataVisitorTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Meta/MetaMappingApiTests.cs
+++ b/tests/Tests/Mapping/Meta/MetaMappingApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/PropertyDescriptorTests.cs
+++ b/tests/Tests/Mapping/PropertyDescriptorTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Scalar/ScalarUsageTests.cs
+++ b/tests/Tests/Mapping/Scalar/ScalarUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/AttributeTestsBase.cs
+++ b/tests/Tests/Mapping/Types/AttributeTestsBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Complex/Nested/NestedAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Complex/Nested/NestedAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Complex/Nested/NestedPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Complex/Nested/NestedPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Complex/Object/ObjectAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Complex/Object/ObjectAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Complex/Object/ObjectPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Complex/Object/ObjectPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Binary/BinaryAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Binary/BinaryAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Binary/BinaryPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Binary/BinaryPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Boolean/BooleanAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Boolean/BooleanAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Boolean/BooleanPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Boolean/BooleanPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Date/DateAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Date/DateAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Date/DatePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Date/DatePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Join/JoinAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Join/JoinAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Join/JoinPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Join/JoinPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Keyword/KeywordAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Keyword/KeywordAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Keyword/KeywordPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Keyword/KeywordPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Number/NumberAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Number/NumberAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Number/NumberPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Number/NumberPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Percolator/PercolatorAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Percolator/PercolatorAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Percolator/PercolatorPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Percolator/PercolatorPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/DateRange/DateRangeAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/DateRange/DateRangeAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/DateRange/DateRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/DateRange/DateRangePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/DoubleRange/DoubleRangeAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/DoubleRange/DoubleRangeAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/DoubleRange/DoubleRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/DoubleRange/DoubleRangePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/FloatRange/FloatRangeAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/FloatRange/FloatRangeAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/FloatRange/FloatRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/FloatRange/FloatRangePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/IntegerRange/IntegerRangeAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/IntegerRange/IntegerRangeAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/IntegerRange/IntegerRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/IntegerRange/IntegerRangePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/IpRange/IpRangeAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/IpRange/IpRangeAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/IpRange/IpRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/IpRange/IpRangePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/LongRange/LongRangeAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/LongRange/LongRangeAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Range/LongRange/LongRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/LongRange/LongRangePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/RankFeature/RankFeatureAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/RankFeature/RankFeatureAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/RankFeature/RankFeaturePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/RankFeature/RankFeaturePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeSingleMappingPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeSingleMappingPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Text/TextAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Text/TextAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Core/Text/TextPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Text/TextPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Geo/GeoPoint/GeoPointAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Geo/GeoPoint/GeoPointAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Geo/GeoPoint/GeoPointPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Geo/GeoPoint/GeoPointPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
+++ b/tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapePropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/PropertyTestsBase.cs
+++ b/tests/Tests/Mapping/Types/PropertyTestsBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/SingleMappingPropertyTestsBase.cs
+++ b/tests/Tests/Mapping/Types/SingleMappingPropertyTestsBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/Completion/CompletionAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Completion/CompletionAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/Completion/CompletionPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Completion/CompletionPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/FieldAlias/FieldAliasPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/FieldAlias/FieldAliasPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/Generic/GenericPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Generic/GenericPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/Ip/IpAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Ip/IpAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/Ip/IpPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Ip/IpPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountAttributeTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountPropertyTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/MetaHeader/MetaHeaderHelperTests.cs
+++ b/tests/Tests/MetaHeader/MetaHeaderHelperTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/DeleteScript/DeleteScriptApiTests.cs
+++ b/tests/Tests/Modules/Scripting/DeleteScript/DeleteScriptApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/DeleteScript/DeleteScriptUrlTests.cs
+++ b/tests/Tests/Modules/Scripting/DeleteScript/DeleteScriptUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/ExecutePainlessScript/ExecutePainlessScriptApiTests.cs
+++ b/tests/Tests/Modules/Scripting/ExecutePainlessScript/ExecutePainlessScriptApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/ExecutePainlessScript/ExecutePainlessScriptUrlTests.cs
+++ b/tests/Tests/Modules/Scripting/ExecutePainlessScript/ExecutePainlessScriptUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/GetScript/GetScriptApiTests.cs
+++ b/tests/Tests/Modules/Scripting/GetScript/GetScriptApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/GetScript/GetScriptUrlTests.cs
+++ b/tests/Tests/Modules/Scripting/GetScript/GetScriptUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/PutScript/PutScriptApiTests.cs
+++ b/tests/Tests/Modules/Scripting/PutScript/PutScriptApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/PutScript/PutScriptUrlTests.cs
+++ b/tests/Tests/Modules/Scripting/PutScript/PutScriptUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/Scripting/ScriptingCrudTests.cs
+++ b/tests/Tests/Modules/Scripting/ScriptingCrudTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/CleanupRepository/CleanupRepositoryApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/CleanupRepository/CleanupRepositoryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/CleanupRepository/CleanupRepositoryUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/CleanupRepository/CleanupRepositoryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/DeleteRepository/DeleteRepositoryApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/DeleteRepository/DeleteRepositoryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/DeleteRepository/DeleteRepositoryUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/DeleteRepository/DeleteRepositoryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/RepositoryCrudTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/RepositoryCrudTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Restore/RestoreApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Restore/RestoreApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Restore/RestoreUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Restore/RestoreUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/CloneSnapshot/CloneSnapshotApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/CloneSnapshot/CloneSnapshotApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/CloneSnapshot/CloneSnapshotUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/CloneSnapshot/CloneSnapshotUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/CoordinatedSnapshotTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/CoordinatedSnapshotTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/DeleteSnapshot/DeleteSnapshotApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/DeleteSnapshot/DeleteSnapshotApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/DeleteSnapshot/DeleteSnapshotUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/DeleteSnapshot/DeleteSnapshotUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/GetSnapshot/GetSnapshotApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/GetSnapshot/GetSnapshotApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/GetSnapshot/GetSnapshotUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/GetSnapshot/GetSnapshotUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/Snapshot/SnapshotApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/Snapshot/SnapshotApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/Snapshot/SnapshotUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/Snapshot/SnapshotUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusUrlTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/BoolApiTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/BoolApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/BoolDsl.doc.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/BoolDsl.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/AndAssignManyManualBoolsTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/AndAssignManyManualBoolsTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/AndOperatorOnManualBoolsTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/AndOperatorOnManualBoolsTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/AndOperatorUsageTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/AndOperatorUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/CombinatorialUsageTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/CombinatorialUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/NotOperatorUsageTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/NotOperatorUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/OperatorUsageBase.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/OperatorUsageBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/OrAssignManyManualBoolsTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/OrAssignManyManualBoolsTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/OrOperatorOnManualBoolsTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/OrOperatorOnManualBoolsTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/OrOperatorUsageTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/OrOperatorUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/Operators/UnaryAddOperatorUsageTests.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/Operators/UnaryAddOperatorUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/BoolDsl/QueryContainerDescriptorExtensions.cs
+++ b/tests/Tests/QueryDsl/BoolDsl/QueryContainerDescriptorExtensions.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Compound/Bool/BoolDslComplexQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Compound/Bool/BoolDslComplexQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Compound/Bool/BoolQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Compound/Bool/BoolQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Compound/Boosting/BoostingQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Compound/Boosting/BoostingQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Compound/ConstantScore/ConstantScoreQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Compound/ConstantScore/ConstantScoreQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Compound/Dismax/DismaxQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Compound/Dismax/DismaxQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Compound/FunctionScore/FunctionScoreQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Compound/FunctionScore/FunctionScoreQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/ConditionlessWhen.cs
+++ b/tests/Tests/QueryDsl/ConditionlessWhen.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/FullText/Intervals/IntervalsUsageTests.cs
+++ b/tests/Tests/QueryDsl/FullText/Intervals/IntervalsUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/FullText/Match/MatchUsageTests.cs
+++ b/tests/Tests/QueryDsl/FullText/Match/MatchUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/FullText/MatchBoolPrefix/MatchBoolPrefixUsageTests.cs
+++ b/tests/Tests/QueryDsl/FullText/MatchBoolPrefix/MatchBoolPrefixUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/FullText/MatchPhrase/MatchPhraseUsageTests.cs
+++ b/tests/Tests/QueryDsl/FullText/MatchPhrase/MatchPhraseUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/FullText/MatchPhrasePrefix/MatchPhrasePrefixUsageTests.cs
+++ b/tests/Tests/QueryDsl/FullText/MatchPhrasePrefix/MatchPhrasePrefixUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/FullText/MultiMatch/MultiMatchUsageTests.cs
+++ b/tests/Tests/QueryDsl/FullText/MultiMatch/MultiMatchUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/FullText/QueryString/QueryStringUsageTests.cs
+++ b/tests/Tests/QueryDsl/FullText/QueryString/QueryStringUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringUsageTests.cs
+++ b/tests/Tests/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Geo/Distance/GeoDistanceQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Geo/Distance/GeoDistanceQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Geo/GeoShape/GeoShapeQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Geo/GeoShape/GeoShapeQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Geo/GeoShape/GeoShapeSerializationTests.cs
+++ b/tests/Tests/QueryDsl/Geo/GeoShape/GeoShapeSerializationTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Geo/GeoShape/GeoWKTTests.cs
+++ b/tests/Tests/QueryDsl/Geo/GeoShape/GeoWKTTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Geo/Polygon/GeoPolygonQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Geo/Polygon/GeoPolygonQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Joining/HasChild/HasChildQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Joining/HasChild/HasChildQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Joining/HasParent/HasParentQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Joining/HasParent/HasParentQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Joining/Nested/NestedQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Joining/Nested/NestedQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Joining/ParentId/ParentIdQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Joining/ParentId/ParentIdQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/MatchNoneQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/MatchNoneQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/NotConditionlessWhen.cs
+++ b/tests/Tests/QueryDsl/NotConditionlessWhen.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/OscSpecific/Raw/RawCombineUsageTests.cs
+++ b/tests/Tests/QueryDsl/OscSpecific/Raw/RawCombineUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/OscSpecific/Raw/RawQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/OscSpecific/Raw/RawQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/QueryDslIntegrationTestsBase.cs
+++ b/tests/Tests/QueryDsl/QueryDslIntegrationTestsBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/QueryDslUsageTestsBase.cs
+++ b/tests/Tests/QueryDsl/QueryDslUsageTestsBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/Containing/SpanContainingQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/Containing/SpanContainingQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/FieldMasking/SpanFieldMaskingUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/FieldMasking/SpanFieldMaskingUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/First/SpanFirstQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/First/SpanFirstQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/MultiTerm/SpanMultiTermQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/MultiTerm/SpanMultiTermQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/Near/SpanNearQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/Near/SpanNearQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/Not/SpanNotQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/Not/SpanNotQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/Or/SpanOrQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/Or/SpanOrQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/Term/SpanTermQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/Term/SpanTermQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Span/Within/SpanWithinQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Span/Within/SpanWithinQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Specialized/DistanceFeature/DistanceFeatureQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/DistanceFeature/DistanceFeatureQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Specialized/Percolate/PercolateQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/Percolate/PercolateQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Specialized/Script/ScriptQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/Script/ScriptQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Exists/ExistsQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Exists/ExistsQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyDateQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyDateQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyNumericQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyNumericQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Ids/IdsQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Ids/IdsQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Prefix/PrefixQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Prefix/PrefixQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Range/DateRangeQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Range/DateRangeQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Range/LongRangeQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Range/LongRangeQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Range/NumericRangeQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Range/NumericRangeQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Range/TermRangeQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Range/TermRangeQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Regexp/RegexpQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Regexp/RegexpQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Term/TermQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Term/TermQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Terms/TermsListQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Terms/TermsListQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Terms/TermsLookupQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Terms/TermsLookupQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Terms/TermsQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Terms/TermsQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/TermsSet/TermsSetQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/TermsSet/TermsSetQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/TermLevel/Wildcard/WildcardQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Wildcard/WildcardQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/QueryDsl/Verbatim/VerbatimAndStrictQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Verbatim/VerbatimAndStrictQueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Count/CountApiTests.cs
+++ b/tests/Tests/Search/Count/CountApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Count/CountUrlTests.cs
+++ b/tests/Tests/Search/Count/CountUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Explain/ExplainApiTests.cs
+++ b/tests/Tests/Search/Explain/ExplainApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Explain/ExplainUrlTests.cs
+++ b/tests/Tests/Search/Explain/ExplainUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/FieldCapabilities/FieldCapabilitiesApiTests.cs
+++ b/tests/Tests/Search/FieldCapabilities/FieldCapabilitiesApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/FieldCapabilities/FieldCapabilitiesUrlTests.cs
+++ b/tests/Tests/Search/FieldCapabilities/FieldCapabilitiesUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Hits/HitsSerializationTests.cs
+++ b/tests/Tests/Search/Hits/HitsSerializationTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/MultiSearch/MultiSearchApiTests.cs
+++ b/tests/Tests/Search/MultiSearch/MultiSearchApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/MultiSearch/MultiSearchInvalidApiTests.cs
+++ b/tests/Tests/Search/MultiSearch/MultiSearchInvalidApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/MultiSearch/MultiSearchLowLevelPostDataTests.cs
+++ b/tests/Tests/Search/MultiSearch/MultiSearchLowLevelPostDataTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/MultiSearch/MultiSearchTemplate/MultiSearchTemplateApiTests.cs
+++ b/tests/Tests/Search/MultiSearch/MultiSearchTemplate/MultiSearchTemplateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/MultiSearch/MultiSearchTemplate/MultiSearchTemplateUrlTests.cs
+++ b/tests/Tests/Search/MultiSearch/MultiSearchTemplate/MultiSearchTemplateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/MultiSearch/MultiSearchUrlTests.cs
+++ b/tests/Tests/Search/MultiSearch/MultiSearchUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/ExplainUsageTests.cs
+++ b/tests/Tests/Search/Request/ExplainUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/FieldsUsageTests.cs
+++ b/tests/Tests/Search/Request/FieldsUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/FromAndSizeUsageTests.cs
+++ b/tests/Tests/Search/Request/FromAndSizeUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/HighlightingUsageTests.cs
+++ b/tests/Tests/Search/Request/HighlightingUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/IndicesBoostSerializationTests.cs
+++ b/tests/Tests/Search/Request/IndicesBoostSerializationTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/IndicesBoostUsageTests.cs
+++ b/tests/Tests/Search/Request/IndicesBoostUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/InnerHitsUsageTests.cs
+++ b/tests/Tests/Search/Request/InnerHitsUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/MinScoreUsageTests.cs
+++ b/tests/Tests/Search/Request/MinScoreUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/PostFilterUsageTests.cs
+++ b/tests/Tests/Search/Request/PostFilterUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/ProfileUsageTests.cs
+++ b/tests/Tests/Search/Request/ProfileUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/QueryUsageTests.cs
+++ b/tests/Tests/Search/Request/QueryUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/ScriptFieldsUsageTests.cs
+++ b/tests/Tests/Search/Request/ScriptFieldsUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/SearchAfterUsageTests.cs
+++ b/tests/Tests/Search/Request/SearchAfterUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/SlicedScrollSearchUsageTests.cs
+++ b/tests/Tests/Search/Request/SlicedScrollSearchUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/SortUsageTests.cs
+++ b/tests/Tests/Search/Request/SortUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/SourceFilteringUsageTests.cs
+++ b/tests/Tests/Search/Request/SourceFilteringUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Request/SuggestUsageTests.cs
+++ b/tests/Tests/Search/Request/SuggestUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/ReturnedFields.doc.cs
+++ b/tests/Tests/Search/ReturnedFields.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Scroll/ClearScroll/ClearScrollApiTests.cs
+++ b/tests/Tests/Search/Scroll/ClearScroll/ClearScrollApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Scroll/ClearScroll/ClearScrollUrlTests.cs
+++ b/tests/Tests/Search/Scroll/ClearScroll/ClearScrollUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Scroll/Scroll/ScrollApiTests.cs
+++ b/tests/Tests/Search/Scroll/Scroll/ScrollApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Scroll/Scroll/ScrollUrlTests.cs
+++ b/tests/Tests/Search/Scroll/Scroll/ScrollUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Scroll/Scroll/SlicedScrollSearchApiTests.cs
+++ b/tests/Tests/Search/Scroll/Scroll/SlicedScrollSearchApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/ScrollingDocuments.doc.cs
+++ b/tests/Tests/Search/ScrollingDocuments.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Search/Collapsing/FieldCollapseUsageTests.cs
+++ b/tests/Tests/Search/Search/Collapsing/FieldCollapseUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Search/InvalidSearchApiTests.cs
+++ b/tests/Tests/Search/Search/InvalidSearchApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Search/Rescoring/RescoreUsageTests.cs
+++ b/tests/Tests/Search/Search/Rescoring/RescoreUsageTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Search/SearchApiTests.cs
+++ b/tests/Tests/Search/Search/SearchApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Search/SearchProfileApiTests.cs
+++ b/tests/Tests/Search/Search/SearchProfileApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Search/SearchProfileTests.cs
+++ b/tests/Tests/Search/Search/SearchProfileTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Search/SearchUrlTests.cs
+++ b/tests/Tests/Search/Search/SearchUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/SearchShards/SearchShardsApiTests.cs
+++ b/tests/Tests/Search/SearchShards/SearchShardsApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/SearchShards/SearchShardsUrlTests.cs
+++ b/tests/Tests/Search/SearchShards/SearchShardsUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateApiTests.cs
+++ b/tests/Tests/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateUrlTests.cs
+++ b/tests/Tests/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/SearchTemplate/SearchTemplateApiTests.cs
+++ b/tests/Tests/Search/SearchTemplate/SearchTemplateApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/SearchTemplate/SearchTemplateUrlTests.cs
+++ b/tests/Tests/Search/SearchTemplate/SearchTemplateUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/SearchUsageTestBase.cs
+++ b/tests/Tests/Search/SearchUsageTestBase.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/SearchingRuntimeFields.doc.cs
+++ b/tests/Tests/Search/SearchingRuntimeFields.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Validate/ValidateQueryApiTests.cs
+++ b/tests/Tests/Search/Validate/ValidateQueryApiTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/Validate/ValidateQueryUrlTests.cs
+++ b/tests/Tests/Search/Validate/ValidateQueryUrlTests.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/Search/WritingQueries.doc.cs
+++ b/tests/Tests/Search/WritingQueries.doc.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *

--- a/tests/Tests/XunitBootstrap.cs
+++ b/tests/Tests/XunitBootstrap.cs
@@ -3,7 +3,8 @@
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
-*
+*/
+/*
 * Modifications Copyright OpenSearch Contributors. See
 * GitHub history for details.
 *


### PR DESCRIPTION
### Description
Improves the license header check to only check for the SPDX header instead of the older header with explicit grants to Elasticsearch. This involves separating the old header block into two in all C# files to keep the checker happy.

I've split this into separate commits to see the "real" changes easier.
The replacement inside the C# files was entirely "mechanical" via:
```sh
perl -i -p0e 's|license\.\n\*\n\* Modifications|license.\n*/\n/*\n* Modifications|s' $(find . -iname '*.cs')
```

### Issues Resolved
Closes #69 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
