### PR TITLE
Move CAT API requests into the `.Specification.CatApi` namespace

### DIFF
--- a/src/OpenSearch.Client/Cat/CatAliases/CatAliasesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatAliases/CatAliasesRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatAliasesRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatAliases/CatAliasesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatAliases/CatAliasesRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.aliases.json")]
 	public partial interface ICatAliasesRequest { }

--- a/src/OpenSearch.Client/Cat/CatAllocation/CatAllocationRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatAllocation/CatAllocationRecord.cs
@@ -29,7 +29,7 @@
 using System;
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatAllocationRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatAllocation/CatAllocationRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatAllocation/CatAllocationRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.allocation.json")]
 	public partial interface ICatAllocationRequest { }

--- a/src/OpenSearch.Client/Cat/CatClusterManager/CatClusterManagerRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatClusterManager/CatClusterManagerRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	/// <summary>
 	/// See docs <see href="https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/">here</see>

--- a/src/OpenSearch.Client/Cat/CatClusterManager/CatClusterManagerRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatClusterManager/CatClusterManagerRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.cluster_manager.json")]
 	///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="ICatMasterRequest"/></remarks>

--- a/src/OpenSearch.Client/Cat/CatCount/CatCountRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatCount/CatCountRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatCountRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatCount/CatCountRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatCount/CatCountRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.count.json")]
 	public partial interface ICatCountRequest { }

--- a/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRecord.cs
@@ -29,7 +29,7 @@
 using System.Runtime.Serialization;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	[JsonFormatter(typeof(CatFielddataRecordFormatter))]

--- a/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRecordJsonConverter.cs
+++ b/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRecordJsonConverter.cs
@@ -31,7 +31,7 @@ using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
 
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	internal class CatFielddataRecordFormatter : IJsonFormatter<CatFielddataRecord>
 	{

--- a/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatFielddata/CatFielddataRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.fielddata.json")]
 	public partial interface ICatFielddataRequest { }

--- a/src/OpenSearch.Client/Cat/CatHealth/CatHealthRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatHealth/CatHealthRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatHealthRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatHealth/CatHealthRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatHealth/CatHealthRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.health.json")]
 	public partial interface ICatHealthRequest { }

--- a/src/OpenSearch.Client/Cat/CatHelp/CatHelpRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatHelp/CatHelpRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatHelpRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatHelp/CatHelpRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatHelp/CatHelpRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.help.json")]
 	public partial interface ICatHelpRequest { }

--- a/src/OpenSearch.Client/Cat/CatHelpResponseBuilder.cs
+++ b/src/OpenSearch.Client/Cat/CatHelpResponseBuilder.cs
@@ -32,7 +32,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	internal class CatHelpResponseBuilder : CustomResponseBuilderBase
 	{

--- a/src/OpenSearch.Client/Cat/CatIndices/CatIndicesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatIndices/CatIndicesRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatIndicesRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatIndices/CatIndicesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatIndices/CatIndicesRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.indices.json")]
 	public partial interface ICatIndicesRequest { }

--- a/src/OpenSearch.Client/Cat/CatMaster/CatMasterRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatMaster/CatMasterRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	/// <summary>
 	/// See docs <see href="https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/">here</see>

--- a/src/OpenSearch.Client/Cat/CatMaster/CatMasterRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatMaster/CatMasterRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.master.json")]
 	/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="ICatClusterManagerRequest"/> instead</remarks>

--- a/src/OpenSearch.Client/Cat/CatNodeAttributes/CatNodeAttributesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatNodeAttributes/CatNodeAttributesRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatNodeAttributesRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatNodeAttributes/CatNodeAttributesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatNodeAttributes/CatNodeAttributesRequest.cs
@@ -28,7 +28,7 @@
 
 #pragma warning disable 612, 618
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.nodeattrs.json")]
 	public partial interface ICatNodeAttributesRequest { }

--- a/src/OpenSearch.Client/Cat/CatNodes/CatNodesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatNodes/CatNodesRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatNodesRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatNodes/CatNodesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatNodes/CatNodesRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.nodes.json")]
 	public partial interface ICatNodesRequest { }

--- a/src/OpenSearch.Client/Cat/CatPendingTasks/CatPendingTasksRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatPendingTasks/CatPendingTasksRecord.cs
@@ -29,7 +29,7 @@
 using System.Runtime.Serialization;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatPendingTasksRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatPendingTasks/CatPendingTasksRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatPendingTasks/CatPendingTasksRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.pending_tasks.json")]
 	public partial interface ICatPendingTasksRequest { }

--- a/src/OpenSearch.Client/Cat/CatPlugins/CatPluginsRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatPlugins/CatPluginsRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatPluginsRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatPlugins/CatPluginsRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatPlugins/CatPluginsRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.plugins.json")]
 	public partial interface ICatPluginsRequest { }

--- a/src/OpenSearch.Client/Cat/CatRecovery/CatRecoveryRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatRecovery/CatRecoveryRecord.cs
@@ -29,7 +29,7 @@
 using System.Runtime.Serialization;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatRecoveryRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatRecovery/CatRecoveryRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatRecovery/CatRecoveryRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.recovery.json")]
 	public partial interface ICatRecoveryRequest { }

--- a/src/OpenSearch.Client/Cat/CatRepositories/CatRepositoriesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatRepositories/CatRepositoriesRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatRepositoriesRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatRepositories/CatRepositoriesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatRepositories/CatRepositoriesRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.repositories.json")]
 	public partial interface ICatRepositoriesRequest { }

--- a/src/OpenSearch.Client/Cat/CatResponse.cs
+++ b/src/OpenSearch.Client/Cat/CatResponse.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatResponse<TCatRecord> : ResponseBase

--- a/src/OpenSearch.Client/Cat/CatResponseBuilder.cs
+++ b/src/OpenSearch.Client/Cat/CatResponseBuilder.cs
@@ -32,7 +32,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	internal class CatResponseBuilder<TCatRecord> : CustomResponseBuilderBase where TCatRecord : ICatRecord
 	{

--- a/src/OpenSearch.Client/Cat/CatSegments/CatSegmentsRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatSegments/CatSegmentsRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatSegmentsRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatSegments/CatSegmentsRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatSegments/CatSegmentsRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.segments.json")]
 	public partial interface ICatSegmentsRequest { }

--- a/src/OpenSearch.Client/Cat/CatShards/CatShardsRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatShards/CatShardsRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatShardsRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatShards/CatShardsRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatShards/CatShardsRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.shards.json")]
 	public partial interface ICatShardsRequest { }

--- a/src/OpenSearch.Client/Cat/CatSnapshots/CatSnapshotsRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatSnapshots/CatSnapshotsRecord.cs
@@ -29,7 +29,7 @@
 using System.Runtime.Serialization;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatSnapshotsRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatSnapshots/CatSnapshotsRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatSnapshots/CatSnapshotsRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.snapshots.json")]
 	public partial interface ICatSnapshotsRequest { }

--- a/src/OpenSearch.Client/Cat/CatTasks/CatTasksRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatTasks/CatTasksRecord.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	public class CatTasksRecord : ICatRecord
 	{

--- a/src/OpenSearch.Client/Cat/CatTasks/CatTasksRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatTasks/CatTasksRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.tasks.json")]
 	public partial interface ICatTasksRequest { }

--- a/src/OpenSearch.Client/Cat/CatTemplates/CatTemplatesRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatTemplates/CatTemplatesRecord.cs
@@ -29,7 +29,7 @@
 using System.Runtime.Serialization;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatTemplatesRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatTemplates/CatTemplatesRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatTemplates/CatTemplatesRequest.cs
@@ -28,7 +28,7 @@
 
 #pragma warning disable 612, 618
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.templates.json")]
 	public partial interface ICatTemplatesRequest { }

--- a/src/OpenSearch.Client/Cat/CatThreadPool/CatThreadPoolRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatThreadPool/CatThreadPoolRecord.cs
@@ -29,7 +29,7 @@
 using System.Runtime.Serialization;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[DataContract]
 	public class CatThreadPoolRecord : ICatRecord

--- a/src/OpenSearch.Client/Cat/CatThreadPool/CatThreadPoolRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatThreadPool/CatThreadPoolRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[MapsApi("cat.thread_pool.json")]
 	public partial interface ICatThreadPoolRequest { }

--- a/src/OpenSearch.Client/Cat/ICatRecord.cs
+++ b/src/OpenSearch.Client/Cat/ICatRecord.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	public interface ICatRecord { }
 }

--- a/src/OpenSearch.Client/Descriptors.Cat.cs
+++ b/src/OpenSearch.Client/Descriptors.Cat.cs
@@ -40,7 +40,7 @@ using OpenSearch.Net.Specification.CatApi;
 // ReSharper disable UnusedTypeParameter
 // ReSharper disable PartialMethodWithSinglePart
 // ReSharper disable RedundantNameQualifier
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	///<summary>Descriptor for Aliases <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-aliases/</para></summary>
 	public partial class CatAliasesDescriptor : RequestDescriptorBase<CatAliasesDescriptor, CatAliasesRequestParameters, ICatAliasesRequest>, ICatAliasesRequest

--- a/src/OpenSearch.Client/OpenSearchClient.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenSearch.Client.Specification.CatApi;
 using OpenSearch.Net;
 
 namespace OpenSearch.Client

--- a/src/OpenSearch.Client/Requests.Cat.cs
+++ b/src/OpenSearch.Client/Requests.Cat.cs
@@ -41,7 +41,7 @@ using OpenSearch.Net.Specification.CatApi;
 // ReSharper disable UnusedTypeParameter
 // ReSharper disable PartialMethodWithSinglePart
 // ReSharper disable RedundantNameQualifier
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.CatApi
 {
 	[InterfaceDataContract]
 	public partial interface ICatAliasesRequest : IRequest<CatAliasesRequestParameters>

--- a/tests/Tests/Cat/CatAliases/CatAliasesApiTests.cs
+++ b/tests/Tests/Cat/CatAliases/CatAliasesApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Core.ManagedOpenSearch.NodeSeeders;
 using Tests.Framework.EndpointTests;

--- a/tests/Tests/Cat/CatAliases/CatAliasesUrlTests.cs
+++ b/tests/Tests/Cat/CatAliases/CatAliasesUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatAllocation/CatAllocationApiTests.cs
+++ b/tests/Tests/Cat/CatAllocation/CatAllocationApiTests.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatAllocation/CatAllocationUrlTests.cs
+++ b/tests/Tests/Cat/CatAllocation/CatAllocationUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatClusterManager/CatClusterManagerApiTests.cs
+++ b/tests/Tests/Cat/CatClusterManager/CatClusterManagerApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatClusterManager/CatClusterManagerUrlTests.cs
+++ b/tests/Tests/Cat/CatClusterManager/CatClusterManagerUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatCount/CatCountApiTests.cs
+++ b/tests/Tests/Cat/CatCount/CatCountApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;

--- a/tests/Tests/Cat/CatCount/CatCountUrlTests.cs
+++ b/tests/Tests/Cat/CatCount/CatCountUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatFielddata/CatFielddataApiTests.cs
+++ b/tests/Tests/Cat/CatFielddata/CatFielddataApiTests.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Core.Xunit;
 using Tests.Domain;

--- a/tests/Tests/Cat/CatFielddata/CatFielddataUrlTests.cs
+++ b/tests/Tests/Cat/CatFielddata/CatFielddataUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;

--- a/tests/Tests/Cat/CatHealth/CatHealthApiTests.cs
+++ b/tests/Tests/Cat/CatHealth/CatHealthApiTests.cs
@@ -31,6 +31,7 @@ using FluentAssertions;
 using OpenSearch.Net;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatHealth/CatHealthUrlTests.cs
+++ b/tests/Tests/Cat/CatHealth/CatHealthUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatHelp/CatHelpApiTests.cs
+++ b/tests/Tests/Cat/CatHelp/CatHelpApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatHelp/CatHelpUrlTests.cs
+++ b/tests/Tests/Cat/CatHelp/CatHelpUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatIndices/CatIndicesApiTests.cs
+++ b/tests/Tests/Cat/CatIndices/CatIndicesApiTests.cs
@@ -31,6 +31,7 @@ using OpenSearch.OpenSearch.Ephemeral;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatIndices/CatIndicesUrlTests.cs
+++ b/tests/Tests/Cat/CatIndices/CatIndicesUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;

--- a/tests/Tests/Cat/CatMaster/CatMasterApiTests.cs
+++ b/tests/Tests/Cat/CatMaster/CatMasterApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatMaster/CatMasterUrlTests.cs
+++ b/tests/Tests/Cat/CatMaster/CatMasterUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatNodeAttributes/CatAliasesUrlTests.cs
+++ b/tests/Tests/Cat/CatNodeAttributes/CatAliasesUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatNodeAttributes/CatNodeAttributesApiTests.cs
+++ b/tests/Tests/Cat/CatNodeAttributes/CatNodeAttributesApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatNodes/CatNodesApiTests.cs
+++ b/tests/Tests/Cat/CatNodes/CatNodesApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatNodes/CatNodesUrlTests.cs
+++ b/tests/Tests/Cat/CatNodes/CatNodesUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatPendingTasks/CatPendingTasksApiTests.cs
+++ b/tests/Tests/Cat/CatPendingTasks/CatPendingTasksApiTests.cs
@@ -28,6 +28,7 @@
 
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatPendingTasks/CatPendingTasksUrlTests.cs
+++ b/tests/Tests/Cat/CatPendingTasks/CatPendingTasksUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatPlugins/CatPluginsApiTests.cs
+++ b/tests/Tests/Cat/CatPlugins/CatPluginsApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatPlugins/CatPluginsUrlTests.cs
+++ b/tests/Tests/Cat/CatPlugins/CatPluginsUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatRecovery/CatRecoveryApiTests.cs
+++ b/tests/Tests/Cat/CatRecovery/CatRecoveryApiTests.cs
@@ -28,6 +28,7 @@
 
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatRecovery/CatRecoveryUrlTests.cs
+++ b/tests/Tests/Cat/CatRecovery/CatRecoveryUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;

--- a/tests/Tests/Cat/CatRepositories/CatRepositoriesApiTests.cs
+++ b/tests/Tests/Cat/CatRepositories/CatRepositoriesApiTests.cs
@@ -32,6 +32,7 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.Client;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;

--- a/tests/Tests/Cat/CatRepositories/CatRepositoriesUrlTests.cs
+++ b/tests/Tests/Cat/CatRepositories/CatRepositoriesUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatSegments/CatSegmentsApiTests.cs
+++ b/tests/Tests/Cat/CatSegments/CatSegmentsApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatSegments/CatSegmentsUrlTests.cs
+++ b/tests/Tests/Cat/CatSegments/CatSegmentsUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;

--- a/tests/Tests/Cat/CatShards/CatShardsApiTests.cs
+++ b/tests/Tests/Cat/CatShards/CatShardsApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatShards/CatShardsUrlTests.cs
+++ b/tests/Tests/Cat/CatShards/CatShardsUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;

--- a/tests/Tests/Cat/CatSnapshots/CatSnapshotsApiTests.cs
+++ b/tests/Tests/Cat/CatSnapshots/CatSnapshotsApiTests.cs
@@ -32,6 +32,7 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.Client;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;

--- a/tests/Tests/Cat/CatSnapshots/CatSnapshotsUrlTests.cs
+++ b/tests/Tests/Cat/CatSnapshots/CatSnapshotsUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatTasks/CatTasksApiTests.cs
+++ b/tests/Tests/Cat/CatTasks/CatTasksApiTests.cs
@@ -28,6 +28,7 @@
 
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatTasks/CatTasksUrlTests.cs
+++ b/tests/Tests/Cat/CatTasks/CatTasksUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatTemplates/CatTemplatesApiTests.cs
+++ b/tests/Tests/Cat/CatTemplates/CatTemplatesApiTests.cs
@@ -30,6 +30,7 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cat/CatTemplates/CatTemplatesUrlTests.cs
+++ b/tests/Tests/Cat/CatTemplates/CatTemplatesUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatThreadPool/CatThreadPoolUrlTests.cs
+++ b/tests/Tests/Cat/CatThreadPool/CatThreadPoolUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cat/CatThreadPool/CatThreadpoolApiTests.cs
+++ b/tests/Tests/Cat/CatThreadPool/CatThreadpoolApiTests.cs
@@ -30,6 +30,7 @@ using System;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.CatApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;


### PR DESCRIPTION
### Description
Moves CAT API requests in `OpenSearch.Client` into the `.Specification.CatApi` namespace.
Brings them inline with the rest of the parts of the client:
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Client/OpenSearchClient.Cat.cs#L37
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Net/OpenSearchLowLevelClient.Cat.cs#L44
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cat.cs#L37

Part of #196, but broken up by namespace to aid review-ability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
