### PR TITLE
Fix parsing of DateHistogramBucket key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed `net461` target from internal packages ([#128](https://github.com/opensearch-project/opensearch-net/pull/128))
 
 ### Fixed
+- Fixed parsing of date histogram buckets ([#131](https://github.com/opensearch-project/opensearch-net/pull/131))
 
 ### Security
 

--- a/src/OpenSearch.Client/Aggregations/AggregateFormatter.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregateFormatter.cs
@@ -843,7 +843,7 @@ namespace OpenSearch.Client
 			reader.ReadNext(); // ,
 			reader.ReadNext(); // "key"
 			reader.ReadNext(); // :
-			var key = reader.ReadInt64();
+			var key = reader.ReadDouble();
 			reader.ReadNext(); // ,
 			reader.ReadNext(); // "doc_count"
 			reader.ReadNext(); // :

--- a/tests/Tests.Reproduce/GitHubIssue130.cs
+++ b/tests/Tests.Reproduce/GitHubIssue130.cs
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Linq;
+using System.Threading;
+using OpenSearch.Client;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
+using Tests.Core.Extensions;
+using Tests.Core.ManagedOpenSearch.Clusters;
+using Tests.Domain;
+
+namespace Tests.Reproduce
+{
+	/// <summary>
+	/// Parsing histogram interval failed: <a href="https://github.com/opensearch-project/opensearch-net/issues/130">Issue #130</a>
+	/// </summary>
+	///
+	public class GitHubIssue130 : IClusterFixture<WritableCluster>
+	{
+		private readonly WritableCluster _cluster;
+
+		public GitHubIssue130(WritableCluster cluster) => _cluster = cluster;
+
+		[I] public void CanDeserializeDateHistogramBucket()
+		{
+			var response = _cluster.Client.Search<Project>(c => c
+				.Size(0)
+				.Query(q => q.MatchAll())
+				.Aggregations(a => a.Histogram("aggregation_ranges", r => r
+						.Field(f => f.LastActivity)
+						.Interval(5000)
+					)
+				)
+			);
+
+			response.ShouldBeValid();
+		}
+	}
+}


### PR DESCRIPTION
### Description
Fixes the parsing of DateHistogramBuckets. The key was incorrectly being read as a long, when it should be a double. As can be seen here, the type parameter to `KeyedBucket` is `double`: https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Client/Aggregations/Bucket/DateHistogram/DateHistogramBucket.cs#LL34C51-L34C51
And response body from server looks like so:
```json
{
    "_shards": {
        "failed": 0,
        "skipped": 0,
        "successful": 1,
        "total": 1
    },
    "aggregations": {
        "histogram#aggregation_ranges": {
            "buckets": [
                {
                    "doc_count": 1,
                    "key": 1672871085000.0,
                    "key_as_string": "2023-01-04T22:24:45.000Z"
                }
            ]
        }
    },
    "hits": {
        "hits": [],
        "max_score": null,
        "total": {
            "relation": "eq",
            "value": 1
        }
    },
    "timed_out": false,
    "took": 90
}
```

### Issues Resolved
Fixes #130 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
