### PR TITLE
Move cluster API requests into the `.Specification.ClusterApi` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### ⚠️ Breaking Changes ⚠️
+- Moved `OpenSearch.Client` request classes into their respective namespaces to match those in `OpenSearch.Net` ([#202](https://github.com/opensearch-project/opensearch-net/pull/202))
+
 ### Dependencies
 - Bumps `System.Reflection.Emit` from 4.3.0 to 4.7.0
 - Bumps `Argu` from 5.5.0 to 6.1.1

--- a/src/OpenSearch.Client/Cluster/ClusterAllocationExplain/ClusterAllocationExplainRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterAllocationExplain/ClusterAllocationExplainRequest.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.allocation_explain.json")]
 	[ReadAs(typeof(ClusterAllocationExplainRequest))]

--- a/src/OpenSearch.Client/Cluster/ClusterAllocationExplain/ClusterAllocationExplainResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterAllocationExplain/ClusterAllocationExplainResponse.cs
@@ -31,7 +31,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterAllocationExplainResponse : ResponseBase

--- a/src/OpenSearch.Client/Cluster/ClusterHealth.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth.cs
@@ -29,7 +29,7 @@
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[StringEnum]
 	public enum ClusterStatus

--- a/src/OpenSearch.Client/Cluster/ClusterHealth/ClusterHealthRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth/ClusterHealthRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.health.json")]
 	public partial interface IClusterHealthRequest { }

--- a/src/OpenSearch.Client/Cluster/ClusterHealth/ClusterHealthResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth/ClusterHealthResponse.cs
@@ -31,7 +31,7 @@ using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterHealthResponse : ResponseBase

--- a/src/OpenSearch.Client/Cluster/ClusterHealth/IndexHealthStats.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth/IndexHealthStats.cs
@@ -31,7 +31,7 @@ using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class IndexHealthStats

--- a/src/OpenSearch.Client/Cluster/ClusterHealth/ShardHealthStats.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterHealth/ShardHealthStats.cs
@@ -29,7 +29,7 @@
 using OpenSearch.Net;
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ShardHealthStats

--- a/src/OpenSearch.Client/Cluster/ClusterPendingTasks/ClusterPendingTasksRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterPendingTasks/ClusterPendingTasksRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.pending_tasks.json")]
 	public partial interface IClusterPendingTasksRequest { }

--- a/src/OpenSearch.Client/Cluster/ClusterPendingTasks/ClusterPendingTasksResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterPendingTasks/ClusterPendingTasksResponse.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterPendingTasksResponse : ResponseBase

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteDecision.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteDecision.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterRerouteDecision

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteExplanation.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteExplanation.cs
@@ -29,7 +29,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterRerouteExplanation

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteParameters.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteParameters.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterRerouteParameters

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteRequest.cs
@@ -30,7 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.reroute.json")]
 	[ReadAs(typeof(ClusterRerouteRequest))]

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/ClusterRerouteResponse.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterRerouteResponse : ResponseBase

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/AllocateClusterRerouteCommandBase.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/AllocateClusterRerouteCommandBase.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	public interface IAllocateClusterRerouteCommand : IClusterRerouteCommand
 	{

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/CancelClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/CancelClusterRerouteCommand.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	public interface ICancelClusterRerouteCommand : IClusterRerouteCommand
 	{

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/ClusterRerouteCommandFormatter.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/ClusterRerouteCommandFormatter.cs
@@ -31,7 +31,7 @@ using OpenSearch.Net.Utf8Json.Internal;
 using OpenSearch.Net.Utf8Json.Resolvers;
 
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	internal class ClusterRerouteCommandFormatter : IJsonFormatter<IClusterRerouteCommand>
 	{

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/IClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/IClusterRerouteCommand.cs
@@ -29,7 +29,7 @@
 using System.Runtime.Serialization;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[JsonFormatter(typeof(ClusterRerouteCommandFormatter))]
 	public interface IClusterRerouteCommand

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/MoveClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/MoveClusterRerouteCommand.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	public interface IMoveClusterRerouteCommand : IClusterRerouteCommand
 	{

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.get_settings.json")]
 	public partial interface IClusterGetSettingsRequest { }

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsResponse.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterGetSettingsResponse : ResponseBase

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsRequest.cs
@@ -30,7 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.put_settings.json")]
 	public partial interface IClusterPutSettingsRequest

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsResponse.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterPutSettingsResponse : ResponseBase

--- a/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/RemoteClusterConfiguration.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterSettings/ClusterPutSettings/RemoteClusterConfiguration.cs
@@ -30,7 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	/// <summary>
 	/// Simplifies the creation of remote cluster configuration, can be combined with a dictionary using the overloaded + operator

--- a/src/OpenSearch.Client/Cluster/ClusterState/ClusterStateRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterState/ClusterStateRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.state.json")]
 	public partial interface IClusterStateRequest { }

--- a/src/OpenSearch.Client/Cluster/ClusterState/ClusterStateResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterState/ClusterStateResponse.cs
@@ -30,7 +30,7 @@ using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[JsonFormatter(typeof(DynamicResponseFormatter<ClusterStateResponse>))]
 	public class ClusterStateResponse : DynamicResponseBase

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterIndicesStats.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterIndicesStats.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterIndicesStats

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterNodesStats.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterNodesStats.cs
@@ -29,7 +29,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	public class ClusterNodesStats
@@ -200,7 +200,7 @@ namespace OpenSearch.Client
 		public IReadOnlyCollection<ClusterOperatingSystemName> Names { get; internal set; }
 
 		[DataMember(Name = "pretty_names")]
-		public IReadOnlyCollection<ClusterOperatingSystemPrettyNane> PrettyNames { get; internal set; }
+		public IReadOnlyCollection<ClusterOperatingSystemPrettyName> PrettyNames { get; internal set; }
 
 		[DataMember(Name = "architectures")]
 		public IReadOnlyCollection<ArchitectureStats> Architectures { get; internal set; }
@@ -233,6 +233,16 @@ namespace OpenSearch.Client
 
 		[DataMember(Name = "name")]
 		public string Name { get; internal set; }
+	}
+
+	[DataContract]
+	public class ClusterOperatingSystemPrettyName
+	{
+		[DataMember(Name = "count")]
+		public int Count { get; internal set; }
+
+		[DataMember(Name = "pretty_name")]
+		public string PrettyName { get; internal set; }
 	}
 
 	[DataContract]

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.stats.json")]
 	public partial interface IClusterStatsRequest { }

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsResponse.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	public class ClusterStatsResponse : NodesResponseBase
 	{

--- a/src/OpenSearch.Client/Cluster/NodesInfo/NodeInfo.cs
+++ b/src/OpenSearch.Client/Cluster/NodesInfo/NodeInfo.cs
@@ -131,16 +131,6 @@ namespace OpenSearch.Client
 	}
 
 	[DataContract]
-	public class ClusterOperatingSystemPrettyNane
-	{
-		[DataMember(Name = "count")]
-		public int Count { get; internal set; }
-
-		[DataMember(Name = "pretty_name")]
-		public string PrettyName { get; internal set; }
-	}
-
-	[DataContract]
 	public class NodeInfoOSCPU
 	{
 		[DataMember(Name = "cache_size")]

--- a/src/OpenSearch.Client/Cluster/RemoteInfo/RemoteInfoRequest.cs
+++ b/src/OpenSearch.Client/Cluster/RemoteInfo/RemoteInfoRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.remote_info.json")]
 	public partial interface IRemoteInfoRequest { }

--- a/src/OpenSearch.Client/Cluster/RemoteInfo/RemoteInfoResponse.cs
+++ b/src/OpenSearch.Client/Cluster/RemoteInfo/RemoteInfoResponse.cs
@@ -31,7 +31,7 @@ using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[DataContract]
 	[JsonFormatter(typeof(DictionaryResponseFormatter<RemoteInfoResponse, string, RemoteInfo>))]

--- a/src/OpenSearch.Client/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsRequest.cs
@@ -32,7 +32,7 @@ using System.Threading.Tasks;
 using OpenSearch.Net;
 using OpenSearch.Net.Specification.ClusterApi;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.delete_voting_config_exclusions")]
 	public partial interface IDeleteVotingConfigExclusionsRequest { }

--- a/src/OpenSearch.Client/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsResponse.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	public class DeleteVotingConfigExclusionsResponse : ResponseBase
 	{

--- a/src/OpenSearch.Client/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsRequest.cs
+++ b/src/OpenSearch.Client/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsRequest.cs
@@ -32,7 +32,7 @@ using System.Threading.Tasks;
 using OpenSearch.Net;
 using OpenSearch.Net.Specification.ClusterApi;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[MapsApi("cluster.post_voting_config_exclusions")]
 	public partial interface IPostVotingConfigExclusionsRequest { }

--- a/src/OpenSearch.Client/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsResponse.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	public class PostVotingConfigExclusionsResponse : ResponseBase
 	{

--- a/src/OpenSearch.Client/Descriptors.Cluster.cs
+++ b/src/OpenSearch.Client/Descriptors.Cluster.cs
@@ -40,7 +40,7 @@ using OpenSearch.Net.Specification.ClusterApi;
 // ReSharper disable UnusedTypeParameter
 // ReSharper disable PartialMethodWithSinglePart
 // ReSharper disable RedundantNameQualifier
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	///<summary>Descriptor for AllocationExplain <para>https://opensearch.org/docs/latest/opensearch/rest-api/cluster-allocation/</para></summary>
 	public partial class ClusterAllocationExplainDescriptor : RequestDescriptorBase<ClusterAllocationExplainDescriptor, ClusterAllocationExplainRequestParameters, IClusterAllocationExplainRequest>, IClusterAllocationExplainRequest

--- a/src/OpenSearch.Client/OpenSearch.Client.csproj
+++ b/src/OpenSearch.Client/OpenSearch.Client.csproj
@@ -44,4 +44,7 @@
       <DependentUpon>OpenSearchClient.cs</DependentUpon>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Tasks\" />
+  </ItemGroup>
 </Project>

--- a/src/OpenSearch.Client/OpenSearch.Client.csproj
+++ b/src/OpenSearch.Client/OpenSearch.Client.csproj
@@ -44,7 +44,4 @@
       <DependentUpon>OpenSearchClient.cs</DependentUpon>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Tasks\" />
-  </ItemGroup>
 </Project>

--- a/src/OpenSearch.Client/Requests.Cluster.cs
+++ b/src/OpenSearch.Client/Requests.Cluster.cs
@@ -41,7 +41,7 @@ using OpenSearch.Net.Specification.ClusterApi;
 // ReSharper disable UnusedTypeParameter
 // ReSharper disable PartialMethodWithSinglePart
 // ReSharper disable RedundantNameQualifier
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.ClusterApi
 {
 	[InterfaceDataContract]
 	public partial interface IClusterAllocationExplainRequest : IRequest<ClusterAllocationExplainRequestParameters>

--- a/tests/Tests.Core/Extensions/ClientExtensions.cs
+++ b/tests/Tests.Core/Extensions/ClientExtensions.cs
@@ -28,6 +28,7 @@
 
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 
 namespace Tests.Core.Extensions
 {

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/ClientTestClusterBase.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/ClientTestClusterBase.cs
@@ -33,6 +33,7 @@ using OpenSearch.OpenSearch.Xunit;
 using OpenSearch.Stack.ArtifactsApi.Products;
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Configuration;
 using Tests.Core.Client;
 using Tests.Core.Extensions;

--- a/tests/Tests.Core/ManagedOpenSearch/NodeSeeders/DefaultSeeder.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/NodeSeeders/DefaultSeeder.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Configuration;
 using Tests.Core.Client;
 using Tests.Core.Extensions;

--- a/tests/Tests.Reproduce/GithubIssue3210.cs
+++ b/tests/Tests.Reproduce/GithubIssue3210.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.Client;
 
 namespace Tests.Reproduce

--- a/tests/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainApiTests.cs
+++ b/tests/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainApiTests.cs
@@ -30,6 +30,7 @@ using System;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;

--- a/tests/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 

--- a/tests/Tests/Cluster/ClusterHealth/ClusterHealthApiTests.cs
+++ b/tests/Tests/Cluster/ClusterHealth/ClusterHealthApiTests.cs
@@ -30,6 +30,7 @@ using System;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Domain;

--- a/tests/Tests/Cluster/ClusterHealth/ClusterHealthUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterHealth/ClusterHealthUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;

--- a/tests/Tests/Cluster/ClusterPendingTasks/ClusterPendingTasksApiTests.cs
+++ b/tests/Tests/Cluster/ClusterPendingTasks/ClusterPendingTasksApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cluster/ClusterPendingTasks/ClusterPendingTasksUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterPendingTasks/ClusterPendingTasksUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/ClusterReroute/ClusterRerouteApiTests.cs
+++ b/tests/Tests/Cluster/ClusterReroute/ClusterRerouteApiTests.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Core.ManagedOpenSearch.NodeSeeders;

--- a/tests/Tests/Cluster/ClusterReroute/ClusterRerouteUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterReroute/ClusterRerouteUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsApiTests.cs
+++ b/tests/Tests/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsApiTests.cs
@@ -28,6 +28,7 @@
 
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterSettings/ClusterGetSettings/ClusterGetSettingsUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsApiTests.cs
+++ b/tests/Tests/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutSettingsApiTests.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;

--- a/tests/Tests/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterSettings/ClusterPutSettings/ClusterPutUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
+++ b/tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cluster/ClusterState/ClusterStateUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterState/ClusterStateUrlTests.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
+++ b/tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cluster/ClusterStats/ClusterStatsUrlTests.cs
+++ b/tests/Tests/Cluster/ClusterStats/ClusterStatsUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/RemoteInfo/RemoteInfoApiTests.cs
+++ b/tests/Tests/Cluster/RemoteInfo/RemoteInfoApiTests.cs
@@ -29,6 +29,7 @@
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Domain;

--- a/tests/Tests/Cluster/RemoteInfo/RemoteInfoUrlTests.cs
+++ b/tests/Tests/Cluster/RemoteInfo/RemoteInfoUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsApiTests.cs
+++ b/tests/Tests/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteVotingConfigExclusionsApiTests.cs
@@ -32,6 +32,7 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Cluster.TaskManagement.GetTask;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;

--- a/tests/Tests/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteingVotingConfigExclusionsTests.cs
+++ b/tests/Tests/Cluster/VotingConfigExclusions/DeleteVotingConfigExclusions/DeleteingVotingConfigExclusionsTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsApiTests.cs
+++ b/tests/Tests/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostVotingConfigExclusionsApiTests.cs
@@ -32,6 +32,7 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Cluster.TaskManagement.GetTask;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;

--- a/tests/Tests/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostingVotingConfigExclusionsTests.cs
+++ b/tests/Tests/Cluster/VotingConfigExclusions/PostVotingConfigExclusions/PostingVotingConfigExclusionsTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.ClusterApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/CodeStandards/Descriptors.doc.cs
+++ b/tests/Tests/CodeStandards/Descriptors.doc.cs
@@ -33,6 +33,7 @@ using FluentAssertions;
 using OpenSearch.Client;
 using Tests.Framework;
 using System.Reflection;
+using OpenSearch.Client.Specification.ClusterApi;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 
 namespace Tests.CodeStandards


### PR DESCRIPTION
### Description
Moves cluster API requests in `OpenSearch.Client` into the `.Specification.ClusterApi` namespace.
Brings them inline with the rest of the parts of the client:
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Client/OpenSearchClient.Cluster.cs#L37
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Net/OpenSearchLowLevelClient.Cluster.cs#L44
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs#L37

Part of #196, but broken up by namespace to aid review-ability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
