### PR TITLE
Move dangling_indices API requests into the `.Specification.DanglingIndicesApi` namespace

### DIFF
--- a/src/OpenSearch.Client/DanglingIndices/Delete/DeleteDanglingIndexRequest.cs
+++ b/src/OpenSearch.Client/DanglingIndices/Delete/DeleteDanglingIndexRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
 	[MapsApi("dangling_indices.delete_dangling_index.json")]
 	public partial interface IDeleteDanglingIndexRequest

--- a/src/OpenSearch.Client/DanglingIndices/Delete/DeleteDanglingIndexResponse.cs
+++ b/src/OpenSearch.Client/DanglingIndices/Delete/DeleteDanglingIndexResponse.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
 	[DataContract]
 	public class DeleteDanglingIndexResponse : AcknowledgedResponseBase

--- a/src/OpenSearch.Client/DanglingIndices/Import/ImportDanglingIndexRequest.cs
+++ b/src/OpenSearch.Client/DanglingIndices/Import/ImportDanglingIndexRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
 	[MapsApi("dangling_indices.import_dangling_index.json")]
 	public partial interface IImportDanglingIndexRequest

--- a/src/OpenSearch.Client/DanglingIndices/Import/ImportDanglingIndexResponse.cs
+++ b/src/OpenSearch.Client/DanglingIndices/Import/ImportDanglingIndexResponse.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
 	[DataContract]
 	public class ImportDanglingIndexResponse : AcknowledgedResponseBase

--- a/src/OpenSearch.Client/DanglingIndices/List/ListDanglingIndicesRequest.cs
+++ b/src/OpenSearch.Client/DanglingIndices/List/ListDanglingIndicesRequest.cs
@@ -26,7 +26,7 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
 	[MapsApi("dangling_indices.list_dangling_indices.json")]
 	public partial interface IListDanglingIndicesRequest

--- a/src/OpenSearch.Client/DanglingIndices/List/ListDanglingIndicesResponse.cs
+++ b/src/OpenSearch.Client/DanglingIndices/List/ListDanglingIndicesResponse.cs
@@ -31,7 +31,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
 	[DataContract]
 	public class ListDanglingIndicesResponse : ResponseBase

--- a/src/OpenSearch.Client/Descriptors.DanglingIndices.cs
+++ b/src/OpenSearch.Client/Descriptors.DanglingIndices.cs
@@ -40,7 +40,7 @@ using OpenSearch.Net.Specification.DanglingIndicesApi;
 // ReSharper disable UnusedTypeParameter
 // ReSharper disable PartialMethodWithSinglePart
 // ReSharper disable RedundantNameQualifier
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
 	///<summary>Descriptor for DeleteDanglingIndex <para></para></summary>
 	public partial class DeleteDanglingIndexDescriptor : RequestDescriptorBase<DeleteDanglingIndexDescriptor, DeleteDanglingIndexRequestParameters, IDeleteDanglingIndexRequest>, IDeleteDanglingIndexRequest

--- a/src/OpenSearch.Client/Requests.DanglingIndices.cs
+++ b/src/OpenSearch.Client/Requests.DanglingIndices.cs
@@ -41,7 +41,7 @@ using OpenSearch.Net.Specification.DanglingIndicesApi;
 // ReSharper disable UnusedTypeParameter
 // ReSharper disable PartialMethodWithSinglePart
 // ReSharper disable RedundantNameQualifier
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
 	[InterfaceDataContract]
 	public partial interface IDeleteDanglingIndexRequest : IRequest<DeleteDanglingIndexRequestParameters>

--- a/tests/Tests/DanglingIndices/Delete/DeleteDanglingIndexApiTests.cs
+++ b/tests/Tests/DanglingIndices/Delete/DeleteDanglingIndexApiTests.cs
@@ -29,6 +29,7 @@
 using System;
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.DanglingIndicesApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/DanglingIndices/Delete/DeleteDanglingIndexUrlTests.cs
+++ b/tests/Tests/DanglingIndices/Delete/DeleteDanglingIndexUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.DanglingIndicesApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/DanglingIndices/Import/ImportDanglingIndexApiTests.cs
+++ b/tests/Tests/DanglingIndices/Import/ImportDanglingIndexApiTests.cs
@@ -29,6 +29,7 @@
 using System;
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.DanglingIndicesApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/DanglingIndices/Import/ImportDanglingIndexUrlTests.cs
+++ b/tests/Tests/DanglingIndices/Import/ImportDanglingIndexUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.DanglingIndicesApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/DanglingIndices/List/ListDanglingIndicesApiTests.cs
+++ b/tests/Tests/DanglingIndices/List/ListDanglingIndicesApiTests.cs
@@ -29,6 +29,7 @@
 using System;
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.DanglingIndicesApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/DanglingIndices/List/ListDanglingIndicesUrlTests.cs
+++ b/tests/Tests/DanglingIndices/List/ListDanglingIndicesUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.DanglingIndicesApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 


### PR DESCRIPTION
### Description
Moves dangling_indices API requests in `OpenSearch.Client` into the `.Specification.DanglingIndicesApi` namespace.
Brings them inline with the rest of the parts of the client:
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Client/OpenSearchClient.DanglingIndices.cs#L37
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Net/OpenSearchLowLevelClient.DanglingIndices.cs#L44
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.DanglingIndices.cs#L37

Part of #196, but broken up by namespace to aid review-ability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
