### PR TITLE
Support AwsSigV4 signing for Amazon OpenSearch Serverless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `Octokit` from 0.32.0 to 4.0.3
 - Bumps `BenchMarkDotNet` from 0.13.1 to 0.13.3
 - Bumps `System.Reactive` from 3.1.1 to 5.0.0
-- Bumps `SharpZipLib` from 1.0.4 to `1.4.1` ([#136](https://github.com/opensearch-project/opensearch-net/pull/136))
+- Bumps `SharpZipLib` from 1.0.4 to 1.4.1 ([#136](https://github.com/opensearch-project/opensearch-net/pull/136))
+- Bumps `AWSSDK.Core` from 3.7.12.11 to 3.7.103.17
 
 [Unreleased]: https://github.com/opensearch-project/opensearch-net/compare/1.2.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Added support for Amazon OpenSearch Serverless request signing ([#133](https://github.com/opensearch-project/opensearch-net/pull/133))
 - Github workflow for changelog verification ([#111](https://github.com/opensearch-project/opensearch-net/pull/111))
 - Bump version to `1.2.1`([#115](https://github.com/opensearch-project/opensearch-net/pull/115))
 - Added `dependabot_changelog` workflow ([#118](https://github.com/opensearch-project/opensearch-net/pull/118))

--- a/OpenSearch.sln
+++ b/OpenSearch.sln
@@ -76,6 +76,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenSearch.Net.Auth.AwsSigV4", "src\OpenSearch.Net.Auth.AwsSigV4\OpenSearch.Net.Auth.AwsSigV4.csproj", "{2BDA50C8-767A-4560-9547-15AFC972A6E3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Auth.AwsSigV4", "tests\Tests.Auth.AwsSigV4\Tests.Auth.AwsSigV4.csproj", "{2BCE8150-C16C-4226-B216-C7A0463ADC56}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenSearch.Stack.ArtifactsApiTests", "abstractions\tests\OpenSearch.Stack.ArtifactsApiTests\OpenSearch.Stack.ArtifactsApiTests.csproj", "{1F5A7B1A-2566-481F-91B5-A63D7F939973}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "abstractions", "abstractions", "{87ABA679-F3F4-48CE-82B3-1AAE5D0A5935}"

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -10,6 +10,7 @@
     - [Getting Started](#getting-started-1)
     - [Connecting](#connecting-1)
     - [Configuring Region & Credentials](#configuring-region--credentials)
+    - [Amazon OpenSearch Serverless](#amazon-opensearch-serverless)
   - [OpenSearch.Net](#opensearchnet)
     - [Getting Started](#getting-started-2)
     - [Connecting](#connecting-2)
@@ -26,7 +27,7 @@ Include OpenSearch.Client in your .csproj file.
 <Project>
   ...
   <ItemGroup>
-    <PackageReference Include="OpenSearch.Client" Version="1.0.0" />
+    <PackageReference Include="OpenSearch.Client" Version="1.*" />
   </ItemGroup>
 </Project>
 ```
@@ -141,7 +142,7 @@ var response = lowLevelClient.Search<SearchResponse<Tweet>>("mytweetindex", Post
 
 ## [OpenSearch.Net.Auth.AwsSigV4](src/OpenSearch.Net.Auth.AwsSigV4)
 
-An implementation of AWS SigV4 request signing for performing IAM authentication against the managed Amazon OpenSearch Service.
+An implementation of AWS SigV4 request signing for performing IAM authentication against the managed [Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/).
 It can be used with both the low-level OpenSearch.Net client as well as the higher-level OpenSearch.Client client.
 
 ### Getting Started
@@ -150,8 +151,8 @@ Include OpenSearch.Net.Auth.AwsSigV4 along with your preferred client in your .c
 <Project>
   ...
   <ItemGroup>
-    <PackageReference Include="OpenSearch.Client" Version="1.0.0" />
-    <PackageReference Include="OpenSearch.Net.Auth.AwsSigV4" Version="1.0.0" />
+    <PackageReference Include="OpenSearch.Client" Version="1.*" />
+    <PackageReference Include="OpenSearch.Net.Auth.AwsSigV4" Version="1.*" />
   </ItemGroup>
 </Project>
 ```
@@ -215,6 +216,21 @@ var credentials = new AssumeRoleAWSCredentials(
 				"arn:aws:iam::123456789012:role/my-open-search-ingest-role",
 				"my-ingest-application");
 var connection = new AwsSigV4HttpConnection(credentials, RegionEndpoint.APSoutheast2);
+var config = new ConnectionSettings(endpoint, connection);
+var client = new OpenSearchClient(config);
+```
+
+### Amazon OpenSearch Serverless
+To configure signing when making requests to [Amazon OpenSearch Serverless](https://aws.amazon.com/opensearch-service/features/serverless/) is nearly identical to all above configuration for AwsSigV4, the only difference being the need to configure the service identifier.
+This applies to all variants of the constructor as documented above.
+```shell
+export AWS_ACCESS_KEY_ID="..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_SESSION_TOKEN="..."
+```
+```csharp
+var endpoint = new Uri("https://aaabbbcccddd111222333.ap-southeast-2.aoss.amazonaws.com");
+var connection = new AwsSigV4HttpConnection(RegionEndpoint.APSoutheast2, serviceId: AwsSigV4HttpConnection.OpenSearchServerlessServiceId);
 var config = new ConnectionSettings(endpoint, connection);
 var client = new OpenSearchClient(config);
 ```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -221,8 +221,7 @@ var client = new OpenSearchClient(config);
 ```
 
 ### Amazon OpenSearch Serverless
-To configure signing when making requests to [Amazon OpenSearch Serverless](https://aws.amazon.com/opensearch-service/features/serverless/) is nearly identical to all above configuration for AwsSigV4, the only difference being the need to configure the service identifier.
-This applies to all variants of the constructor as documented above.
+Use the `"aoss"` service identifier to make requests to [Amazon OpenSearch Serverless](https://aws.amazon.com/opensearch-service/features/serverless/), otherwise all configuration options are identical to above.
 ```shell
 export AWS_ACCESS_KEY_ID="..."
 export AWS_SECRET_ACCESS_KEY="..."

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -221,7 +221,7 @@ var client = new OpenSearchClient(config);
 ```
 
 ### Amazon OpenSearch Serverless
-Use the `"aoss"` service identifier to make requests to [Amazon OpenSearch Serverless](https://aws.amazon.com/opensearch-service/features/serverless/), otherwise all configuration options are identical to above.
+Use the `"aoss"` service code to make requests to [Amazon OpenSearch Serverless](https://aws.amazon.com/opensearch-service/features/serverless/), otherwise all configuration options are identical to above.
 ```shell
 export AWS_ACCESS_KEY_ID="..."
 export AWS_SECRET_ACCESS_KEY="..."
@@ -229,7 +229,7 @@ export AWS_SESSION_TOKEN="..."
 ```
 ```csharp
 var endpoint = new Uri("https://aaabbbcccddd111222333.ap-southeast-2.aoss.amazonaws.com");
-var connection = new AwsSigV4HttpConnection(RegionEndpoint.APSoutheast2, serviceId: AwsSigV4HttpConnection.OpenSearchServerlessServiceId);
+var connection = new AwsSigV4HttpConnection(RegionEndpoint.APSoutheast2, service: AwsSigV4HttpConnection.OpenSearchServerlessService);
 var config = new ConnectionSettings(endpoint, connection);
 var client = new OpenSearchClient(config);
 ```

--- a/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpClientHandler.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpClientHandler.cs
@@ -20,21 +20,21 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 	{
 		private readonly AWSCredentials _credentials;
 		private readonly RegionEndpoint _region;
-		private readonly string _serviceId;
+		private readonly string _service;
 
-		public AwsSigV4HttpClientHandler(AWSCredentials credentials, RegionEndpoint region, string serviceId, HttpMessageHandler innerHandler)
+		public AwsSigV4HttpClientHandler(AWSCredentials credentials, RegionEndpoint region, string service, HttpMessageHandler innerHandler)
 			: base(innerHandler)
 		{
 			_credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
 			_region = region ?? throw new ArgumentNullException(nameof(region));
-			_serviceId = serviceId ?? throw new ArgumentNullException(nameof(serviceId));
+			_service = service ?? throw new ArgumentNullException(nameof(service));
 		}
 
 		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 		{
 			var credentials = await _credentials.GetCredentialsAsync().ConfigureAwait(false);
 
-			await AwsSigV4Util.SignRequest(request, credentials, _region, DateTime.UtcNow, _serviceId).ConfigureAwait(false);
+			await AwsSigV4Util.SignRequest(request, credentials, _region, DateTime.UtcNow, _service).ConfigureAwait(false);
 
 			return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 		}

--- a/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpClientHandler.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpClientHandler.cs
@@ -21,20 +21,22 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 		private readonly AWSCredentials _credentials;
 		private readonly RegionEndpoint _region;
 		private readonly string _service;
+		private readonly IDateTimeProvider _dateTimeProvider;
 
-		public AwsSigV4HttpClientHandler(AWSCredentials credentials, RegionEndpoint region, string service, HttpMessageHandler innerHandler)
+		public AwsSigV4HttpClientHandler(AWSCredentials credentials, RegionEndpoint region, string service, IDateTimeProvider dateTimeProvider, HttpMessageHandler innerHandler)
 			: base(innerHandler)
 		{
 			_credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
 			_region = region ?? throw new ArgumentNullException(nameof(region));
 			_service = service ?? throw new ArgumentNullException(nameof(service));
+			_dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
 		}
 
 		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 		{
 			var credentials = await _credentials.GetCredentialsAsync().ConfigureAwait(false);
 
-			await AwsSigV4Util.SignRequest(request, credentials, _region, DateTime.UtcNow, _service).ConfigureAwait(false);
+			await AwsSigV4Util.SignRequest(request, credentials, _region, _dateTimeProvider.Now(), _service).ConfigureAwait(false);
 
 			return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 		}

--- a/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpClientHandler.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpClientHandler.cs
@@ -20,19 +20,21 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 	{
 		private readonly AWSCredentials _credentials;
 		private readonly RegionEndpoint _region;
+		private readonly string _serviceId;
 
-		public AwsSigV4HttpClientHandler(AWSCredentials credentials, RegionEndpoint region, HttpMessageHandler innerHandler)
+		public AwsSigV4HttpClientHandler(AWSCredentials credentials, RegionEndpoint region, string serviceId, HttpMessageHandler innerHandler)
 			: base(innerHandler)
 		{
 			_credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
 			_region = region ?? throw new ArgumentNullException(nameof(region));
+			_serviceId = serviceId ?? throw new ArgumentNullException(nameof(serviceId));
 		}
 
 		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 		{
 			var credentials = await _credentials.GetCredentialsAsync().ConfigureAwait(false);
 
-			await AwsSigV4Util.SignRequest(request, credentials, _region, DateTime.UtcNow).ConfigureAwait(false);
+			await AwsSigV4Util.SignRequest(request, credentials, _region, DateTime.UtcNow, _serviceId).ConfigureAwait(false);
 
 			return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 		}

--- a/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpConnection.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpConnection.cs
@@ -16,58 +16,67 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 	/// </summary>
 	public class AwsSigV4HttpConnection : HttpConnection
 	{
+		public const string OpenSearchServiceId = "es";
+		public const string OpenSearchServerlessServiceId = "aoss";
+
 		private readonly AWSCredentials _credentials;
 		private readonly RegionEndpoint _region;
+		private readonly string _serviceId;
 
 		/// <summary>
 		/// Construct a new connection discovering both the credentials and region from the environment.
 		/// </summary>
-		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint)"/>
-		public AwsSigV4HttpConnection() : this(null, null) { }
+		/// <param name="serviceId">The service ID to use when signing, defaults to the service ID for Amazon OpenSearch Service (<c>"es"</c>).</param>
+		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
+		public AwsSigV4HttpConnection(string serviceId = OpenSearchServiceId) : this(null, null, serviceId) { }
 
 		/// <summary>
 		/// Construct a new connection configured with the specified credentials and using the region discovered from the environment.
 		/// </summary>
 		/// <param name="credentials">The credentials to use when signing.</param>
-		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint)"/>
-		public AwsSigV4HttpConnection(AWSCredentials credentials) : this(credentials, null) { }
+		/// <param name="serviceId">The service ID to use when signing, defaults to the service ID for Amazon OpenSearch Service (<c>"es"</c>).</param>
+		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
+		public AwsSigV4HttpConnection(AWSCredentials credentials, string serviceId = OpenSearchServiceId) : this(credentials, null, serviceId) { }
 
 		/// <summary>
 		/// Construct a new connection configured with a specified region and using credentials discovered from the environment.
 		/// </summary>
 		/// <param name="region">The region to use when signing.</param>
-		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint)"/>
-		public AwsSigV4HttpConnection(RegionEndpoint region) : this(null, region) { }
+		/// <param name="serviceId">The service ID to use when signing, defaults to the service ID for Amazon OpenSearch Service (<c>"es"</c>).</param>
+		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
+		public AwsSigV4HttpConnection(RegionEndpoint region, string serviceId = OpenSearchServiceId) : this(null, region, serviceId) { }
 
 		/// <summary>
 		/// Construct a new connection configured with the given credentials and region.
 		/// </summary>
 		/// <param name="credentials">The credentials to use when signing, or null to have them discovered automatically by the AWS SDK.</param>
 		/// <param name="region">The region to use when signing, or null to have it discovered automatically by the AWS SDK.</param>
+		///	<param name="serviceId">The service ID to use when signing, defaults to the service ID for Amazon OpenSearch Service (<c>"es"</c>).</param>
 		/// <exception cref="ArgumentNullException">Thrown if region is null and is unable to be automatically discovered by the AWS SDK.</exception>
 		/// <remarks>
 		/// The same logic as the <a href="https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html">AWS SDK for .NET</a>
 		/// is used to automatically discover the credentials and region to use if not provided explicitly.
 		/// </remarks>
-		public AwsSigV4HttpConnection(AWSCredentials credentials, RegionEndpoint region)
+		public AwsSigV4HttpConnection(AWSCredentials credentials, RegionEndpoint region, string serviceId = OpenSearchServiceId)
 		{
 			_credentials = credentials ?? FallbackCredentialsFactory.GetCredentials(); // FallbackCredentialsFactory throws in case of not finding credentials.
 			_region = region
 				?? FallbackRegionFactory.GetRegionEndpoint() // FallbackRegionFactory can return null.
 				?? throw new ArgumentNullException(nameof(region), "A RegionEndpoint was not provided and was unable to be determined from the environment.");
+			_serviceId = serviceId ?? OpenSearchServiceId;
 		}
 
 #if DOTNETCORE
 
 		protected override System.Net.Http.HttpMessageHandler CreateHttpClientHandler(RequestData requestData) =>
-			new AwsSigV4HttpClientHandler(_credentials, _region, base.CreateHttpClientHandler(requestData));
+			new AwsSigV4HttpClientHandler(_credentials, _region, _serviceId, base.CreateHttpClientHandler(requestData));
 
 #else
 
 		protected override System.Net.HttpWebRequest CreateHttpWebRequest(RequestData requestData)
 		{
 			var request = base.CreateHttpWebRequest(requestData);
-			AwsSigV4Util.SignRequest(request, requestData, _credentials.GetCredentials(), _region, DateTime.UtcNow);
+			AwsSigV4Util.SignRequest(request, requestData, _credentials.GetCredentials(), _region, DateTime.UtcNow, _serviceId);
 			return request;
 		}
 

--- a/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpConnection.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpConnection.cs
@@ -16,67 +16,67 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 	/// </summary>
 	public class AwsSigV4HttpConnection : HttpConnection
 	{
-		public const string OpenSearchServiceId = "es";
-		public const string OpenSearchServerlessServiceId = "aoss";
+		public const string OpenSearchService = "es";
+		public const string OpenSearchServerlessService = "aoss";
 
 		private readonly AWSCredentials _credentials;
 		private readonly RegionEndpoint _region;
-		private readonly string _serviceId;
+		private readonly string _service;
 
 		/// <summary>
 		/// Construct a new connection discovering both the credentials and region from the environment.
 		/// </summary>
-		/// <param name="serviceId">The service ID to use when signing, defaults to the service ID for Amazon OpenSearch Service (<c>"es"</c>).</param>
+		/// <param name="service">The service code to use when signing, defaults to the service code for the Amazon OpenSearch Service (<c>"es"</c>).</param>
 		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
-		public AwsSigV4HttpConnection(string serviceId = OpenSearchServiceId) : this(null, null, serviceId) { }
+		public AwsSigV4HttpConnection(string service = OpenSearchService) : this(null, null, service) { }
 
 		/// <summary>
 		/// Construct a new connection configured with the specified credentials and using the region discovered from the environment.
 		/// </summary>
 		/// <param name="credentials">The credentials to use when signing.</param>
-		/// <param name="serviceId">The service ID to use when signing, defaults to the service ID for Amazon OpenSearch Service (<c>"es"</c>).</param>
+		/// <param name="service">The service code to use when signing, defaults to the service code for the Amazon OpenSearch Service (<c>"es"</c>).</param>
 		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
-		public AwsSigV4HttpConnection(AWSCredentials credentials, string serviceId = OpenSearchServiceId) : this(credentials, null, serviceId) { }
+		public AwsSigV4HttpConnection(AWSCredentials credentials, string service = OpenSearchService) : this(credentials, null, service) { }
 
 		/// <summary>
 		/// Construct a new connection configured with a specified region and using credentials discovered from the environment.
 		/// </summary>
 		/// <param name="region">The region to use when signing.</param>
-		/// <param name="serviceId">The service ID to use when signing, defaults to the service ID for Amazon OpenSearch Service (<c>"es"</c>).</param>
+		/// <param name="service">The service code to use when signing, defaults to the service code for the Amazon OpenSearch Service (<c>"es"</c>).</param>
 		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
-		public AwsSigV4HttpConnection(RegionEndpoint region, string serviceId = OpenSearchServiceId) : this(null, region, serviceId) { }
+		public AwsSigV4HttpConnection(RegionEndpoint region, string service = OpenSearchService) : this(null, region, service) { }
 
 		/// <summary>
 		/// Construct a new connection configured with the given credentials and region.
 		/// </summary>
 		/// <param name="credentials">The credentials to use when signing, or null to have them discovered automatically by the AWS SDK.</param>
 		/// <param name="region">The region to use when signing, or null to have it discovered automatically by the AWS SDK.</param>
-		///	<param name="serviceId">The service ID to use when signing, defaults to the service ID for Amazon OpenSearch Service (<c>"es"</c>).</param>
+		///	<param name="service">The service code to use when signing, defaults to the service code for the Amazon OpenSearch Service (<c>"es"</c>).</param>
 		/// <exception cref="ArgumentNullException">Thrown if region is null and is unable to be automatically discovered by the AWS SDK.</exception>
 		/// <remarks>
 		/// The same logic as the <a href="https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html">AWS SDK for .NET</a>
 		/// is used to automatically discover the credentials and region to use if not provided explicitly.
 		/// </remarks>
-		public AwsSigV4HttpConnection(AWSCredentials credentials, RegionEndpoint region, string serviceId = OpenSearchServiceId)
+		public AwsSigV4HttpConnection(AWSCredentials credentials, RegionEndpoint region, string service = OpenSearchService)
 		{
 			_credentials = credentials ?? FallbackCredentialsFactory.GetCredentials(); // FallbackCredentialsFactory throws in case of not finding credentials.
 			_region = region
 				?? FallbackRegionFactory.GetRegionEndpoint() // FallbackRegionFactory can return null.
 				?? throw new ArgumentNullException(nameof(region), "A RegionEndpoint was not provided and was unable to be determined from the environment.");
-			_serviceId = serviceId ?? OpenSearchServiceId;
+			_service = service ?? OpenSearchService;
 		}
 
 #if DOTNETCORE
 
 		protected override System.Net.Http.HttpMessageHandler CreateHttpClientHandler(RequestData requestData) =>
-			new AwsSigV4HttpClientHandler(_credentials, _region, _serviceId, base.CreateHttpClientHandler(requestData));
+			new AwsSigV4HttpClientHandler(_credentials, _region, _service, base.CreateHttpClientHandler(requestData));
 
 #else
 
 		protected override System.Net.HttpWebRequest CreateHttpWebRequest(RequestData requestData)
 		{
 			var request = base.CreateHttpWebRequest(requestData);
-			AwsSigV4Util.SignRequest(request, requestData, _credentials.GetCredentials(), _region, DateTime.UtcNow, _serviceId);
+			AwsSigV4Util.SignRequest(request, requestData, _credentials.GetCredentials(), _region, DateTime.UtcNow, _service);
 			return request;
 		}
 

--- a/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpConnection.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4HttpConnection.cs
@@ -22,29 +22,33 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 		private readonly AWSCredentials _credentials;
 		private readonly RegionEndpoint _region;
 		private readonly string _service;
+		private readonly IDateTimeProvider _dateTimeProvider;
 
 		/// <summary>
 		/// Construct a new connection discovering both the credentials and region from the environment.
 		/// </summary>
 		/// <param name="service">The service code to use when signing, defaults to the service code for the Amazon OpenSearch Service (<c>"es"</c>).</param>
-		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
-		public AwsSigV4HttpConnection(string service = OpenSearchService) : this(null, null, service) { }
+		/// <param name="dateTimeProvider">The date time proved to use, safe to pass null to use the default</param>
+		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string, IDateTimeProvider)"/>
+		public AwsSigV4HttpConnection(string service = OpenSearchService, IDateTimeProvider dateTimeProvider = null) : this(null, null, service, dateTimeProvider) { }
 
 		/// <summary>
 		/// Construct a new connection configured with the specified credentials and using the region discovered from the environment.
 		/// </summary>
 		/// <param name="credentials">The credentials to use when signing.</param>
 		/// <param name="service">The service code to use when signing, defaults to the service code for the Amazon OpenSearch Service (<c>"es"</c>).</param>
-		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
-		public AwsSigV4HttpConnection(AWSCredentials credentials, string service = OpenSearchService) : this(credentials, null, service) { }
+		/// <param name="dateTimeProvider">The date time proved to use, safe to pass null to use the default</param>
+		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string, IDateTimeProvider)"/>
+		public AwsSigV4HttpConnection(AWSCredentials credentials, string service = OpenSearchService, IDateTimeProvider dateTimeProvider = null) : this(credentials, null, service, dateTimeProvider) { }
 
 		/// <summary>
 		/// Construct a new connection configured with a specified region and using credentials discovered from the environment.
 		/// </summary>
 		/// <param name="region">The region to use when signing.</param>
 		/// <param name="service">The service code to use when signing, defaults to the service code for the Amazon OpenSearch Service (<c>"es"</c>).</param>
-		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string)"/>
-		public AwsSigV4HttpConnection(RegionEndpoint region, string service = OpenSearchService) : this(null, region, service) { }
+		/// <param name="dateTimeProvider">The date time proved to use, safe to pass null to use the default</param>
+		/// <seealso cref="AwsSigV4HttpConnection(AWSCredentials, RegionEndpoint, string, IDateTimeProvider)"/>
+		public AwsSigV4HttpConnection(RegionEndpoint region, string service = OpenSearchService, IDateTimeProvider dateTimeProvider = null) : this(null, region, service, dateTimeProvider) { }
 
 		/// <summary>
 		/// Construct a new connection configured with the given credentials and region.
@@ -52,31 +56,36 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 		/// <param name="credentials">The credentials to use when signing, or null to have them discovered automatically by the AWS SDK.</param>
 		/// <param name="region">The region to use when signing, or null to have it discovered automatically by the AWS SDK.</param>
 		///	<param name="service">The service code to use when signing, defaults to the service code for the Amazon OpenSearch Service (<c>"es"</c>).</param>
+		/// <param name="dateTimeProvider">The date time proved to use, safe to pass null to use the default</param>
 		/// <exception cref="ArgumentNullException">Thrown if region is null and is unable to be automatically discovered by the AWS SDK.</exception>
 		/// <remarks>
 		/// The same logic as the <a href="https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html">AWS SDK for .NET</a>
 		/// is used to automatically discover the credentials and region to use if not provided explicitly.
 		/// </remarks>
-		public AwsSigV4HttpConnection(AWSCredentials credentials, RegionEndpoint region, string service = OpenSearchService)
+		public AwsSigV4HttpConnection(AWSCredentials credentials, RegionEndpoint region, string service = OpenSearchService, IDateTimeProvider dateTimeProvider = null)
 		{
 			_credentials = credentials ?? FallbackCredentialsFactory.GetCredentials(); // FallbackCredentialsFactory throws in case of not finding credentials.
 			_region = region
 				?? FallbackRegionFactory.GetRegionEndpoint() // FallbackRegionFactory can return null.
 				?? throw new ArgumentNullException(nameof(region), "A RegionEndpoint was not provided and was unable to be determined from the environment.");
 			_service = service ?? OpenSearchService;
+			_dateTimeProvider = dateTimeProvider ?? DateTimeProvider.Default;
 		}
 
 #if DOTNETCORE
 
+		protected virtual System.Net.Http.HttpMessageHandler InnerCreateHttpClientHandler(RequestData requestData) =>
+			base.CreateHttpClientHandler(requestData);
+
 		protected override System.Net.Http.HttpMessageHandler CreateHttpClientHandler(RequestData requestData) =>
-			new AwsSigV4HttpClientHandler(_credentials, _region, _service, base.CreateHttpClientHandler(requestData));
+			new AwsSigV4HttpClientHandler(_credentials, _region, _service, _dateTimeProvider, InnerCreateHttpClientHandler(requestData));
 
 #else
 
 		protected override System.Net.HttpWebRequest CreateHttpWebRequest(RequestData requestData)
 		{
 			var request = base.CreateHttpWebRequest(requestData);
-			AwsSigV4Util.SignRequest(request, requestData, _credentials.GetCredentials(), _region, DateTime.UtcNow, _service);
+			AwsSigV4Util.SignRequest(request, requestData, _credentials.GetCredentials(), _region, _dateTimeProvider.Now(), _service);
 			return request;
 		}
 

--- a/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4Util.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/AwsSigV4Util.cs
@@ -26,11 +26,11 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 			ImmutableCredentials credentials,
 			RegionEndpoint region,
 			DateTime signingTime,
-			string serviceId)
+			string service)
 		{
 			var canonicalRequest = await CanonicalRequest.From(request, credentials, signingTime).ConfigureAwait(false);
 
-			var signature = AWS4Signer.ComputeSignature(credentials, region.SystemName, signingTime, serviceId, canonicalRequest.SignedHeaders,
+			var signature = AWS4Signer.ComputeSignature(credentials, region.SystemName, signingTime, service, canonicalRequest.SignedHeaders,
 				canonicalRequest.ToString());
 
 			request.Headers.TryAddWithoutValidation(HeaderNames.XAmzDate, canonicalRequest.XAmzDate);
@@ -45,11 +45,11 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 			ImmutableCredentials credentials,
 			RegionEndpoint region,
 			DateTime signingTime,
-			string serviceId)
+			string service)
 		{
 			var canonicalRequest = CanonicalRequest.From(request, requestData, credentials, signingTime);
 
-			var signature = AWS4Signer.ComputeSignature(credentials, region.SystemName, signingTime, serviceId, canonicalRequest.SignedHeaders,
+			var signature = AWS4Signer.ComputeSignature(credentials, region.SystemName, signingTime, service, canonicalRequest.SignedHeaders,
 				canonicalRequest.ToString());
 
 			request.Headers[HeaderNames.XAmzDate] = canonicalRequest.XAmzDate;

--- a/src/OpenSearch.Net.Auth.AwsSigV4/CanonicalRequest.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/CanonicalRequest.cs
@@ -65,7 +65,7 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 		public static CanonicalRequest From(HttpWebRequest request, RequestData requestData, ImmutableCredentials credentials, DateTime signingTime)
 #endif
 		{
-			var path = AWSSDKUtils.CanonicalizeResourcePath(request.RequestUri, null, false);
+			var path = AWSSDKUtils.CanonicalizeResourcePathV2(request.RequestUri, null, false, null);
 
 #if DOTNETCORE
 			var bodyBytes = await GetBodyBytes(request).ConfigureAwait(false);

--- a/src/OpenSearch.Net.Auth.AwsSigV4/CanonicalRequest.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/CanonicalRequest.cs
@@ -73,7 +73,7 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 			var bodyBytes = GetBodyBytes(requestData);
 #endif
 
-			var contentSha256 = AWSSDKUtils.ToHex(AWS4Signer.ComputeHash(bodyBytes), true);
+			var xAmzContentSha256 = AWSSDKUtils.ToHex(AWS4Signer.ComputeHash(bodyBytes), true);
 
 			var xAmzDate = AWS4Signer.FormatDateTime(signingTime, "yyyyMMddTHHmmssZ");
 
@@ -86,6 +86,7 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 
 			canonicalHeaders[HeaderNames.Host] = new List<string> { request.RequestUri.Authority };
 			canonicalHeaders[HeaderNames.XAmzDate] = new List<string> { xAmzDate };
+			canonicalHeaders[HeaderNames.XAmzContentSha256] = new List<string> { xAmzContentSha256 };
 
 			string xAmzSecurityToken = null;
 			if (credentials.UseToken)
@@ -114,7 +115,7 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 			var method = request.Method;
 #endif
 
-			return new CanonicalRequest(method, path, paramString, canonicalHeaders, contentSha256, xAmzDate, xAmzSecurityToken);
+			return new CanonicalRequest(method, path, paramString, canonicalHeaders, xAmzContentSha256, xAmzDate, xAmzSecurityToken);
 		}
 
 #if DOTNETCORE

--- a/src/OpenSearch.Net.Auth.AwsSigV4/CanonicalRequest.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/CanonicalRequest.cs
@@ -30,12 +30,14 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 	public class CanonicalRequest
 	{
 		private static readonly IComparer<KeyValuePair<string, string>> StringPairComparer = new KeyValuePairComparer<string, string>();
+		private static readonly ISet<string> ExcludedHeaders = new HashSet<string> { HeaderNames.UserAgent, HeaderNames.ContentLength };
 
 		private readonly string _method;
 		private readonly string _path;
 		private readonly string _params;
 		private readonly SortedDictionary<string, List<string>> _headers;
-		private readonly string _contentSha256;
+
+		public string XAmzContentSha256 { get; }
 
 		public string XAmzDate { get; }
 
@@ -44,14 +46,14 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 		public string SignedHeaders { get; }
 
 		private CanonicalRequest(string method, string path, string queryParams, SortedDictionary<string, List<string>> headers,
-			string contentSha256, string xAmzDate, string xAmzSecurityToken
+			string xAmzContentSha256, string xAmzDate, string xAmzSecurityToken
 		)
 		{
 			_method = method;
 			_path = path;
 			_params = queryParams;
 			_headers = headers;
-			_contentSha256 = contentSha256;
+			XAmzContentSha256 = xAmzContentSha256;
 			SignedHeaders = string.Join(";", _headers.Keys);
 			XAmzDate = xAmzDate;
 			XAmzSecurityToken = xAmzSecurityToken;
@@ -82,14 +84,14 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 			CanonicalizeHeaders(canonicalHeaders, request.Content?.Headers);
 #endif
 
-			canonicalHeaders["host"] = new List<string> { request.RequestUri.Authority };
-			canonicalHeaders["x-amz-date"] = new List<string> { xAmzDate };
+			canonicalHeaders[HeaderNames.Host] = new List<string> { request.RequestUri.Authority };
+			canonicalHeaders[HeaderNames.XAmzDate] = new List<string> { xAmzDate };
 
 			string xAmzSecurityToken = null;
 			if (credentials.UseToken)
 			{
 				xAmzSecurityToken = credentials.Token;
-				canonicalHeaders["x-amz-security-token"] = new List<string> { xAmzSecurityToken };
+				canonicalHeaders[HeaderNames.XAmzSecurityToken] = new List<string> { xAmzSecurityToken };
 			}
 
 			var queryParams = HttpUtility.ParseQueryString(request.RequestUri.Query);
@@ -127,7 +129,7 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 			var content = new ByteArrayContent(body);
 			foreach (var pair in request.Content.Headers)
 			{
-				if (string.Equals(pair.Key, "Content-Length", StringComparison.OrdinalIgnoreCase)) continue;
+				if (string.Equals(pair.Key, HeaderNames.ContentLength, StringComparison.OrdinalIgnoreCase)) continue;
 
 				content.Headers.TryAddWithoutValidation(pair.Key, pair.Value);
 			}
@@ -173,7 +175,7 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 
 				var key = pair.Key.ToLowerInvariant();
 
-				if (key == "user-agent") continue;
+				if (ExcludedHeaders.Contains(key)) continue;
 
 				if (!canonicalHeaders.TryGetValue(key, out var dictValues))
 					dictValues = canonicalHeaders[key] = new List<string>();
@@ -192,7 +194,7 @@ namespace OpenSearch.Net.Auth.AwsSigV4
 			foreach (var header in _headers) sb.Append($"{header.Key}:{string.Join(",", header.Value)}\n");
 			sb.Append('\n');
 			sb.Append($"{SignedHeaders}\n");
-			sb.Append(_contentSha256);
+			sb.Append(XAmzContentSha256);
 
 			return sb.ToString();
 		}

--- a/src/OpenSearch.Net.Auth.AwsSigV4/HeaderNames.cs
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/HeaderNames.cs
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+namespace OpenSearch.Net.Auth.AwsSigV4
+{
+	internal static class HeaderNames
+	{
+		public const string Authorization = "authorization";
+		public const string ContentLength = "content-length";
+		public const string Host = "host";
+		public const string UserAgent = "user-agent";
+		public const string XAmzContentSha256 = "x-amz-content-sha256";
+		public const string XAmzDate = "x-amz-date";
+		public const string XAmzSecurityToken = "x-amz-security-token";
+	}
+}

--- a/src/OpenSearch.Net.Auth.AwsSigV4/OpenSearch.Net.Auth.AwsSigV4.csproj
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/OpenSearch.Net.Auth.AwsSigV4.csproj
@@ -20,7 +20,7 @@
     <ProjectReference Include="$(SolutionRoot)\src\OpenSearch.Net\OpenSearch.Net.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.12.11" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.103.17" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <Reference Include="System.Web" />

--- a/src/OpenSearch.Net.Auth.AwsSigV4/packages.lock.json
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.6.1": {
       "AWSSDK.Core": {
         "type": "Direct",
-        "requested": "[3.7.12.11, )",
-        "resolved": "3.7.12.11",
-        "contentHash": "Tb6llf5tUU8FiptuB6Xq8vaJpxXDRcWL39nkEiHkDhdctj9l2kPL0DydrCNCAVwLWWTlPXyLUD8i37Rm0mRjaw=="
+        "requested": "[3.7.103.17, )",
+        "resolved": "3.7.103.17",
+        "contentHash": "DLi8jzlIeifLB5sXs2NpFkvffVy2wqKfhMi9qQ32VO0HGU8M24Y9D7YmRGQ35jaXy+S7fpIUlu+xp7hp5zJLVA=="
       },
       "ConfigureAwaitChecker.Analyzer": {
         "type": "Direct",
@@ -99,9 +99,9 @@
     ".NETStandard,Version=v2.0": {
       "AWSSDK.Core": {
         "type": "Direct",
-        "requested": "[3.7.12.11, )",
-        "resolved": "3.7.12.11",
-        "contentHash": "Tb6llf5tUU8FiptuB6Xq8vaJpxXDRcWL39nkEiHkDhdctj9l2kPL0DydrCNCAVwLWWTlPXyLUD8i37Rm0mRjaw==",
+        "requested": "[3.7.103.17, )",
+        "resolved": "3.7.103.17",
+        "contentHash": "DLi8jzlIeifLB5sXs2NpFkvffVy2wqKfhMi9qQ32VO0HGU8M24Y9D7YmRGQ35jaXy+S7fpIUlu+xp7hp5zJLVA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.0"
         }

--- a/tests/Tests.Auth.AwsSigV4/AwsSigV4HttpConnectionTests.cs
+++ b/tests/Tests.Auth.AwsSigV4/AwsSigV4HttpConnectionTests.cs
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using FluentAssertions;
+using OpenSearch.Client;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
+using Tests.Auth.AwsSigV4.Utils;
+using Xunit;
+
+namespace Tests.Auth.AwsSigV4;
+
+public class AwsSigV4HttpConnectionTests
+{
+	private static readonly BasicAWSCredentials TestCredentials = new("test-access-key", "test-secret-key");
+	private static readonly RegionEndpoint TestRegion = RegionEndpoint.APSoutheast2;
+	private static readonly DateTime TestSigningTime = new(2023, 01, 13, 16, 08, 37, DateTimeKind.Utc);
+
+	[TU]
+	[InlineData("es", "275d72b784a3183861ae13b4fcb486ff31a7a9dd7f2d6ebb780f89008aa689cc")]
+	[InlineData("aoss", "89fb38096ed2e9f4a2908d1e40c3e1b7ac68fc4ab2f723feddec61b4ada4607a")]
+	[InlineData("arbitrary", "9bdf7d1cf23d8ca4b41f84cd15aafbc7b665dd4985cf68258c9e7ac40311521b")]
+	public async Task SignsRequestCorrectly(string service, string expectedSignature)
+	{
+		var response = new HttpResponseMessage(HttpStatusCode.OK);
+		response.Content = new StringContent(@"{
+	""acknowledged"": true,
+	""shards_acknowledged"": true,
+    ""index"": ""sample-index1""
+}", Encoding.UTF8, "application/json");
+
+		HttpRequestMessage sentRequest = null;
+
+		var client = CreateClient(r =>
+		{
+			sentRequest = r;
+			return response;
+		}, $"https://aaabbbcccddd111222333.ap-southeast-2.{service}.amazonaws.com", service);
+
+		await client.Indices.CreateAsync("sample-index1", d =>
+			d.Settings(s =>
+					s.NumberOfShards(2).NumberOfReplicas(1))
+				.Map(t =>
+					t.Properties(p =>
+						p.Number(n =>
+							n.Name("age").Type(NumberType.Integer))))
+				.Aliases(a => a.Alias("sample-alias1")));
+
+		sentRequest.ShouldHaveHeader("x-amz-date", "20230113T160837Z");
+		sentRequest.ShouldHaveHeader("x-amz-content-sha256", "4c770eaed349122a28302ff73d34437cad600acda5a9dd373efc7da2910f8564");
+		sentRequest.ShouldHaveHeader("Authorization", $"AWS4-HMAC-SHA256 Credential=test-access-key/20230113/ap-southeast-2/{service}/aws4_request, SignedHeaders=accept;content-type;host;opensearch-client-meta;x-amz-content-sha256;x-amz-date, Signature={expectedSignature}");
+	}
+
+	private static OpenSearchClient CreateClient(MockHttpMessageHandler.Handler handler, string uri, string service) =>
+		new(new ConnectionSettings(
+			new Uri(uri),
+			new TestableAwsSigV4HttpConnection(TestCredentials, TestRegion, service, new FixedDateTimeProvider(TestSigningTime), handler)
+			));
+}

--- a/tests/Tests.Auth.AwsSigV4/AwsSigV4HttpConnectionTests.cs
+++ b/tests/Tests.Auth.AwsSigV4/AwsSigV4HttpConnectionTests.cs
@@ -27,9 +27,9 @@ public class AwsSigV4HttpConnectionTests
 	private static readonly DateTime TestSigningTime = new(2023, 01, 13, 16, 08, 37, DateTimeKind.Utc);
 
 	[TU]
-	[InlineData("es", "275d72b784a3183861ae13b4fcb486ff31a7a9dd7f2d6ebb780f89008aa689cc")]
-	[InlineData("aoss", "89fb38096ed2e9f4a2908d1e40c3e1b7ac68fc4ab2f723feddec61b4ada4607a")]
-	[InlineData("arbitrary", "9bdf7d1cf23d8ca4b41f84cd15aafbc7b665dd4985cf68258c9e7ac40311521b")]
+	[InlineData("es", "10c9be415f4b9f15b12abbb16bd3e3730b2e6c76e0cf40db75d08a44ed04a3a1")]
+	[InlineData("aoss", "34903aef90423aa7dd60575d3d45316c6ef2d57bbe564a152b41bf8f5917abf6")]
+	[InlineData("arbitrary", "156e65c504ea2b2722a481b7515062e7692d27217b477828854e715f507e6a36")]
 	public async Task SignsRequestCorrectly(string service, string expectedSignature)
 	{
 		var response = new HttpResponseMessage(HttpStatusCode.OK);
@@ -58,12 +58,15 @@ public class AwsSigV4HttpConnectionTests
 
 		sentRequest.ShouldHaveHeader("x-amz-date", "20230113T160837Z");
 		sentRequest.ShouldHaveHeader("x-amz-content-sha256", "4c770eaed349122a28302ff73d34437cad600acda5a9dd373efc7da2910f8564");
-		sentRequest.ShouldHaveHeader("Authorization", $"AWS4-HMAC-SHA256 Credential=test-access-key/20230113/ap-southeast-2/{service}/aws4_request, SignedHeaders=accept;content-type;host;opensearch-client-meta;x-amz-content-sha256;x-amz-date, Signature={expectedSignature}");
+		sentRequest.ShouldHaveHeader("Authorization", $"AWS4-HMAC-SHA256 Credential=test-access-key/20230113/ap-southeast-2/{service}/aws4_request, SignedHeaders=accept;content-type;host;x-amz-content-sha256;x-amz-date, Signature={expectedSignature}");
 	}
 
-	private static OpenSearchClient CreateClient(MockHttpMessageHandler.Handler handler, string uri, string service) =>
-		new(new ConnectionSettings(
-			new Uri(uri),
-			new TestableAwsSigV4HttpConnection(TestCredentials, TestRegion, service, new FixedDateTimeProvider(TestSigningTime), handler)
-			));
+	private static OpenSearchClient CreateClient(MockHttpMessageHandler.Handler handler, string uri, string service)
+	{
+		var connection =
+			new TestableAwsSigV4HttpConnection(TestCredentials, TestRegion, service, new FixedDateTimeProvider(TestSigningTime), handler);
+		var settings = new ConnectionSettings(new Uri(uri), connection);
+		settings.DisableMetaHeader(); // Make headers & signature stable across platforms for testing
+		return new OpenSearchClient(settings);
+	}
 }

--- a/tests/Tests.Auth.AwsSigV4/CanonicalRequestTests.cs
+++ b/tests/Tests.Auth.AwsSigV4/CanonicalRequestTests.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using Amazon.Runtime;
@@ -19,6 +20,7 @@ namespace Tests.Auth.AwsSigV4
 {
 	public class CanonicalRequestTests
 	{
+		private const string EmptyBodySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 		private static readonly ImmutableCredentials TestCredentials = new("test-access-key", "test-secret-key", null);
 		private static readonly DateTime TestSigningTime = new(2021, 05, 11, 15, 40, 45, DateTimeKind.Utc);
 
@@ -27,14 +29,55 @@ namespace Tests.Auth.AwsSigV4
 			var request = new HttpRequestMessage(HttpMethod.Post,
 				"https://tj9n5r0m12.execute-api.us-east-1.amazonaws.com/test/@connections/JBDvjfGEIAMCERw%3D");
 
-			await TestCanonicalRequest(request, @"POST
+			await TestCanonicalRequest(request, @$"POST
 /test/%40connections/JBDvjfGEIAMCERw%253D
 
 host:tj9n5r0m12.execute-api.us-east-1.amazonaws.com
+x-amz-content-sha256:{EmptyBodySha256}
 x-amz-date:20210511T154045Z
 
-host;x-amz-date
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+host;x-amz-content-sha256;x-amz-date
+{EmptyBodySha256}");
+		}
+
+		[U] public async Task TestBodyIsHashedCorrectly()
+		{
+			var request = new HttpRequestMessage(HttpMethod.Put,
+				"https://aaabbbcccddd111222333.ap-southeast-2.aoss.amazonaws.com/sample-index1");
+
+			var body = @"{
+	""settings"": {
+		""index"": {
+			""number_of_shards"": 2,
+			""number_of_replicas"": 1
+		}
+	},
+	""mappings"": {
+		""properties"": {
+			""age"": {
+				""type"": ""integer""
+			}
+		}
+	},
+	""aliases"": {
+		""sample-alias1"": {}
+	}
+}".Replace("\r\n", "\n");
+
+			const string bodyHash = "ea713058c116b72f762c89f7fdb5dc24751cd31be412087db17512637b5c0105";
+
+			request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+			await TestCanonicalRequest(request, @$"PUT
+/sample-index1
+
+content-type:application/json; charset=utf-8
+host:aaabbbcccddd111222333.ap-southeast-2.aoss.amazonaws.com
+x-amz-content-sha256:{bodyHash}
+x-amz-date:20210511T154045Z
+
+content-type;host;x-amz-content-sha256;x-amz-date
+{bodyHash}");
 		}
 
 		[U] public async Task TestDoubleUrlEncode()
@@ -42,14 +85,15 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 			var request = new HttpRequestMessage(HttpMethod.Post,
 				"https://lambda.us-east-2.amazonaws.com/2015-03-31/functions/arn%3Aaws%3Alambda%3Aus-west-2%3A892717189312%3Afunction%3Amy-rusty-fun/invocations");
 
-			await TestCanonicalRequest(request, @"POST
+			await TestCanonicalRequest(request, @$"POST
 /2015-03-31/functions/arn%253Aaws%253Alambda%253Aus-west-2%253A892717189312%253Afunction%253Amy-rusty-fun/invocations
 
 host:lambda.us-east-2.amazonaws.com
+x-amz-content-sha256:{EmptyBodySha256}
 x-amz-date:20210511T154045Z
 
-host;x-amz-date
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+host;x-amz-content-sha256;x-amz-date
+{EmptyBodySha256}");
 		}
 
 		[U] public async Task TestTildeInUri()
@@ -57,14 +101,15 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 			var request = new HttpRequestMessage(HttpMethod.Get,
 				"https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2&prefix=~objprefix&single&k=&unreserved=-_.~");
 
-			await TestCanonicalRequest(request, @"GET
+			await TestCanonicalRequest(request, @$"GET
 /my-bucket
 k=&list-type=2&prefix=~objprefix&single=&unreserved=-_.~
 host:s3.us-east-1.amazonaws.com
+x-amz-content-sha256:{EmptyBodySha256}
 x-amz-date:20210511T154045Z
 
-host;x-amz-date
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+host;x-amz-content-sha256;x-amz-date
+{EmptyBodySha256}");
 		}
 
 		[U] public async Task TestQueryParamMultipleValues()
@@ -72,14 +117,15 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 			var request = new HttpRequestMessage(HttpMethod.Get,
 				"https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2&list-type=1");
 
-			await TestCanonicalRequest(request, @"GET
+			await TestCanonicalRequest(request, @$"GET
 /my-bucket
 list-type=1&list-type=2
 host:s3.us-east-1.amazonaws.com
+x-amz-content-sha256:{EmptyBodySha256}
 x-amz-date:20210511T154045Z
 
-host;x-amz-date
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+host;x-amz-content-sha256;x-amz-date
+{EmptyBodySha256}");
 		}
 
 		[U] public static async Task TestAllPrintableAsciiQueryParam()
@@ -100,14 +146,15 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
 			var request = new HttpRequestMessage(HttpMethod.Get, uri);
 
-			await TestCanonicalRequest(request, @"GET
+			await TestCanonicalRequest(request, @$"GET
 /my-bucket
 list-type=2&prefix=%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~
 host:s3.us-east-1.amazonaws.com
+x-amz-content-sha256:{EmptyBodySha256}
 x-amz-date:20210511T154045Z
 
-host;x-amz-date
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+host;x-amz-content-sha256;x-amz-date
+{EmptyBodySha256}");
 		}
 
 		private static async Task TestCanonicalRequest(HttpRequestMessage request, string expected)

--- a/tests/Tests.Auth.AwsSigV4/Utils/FixedDateTimeProvider.cs
+++ b/tests/Tests.Auth.AwsSigV4/Utils/FixedDateTimeProvider.cs
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using OpenSearch.Net;
+
+namespace Tests.Auth.AwsSigV4.Utils;
+
+internal class FixedDateTimeProvider : DateTimeProvider
+{
+	private readonly DateTime _now;
+
+	public FixedDateTimeProvider(DateTime now) => _now = now;
+
+	public override DateTime Now() => _now;
+}

--- a/tests/Tests.Auth.AwsSigV4/Utils/HttpRequestMessageAssertions.cs
+++ b/tests/Tests.Auth.AwsSigV4/Utils/HttpRequestMessageAssertions.cs
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Net.Http;
+using FluentAssertions;
+
+namespace Tests.Auth.AwsSigV4.Utils;
+
+internal static class HttpRequestMessageAssertions
+{
+	public static void ShouldHaveHeader(this HttpRequestMessage request, string name, string value) =>
+		request.Headers.GetValues(name).Should().BeEquivalentTo(value);
+}

--- a/tests/Tests.Auth.AwsSigV4/Utils/MockHttpMessageHandler.cs
+++ b/tests/Tests.Auth.AwsSigV4/Utils/MockHttpMessageHandler.cs
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.Auth.AwsSigV4.Utils;
+
+internal class MockHttpMessageHandler : HttpMessageHandler
+{
+	public delegate HttpResponseMessage Handler(HttpRequestMessage request);
+
+	private readonly Handler _handler;
+
+	public MockHttpMessageHandler(Handler handler) => _handler = handler;
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+		Task.FromResult(_handler(request));
+}

--- a/tests/Tests.Auth.AwsSigV4/Utils/TestableAwsSigV4HttpConnection.cs
+++ b/tests/Tests.Auth.AwsSigV4/Utils/TestableAwsSigV4HttpConnection.cs
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Net.Http;
+using Amazon;
+using Amazon.Runtime;
+using OpenSearch.Net;
+using OpenSearch.Net.Auth.AwsSigV4;
+
+namespace Tests.Auth.AwsSigV4.Utils;
+
+internal class TestableAwsSigV4HttpConnection : AwsSigV4HttpConnection
+{
+	private readonly MockHttpMessageHandler _handler;
+
+	public TestableAwsSigV4HttpConnection(AWSCredentials credentials, RegionEndpoint region, string service, IDateTimeProvider dateTimeProvider, MockHttpMessageHandler.Handler handler)
+		: base(credentials, region, service, dateTimeProvider) =>
+		_handler = new MockHttpMessageHandler(handler);
+
+	protected override HttpMessageHandler InnerCreateHttpClientHandler(RequestData requestData) => _handler;
+}

--- a/tests/Tests.Auth.AwsSigV4/packages.lock.json
+++ b/tests/Tests.Auth.AwsSigV4/packages.lock.json
@@ -29,8 +29,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.7.12.11",
-        "contentHash": "Tb6llf5tUU8FiptuB6Xq8vaJpxXDRcWL39nkEiHkDhdctj9l2kPL0DydrCNCAVwLWWTlPXyLUD8i37Rm0mRjaw=="
+        "resolved": "3.7.103.17",
+        "contentHash": "DLi8jzlIeifLB5sXs2NpFkvffVy2wqKfhMi9qQ32VO0HGU8M24Y9D7YmRGQ35jaXy+S7fpIUlu+xp7hp5zJLVA=="
       },
       "Bogus": {
         "type": "Transitive",
@@ -900,7 +900,7 @@
       "opensearch.net.auth.awssigv4": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.Core": "[3.7.12.11, )",
+          "AWSSDK.Core": "[3.7.103.17, )",
           "OpenSearch.Net": "[1.2.1, )"
         }
       },


### PR DESCRIPTION
### Description
Support AwsSigV4 signing for Amazon OpenSearch Serverless
- Make the service ID customizable, so it can be set to "aoss" for serverless
- Include the x-amz-content-sha256 header
- Don't sign the content-length header

Relates to #129, however does not solve documenting of methods unsupported by serverless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
