### PR TITLE
Increment jenkins lib version to 2.1.1

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@2.0.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@2.1.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
The 2.1.1 includes a bug fix due to which previous release workflow run failed
See release details: https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/2.1.1
TL;DR: The signer client is cloned in another workspace of jenkins and hence needs to be given an absolute path rather than relative.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
