### PR TITLE
Bump SharpZipLib from 1.0.7 to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Security
 
+### Dependencies
+- Bumps `SharpZipLib` from 1.0.4 to `1.4.1` ([#136](https://github.com/opensearch-project/opensearch-net/pull/136))
+
 
 [Unreleased]: https://github.com/opensearch-project/opensearch-net/compare/1.2.0...HEAD

--- a/abstractions/src/OpenSearch.OpenSearch.Ephemeral/OpenSearch.OpenSearch.Ephemeral.csproj
+++ b/abstractions/src/OpenSearch.OpenSearch.Ephemeral/OpenSearch.OpenSearch.Ephemeral.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SharpZipLib.NETStandard" Version="1.0.7" />
+    <PackageReference Include="SharpZipLib" Version="1.4.1" />
     <PackageReference Condition="'$(TargetFramework)' == 'net461'" Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/abstractions/src/OpenSearch.OpenSearch.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/abstractions/src/OpenSearch.OpenSearch.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -244,7 +244,7 @@ namespace OpenSearch.OpenSearch.Ephemeral.Tasks
 		private static void ExtractTar(string file, string toFolder)
 		{
 			using (var inStream = File.OpenRead(file))
-			using (var tarArchive = TarArchive.CreateInputTarArchive(inStream))
+			using (var tarArchive = TarArchive.CreateInputTarArchive(inStream, Encoding.UTF8))
 				tarArchive.ExtractContents(toFolder);
 		}
 
@@ -253,7 +253,7 @@ namespace OpenSearch.OpenSearch.Ephemeral.Tasks
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 				using (var inStream = File.OpenRead(file))
 				using (var gzipStream = new GZipInputStream(inStream))
-				using (var tarArchive = TarArchive.CreateInputTarArchive(gzipStream))
+				using (var tarArchive = TarArchive.CreateInputTarArchive(gzipStream, Encoding.UTF8))
 					tarArchive.ExtractContents(toFolder);
 			else
 				//SharpZipLib loses permissions when untarring

--- a/abstractions/src/OpenSearch.OpenSearch.Ephemeral/packages.lock.json
+++ b/abstractions/src/OpenSearch.OpenSearch.Ephemeral/packages.lock.json
@@ -20,13 +20,14 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Direct",
-        "requested": "[1.0.7, )",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
+        "requested": "[1.4.1, )",
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1"
+          "System.Memory": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {

--- a/abstractions/src/OpenSearch.OpenSearch.Xunit/packages.lock.json
+++ b/abstractions/src/OpenSearch.OpenSearch.Xunit/packages.lock.json
@@ -194,12 +194,13 @@
           "NETStandard.Library": "1.6.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1"
+          "System.Memory": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
       "System.Buffers": {
@@ -833,7 +834,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {

--- a/abstractions/tests/OpenSearch.OpenSearch.EphemeralTests/packages.lock.json
+++ b/abstractions/tests/OpenSearch.OpenSearch.EphemeralTests/packages.lock.json
@@ -250,13 +250,10 @@
           "NETStandard.Library": "1.6.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g=="
       },
       "System.Buffers": {
         "type": "Transitive",
@@ -896,7 +893,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {

--- a/abstractions/tests/OpenSearch.Stack.ArtifactsApiTests/packages.lock.json
+++ b/abstractions/tests/OpenSearch.Stack.ArtifactsApiTests/packages.lock.json
@@ -250,13 +250,10 @@
           "NETStandard.Library": "1.6.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g=="
       },
       "System.Buffers": {
         "type": "Transitive",
@@ -896,7 +893,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {

--- a/tests/Tests.Auth.AwsSigV4/packages.lock.json
+++ b/tests/Tests.Auth.AwsSigV4/packages.lock.json
@@ -255,13 +255,10 @@
           "NETStandard.Library": "1.6.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g=="
       },
       "System.Buffers": {
         "type": "Transitive",
@@ -908,7 +905,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {

--- a/tests/Tests.ClusterLauncher/packages.lock.json
+++ b/tests/Tests.ClusterLauncher/packages.lock.json
@@ -243,13 +243,10 @@
           "NETStandard.Library": "1.6.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g=="
       },
       "System.Buffers": {
         "type": "Transitive",
@@ -889,7 +886,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {

--- a/tests/Tests.Core/packages.lock.json
+++ b/tests/Tests.Core/packages.lock.json
@@ -275,12 +275,13 @@
           "NETStandard.Library": "1.6.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1"
+          "System.Memory": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
       "System.Buffers": {
@@ -1302,7 +1303,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {

--- a/tests/Tests.Reproduce/packages.lock.json
+++ b/tests/Tests.Reproduce/packages.lock.json
@@ -250,13 +250,10 @@
           "NETStandard.Library": "1.6.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g=="
       },
       "System.Buffers": {
         "type": "Transitive",
@@ -896,7 +893,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {

--- a/tests/Tests.ScratchPad/packages.lock.json
+++ b/tests/Tests.ScratchPad/packages.lock.json
@@ -391,13 +391,10 @@
           "NETStandard.Library": "1.6.0"
         }
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g=="
       },
       "System.AppContext": {
         "type": "Transitive",
@@ -1399,7 +1396,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {

--- a/tests/Tests/packages.lock.json
+++ b/tests/Tests/packages.lock.json
@@ -335,13 +335,10 @@
         "resolved": "4.3.2",
         "contentHash": "leXiwfiIkW7Gmn7cgnNcdtNAU70SjmKW3jxGj1iKHOvdn0zRWsgv/l2OJUO5zdGdiv2VRFnAsxxhDgMzofPdWg=="
       },
-      "SharpZipLib.NETStandard": {
+      "SharpZipLib": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "mYKPizF2CY32RQB8FITYy0e30gVgItFA63SFquruaxq+votwL1T+yOfssK10v4enBcxklr8ks48hS1emw5TTXg==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "1.4.1",
+        "contentHash": "X8QiHZS7+bbZy85LfpKCAL9oh0yZkiiecWhQL5F1Yn1AKFDYiOzR3UG5vI+9bDYGRGyseVdMW5sTH8mv8LXF1g=="
       },
       "System.AppContext": {
         "type": "Transitive",
@@ -1308,7 +1305,7 @@
         "type": "Project",
         "dependencies": {
           "OpenSearch.OpenSearch.Managed": "[1.2.1, )",
-          "SharpZipLib.NETStandard": "[1.0.7, )"
+          "SharpZipLib": "[1.4.1, )"
         }
       },
       "opensearch.opensearch.managed": {


### PR DESCRIPTION
### Description
Mitigates the following vulnerabilities:
- https://devhub.checkmarx.com/cve-details/CVE-2021-32840/
- https://devhub.checkmarx.com/cve-details/CVE-2021-32842/ 

Attack surface for these in our use case is very minimal as the library is only used via integration test code. Additionally we only ever try to extract the OpenSearch distro artifacts, so would require MITM/compromise of upstream OpenSearch or already having filesystem access.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
