### PR TITLE
Increment jenkins library version to accommodate a bug-fix

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@2.1.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@2.1.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Bumps jenkins library version to 2.1.2 that contains refactored code for pushing nupkg packages to Nuget. https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/2.1.2

### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/3194

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
