### PR TITLE
Onboard to 1-click release process

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,33 @@
+name: Draft a release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: get_approvers
+        run: |
+          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_approvers.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: 'Release opensearch-net'
+          issue-body: "Please approve or deny the release of opensearch-net \n **TAG**: ${{ github.ref_name }}  \n **COMMIT**: ${{ github.sha }}"
+          exclude-workflow-initiator-as-approver: true
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Github workflow for changelog verification ([#111](https://github.com/opensearch-project/opensearch-net/pull/111))
 - Bump version to `1.2.1`([#115](https://github.com/opensearch-project/opensearch-net/pull/115))
 - Added `dependabot_changelog` workflow ([#118](https://github.com/opensearch-project/opensearch-net/pull/118))
+- Onboard to 1-click release process ([#162](https://github.com/opensearch-project/opensearch-net/pull/162))
 
 ### Changed
 - Updated SDK to .NET 6 ([#126](https://github.com/opensearch-project/opensearch-net/pull/126))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,3 +32,10 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 ## Releasing
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
+
+1. Create a tag, e.g. 1.0.0, and push it to this GitHub repository.
+2. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and is responsible for drafting a new release on GitHub.
+3. Before creating a draft release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). See sample [issue](https://github.com/gaiksaya/opensearch-net/issues/10). The maintainers need to approve in order to continue the workflow run.
+4. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-net-release) as a result of which the client is released on [Nuget.org](https://www.nuget.org/profiles/opensearchproject). Please note that the release workflow is triggered only if created release is in draft state.
+5. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+6. Increment the version to next iteration. See [example](https://github.com/opensearch-project/opensearch-net/pull/93).

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,0 +1,17 @@
+lib = library(identifier: 'jenkins@2.0.2', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v2.3',
+    tokenIdCredential: 'jenkins-opensearch-net-generic-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/opensearch-net repository causing this workflow to run',
+    publishRelease: true) {
+        publishToNuget(
+            repository: 'https://github.com/opensearch-project/opensearch-net',
+            tag: "$tag",
+            solutionFilePath: 'OpenSearch.sln',
+            apiKeyCredentialId: 'jenkins-opensearch-net-api-key'
+        )
+    }


### PR DESCRIPTION
Putting the PR in draft until dependent PRs are merged. Feel free to review till then. 

### Description
This change onboards the opensearch-net client to universal release/1-click release process. See https://github.com/opensearch-project/opensearch-build/issues/1234 for more details.
Due to the complexity of the way dotnet client is build and packaged, we considered building the client on the release CI system is the best way to go ahead. See https://github.com/opensearch-project/opensearch-build/issues/2965 for more details.
See how the underlying library is publishing to nuget https://github.com/opensearch-project/opensearch-build-libraries/blob/main/vars/publishToNuget.groovy

The mentioned docker image: `opensearchstaging/ci-runner:release-centos7-clients-v2.3` (PR pending merge https://github.com/opensearch-project/opensearch-build/pull/3266) contains dotnet version 5.0 and 6.0. We recommend to exercise this image in CI of this repo so when version bump happens, it would be a reminder to upgrade the version on docker image as well. 

This change also incorporates 2 PR approval process for release. See the attached documentation in RELEASING.md file. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3194

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
