### PR TITLE
Move nodes API requests into the `.Specification.NodesApi` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### ⚠️ Breaking Changes ⚠️
-- Moved `OpenSearch.Client` request classes into their respective namespaces to match those in `OpenSearch.Net` ([#200](https://github.com/opensearch-project/opensearch-net/pull/200), [#202](https://github.com/opensearch-project/opensearch-net/pull/202), [#203](https://github.com/opensearch-project/opensearch-net/pull/203), [#205](https://github.com/opensearch-project/opensearch-net/pull/205), [#206](https://github.com/opensearch-project/opensearch-net/pull/206))
+- Moved `OpenSearch.Client` request classes into their respective namespaces to match those in `OpenSearch.Net` ([#200](https://github.com/opensearch-project/opensearch-net/pull/200), [#202](https://github.com/opensearch-project/opensearch-net/pull/202), [#203](https://github.com/opensearch-project/opensearch-net/pull/203), [#205](https://github.com/opensearch-project/opensearch-net/pull/205), [#206](https://github.com/opensearch-project/opensearch-net/pull/206), [#207](https://github.com/opensearch-project/opensearch-net/pull/207))
 
 ### Dependencies
 - Bumps `System.Reflection.Emit` from 4.3.0 to 4.7.0

--- a/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsResponse.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterStats/ClusterStatsResponse.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Client.Specification.NodesApi;
 
 namespace OpenSearch.Client.Specification.ClusterApi
 {

--- a/src/OpenSearch.Client/Descriptors.Nodes.cs
+++ b/src/OpenSearch.Client/Descriptors.Nodes.cs
@@ -40,7 +40,7 @@ using OpenSearch.Net.Specification.NodesApi;
 // ReSharper disable UnusedTypeParameter
 // ReSharper disable PartialMethodWithSinglePart
 // ReSharper disable RedundantNameQualifier
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
 	///<summary>Descriptor for HotThreads <para></para></summary>
 	public partial class NodesHotThreadsDescriptor : RequestDescriptorBase<NodesHotThreadsDescriptor, NodesHotThreadsRequestParameters, INodesHotThreadsRequest>, INodesHotThreadsRequest

--- a/src/OpenSearch.Client/Nodes/NodesHotThreads/NodeHotThreadsResponseBuilder.cs
+++ b/src/OpenSearch.Client/Nodes/NodesHotThreads/NodeHotThreadsResponseBuilder.cs
@@ -35,7 +35,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
 	internal class NodeHotThreadsResponseBuilder : CustomResponseBuilderBase
 	{

--- a/src/OpenSearch.Client/Nodes/NodesHotThreads/NodesHotThreadsRequest.cs
+++ b/src/OpenSearch.Client/Nodes/NodesHotThreads/NodesHotThreadsRequest.cs
@@ -26,56 +26,27 @@
 *  under the License.
 */
 
-using System.Runtime.Serialization;
 using OpenSearch.Net;
+using OpenSearch.Net.Specification.NodesApi;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	[StringEnum]
-	public enum NodeRole
+	[MapsApi("nodes.hot_threads.json")]
+	public partial interface INodesHotThreadsRequest { }
+
+	public partial class NodesHotThreadsRequest
 	{
-		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManager"/> instead</remarks>
-		[EnumMember(Value = "master")]
-		Master,
+		protected override string ContentType => RequestData.MimeTypeTextPlain;
 
-		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="Master"/></remarks>
-		[EnumMember(Value = "cluster_manager")]
-		ClusterManager,
+		protected sealed override void RequestDefaults(NodesHotThreadsRequestParameters parameters) =>
+			parameters.CustomResponseBuilder = NodeHotThreadsResponseBuilder.Instance;
+	}
 
-		[EnumMember(Value = "data")]
-		Data,
+	public partial class NodesHotThreadsDescriptor
+	{
+		protected override string ContentType => RequestData.MimeTypeTextPlain;
 
-		[EnumMember(Value = "data_cold")]
-		DataCold,
-
-		[EnumMember(Value = "data_frozen")]
-		DataFrozen,
-
-		[EnumMember(Value = "data_content")]
-		DataContent,
-
-		[EnumMember(Value = "data_hot")]
-		DataHot,
-
-		[EnumMember(Value = "data_warm")]
-		DataWarm,
-
-		[EnumMember(Value = "client")]
-		Client,
-
-		[EnumMember(Value = "ingest")]
-		Ingest,
-
-		[EnumMember(Value = "voting_only")]
-		VotingOnly,
-
-		[EnumMember(Value = "transform")]
-		Transform,
-
-		[EnumMember(Value = "remote_cluster_client")]
-		RemoteClusterClient,
-
-		[EnumMember(Value = "coordinating_only")]
-		CoordinatingOnly,
+		protected sealed override void RequestDefaults(NodesHotThreadsRequestParameters parameters) =>
+			parameters.CustomResponseBuilder = NodeHotThreadsResponseBuilder.Instance;
 	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesHotThreads/NodesHotThreadsResponse.cs
+++ b/src/OpenSearch.Client/Nodes/NodesHotThreads/NodesHotThreadsResponse.cs
@@ -27,22 +27,24 @@
 */
 
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using OpenSearch.Net;
-using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	public class NodeIngestStats
+	public class NodesHotThreadsResponse : ResponseBase
 	{
-		/// <summary> Per pipeline ingest statistics </summary>
-		[DataMember(Name = "pipelines")]
-		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, IngestStats>))]
-		public IReadOnlyDictionary<string, IngestStats> Pipelines { get; internal set; }
-			= EmptyReadOnly<string, IngestStats>.Dictionary;
+		public NodesHotThreadsResponse() { }
 
-		/// <summary> Overall global ingest statistics </summary>
-		[DataMember(Name = "total")]
-		public IngestStats Total { get; set; }
+		internal NodesHotThreadsResponse(IReadOnlyCollection<HotThreadInformation> threadInfo) => HotThreads = threadInfo;
+
+		public IReadOnlyCollection<HotThreadInformation> HotThreads { get; internal set; } = EmptyReadOnly<HotThreadInformation>.Collection;
+	}
+
+	public class HotThreadInformation
+	{
+		public IReadOnlyCollection<string> Hosts { get; internal set; } = EmptyReadOnly<string>.Collection;
+		public string NodeId { get; internal set; }
+		public string NodeName { get; internal set; }
+		public IReadOnlyCollection<string> Threads { get; internal set; } = EmptyReadOnly<string>.Collection;
 	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesInfo/NodeInfo.cs
+++ b/src/OpenSearch.Client/Nodes/NodesInfo/NodeInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
 	[DataContract]
 	public class NodeInfo

--- a/src/OpenSearch.Client/Nodes/NodesInfo/NodeRole.cs
+++ b/src/OpenSearch.Client/Nodes/NodesInfo/NodeRole.cs
@@ -26,25 +26,56 @@
 *  under the License.
 */
 
-using System.Collections.Generic;
+using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	public class NodesHotThreadsResponse : ResponseBase
+	[StringEnum]
+	public enum NodeRole
 	{
-		public NodesHotThreadsResponse() { }
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManager"/> instead</remarks>
+		[EnumMember(Value = "master")]
+		Master,
 
-		internal NodesHotThreadsResponse(IReadOnlyCollection<HotThreadInformation> threadInfo) => HotThreads = threadInfo;
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="Master"/></remarks>
+		[EnumMember(Value = "cluster_manager")]
+		ClusterManager,
 
-		public IReadOnlyCollection<HotThreadInformation> HotThreads { get; internal set; } = EmptyReadOnly<HotThreadInformation>.Collection;
-	}
+		[EnumMember(Value = "data")]
+		Data,
 
-	public class HotThreadInformation
-	{
-		public IReadOnlyCollection<string> Hosts { get; internal set; } = EmptyReadOnly<string>.Collection;
-		public string NodeId { get; internal set; }
-		public string NodeName { get; internal set; }
-		public IReadOnlyCollection<string> Threads { get; internal set; } = EmptyReadOnly<string>.Collection;
+		[EnumMember(Value = "data_cold")]
+		DataCold,
+
+		[EnumMember(Value = "data_frozen")]
+		DataFrozen,
+
+		[EnumMember(Value = "data_content")]
+		DataContent,
+
+		[EnumMember(Value = "data_hot")]
+		DataHot,
+
+		[EnumMember(Value = "data_warm")]
+		DataWarm,
+
+		[EnumMember(Value = "client")]
+		Client,
+
+		[EnumMember(Value = "ingest")]
+		Ingest,
+
+		[EnumMember(Value = "voting_only")]
+		VotingOnly,
+
+		[EnumMember(Value = "transform")]
+		Transform,
+
+		[EnumMember(Value = "remote_cluster_client")]
+		RemoteClusterClient,
+
+		[EnumMember(Value = "coordinating_only")]
+		CoordinatingOnly,
 	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesInfo/NodesInfoRequest.cs
+++ b/src/OpenSearch.Client/Nodes/NodesInfo/NodesInfoRequest.cs
@@ -26,19 +26,12 @@
 *  under the License.
 */
 
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using OpenSearch.Net;
-
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	public class NodesUsageResponse : NodesResponseBase
-	{
-		[DataMember(Name ="cluster_name")]
-		public string ClusterName { get; internal set; }
+	[MapsApi("nodes.info.json")]
+	public partial interface INodesInfoRequest { }
 
-		[DataMember(Name ="nodes")]
-		public IReadOnlyDictionary<string, NodeUsageInformation> Nodes { get; internal set; } =
-			EmptyReadOnly<string, NodeUsageInformation>.Dictionary;
-	}
+	public partial class NodesInfoRequest { }
+
+	public partial class NodesInfoDescriptor { }
 }

--- a/src/OpenSearch.Client/Nodes/NodesInfo/NodesInfoResponse.cs
+++ b/src/OpenSearch.Client/Nodes/NodesInfo/NodesInfoResponse.cs
@@ -31,15 +31,16 @@ using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	public class NodesStatsResponse : NodesResponseBase
+	[DataContract]
+	public class NodesInfoResponse : NodesResponseBase
 	{
-		[DataMember(Name = "cluster_name")]
+		[DataMember(Name ="cluster_name")]
 		public string ClusterName { get; internal set; }
 
-		[DataMember(Name = "nodes")]
-		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, NodeStats>))]
-		public IReadOnlyDictionary<string, NodeStats> Nodes { get; internal set; } = EmptyReadOnly<string, NodeStats>.Dictionary;
+		[DataMember(Name ="nodes")]
+		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, NodeInfo>))]
+		public IReadOnlyDictionary<string, NodeInfo> Nodes { get; internal set; } = EmptyReadOnly<string, NodeInfo>.Dictionary;
 	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesResponseBase.cs
+++ b/src/OpenSearch.Client/Nodes/NodesResponseBase.cs
@@ -26,12 +26,31 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	[MapsApi("nodes.info.json")]
-	public partial interface INodesInfoRequest { }
+	public abstract class NodesResponseBase : ResponseBase
+	{
+		[DataMember(Name = "_nodes")]
+		public NodeStatistics NodeStatistics { get; internal set; }
+	}
 
-	public partial class NodesInfoRequest { }
+	[DataContract]
+	public class NodeStatistics
+	{
+		[DataMember(Name = "failed")]
+		public int Failed { get; internal set; }
 
-	public partial class NodesInfoDescriptor { }
+		[DataMember(Name = "successful")]
+		public int Successful { get; internal set; }
+
+		[DataMember(Name = "total")]
+		public int Total { get; internal set; }
+
+		[DataMember(Name = "failures")]
+		public IReadOnlyCollection<ErrorCause> Failures { get; internal set; } = EmptyReadOnly<ErrorCause>.Collection;
+	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesStats/AdaptiveSelectionStats.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/AdaptiveSelectionStats.cs
@@ -28,7 +28,7 @@
 
 using System.Runtime.Serialization;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
 	[DataContract]
 	public class AdaptiveSelectionStats

--- a/src/OpenSearch.Client/Nodes/NodesStats/NodeStats.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/NodeStats.cs
@@ -31,7 +31,7 @@ using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
 	[DataContract]
 	public class NodeStats

--- a/src/OpenSearch.Client/Nodes/NodesStats/NodeStatsResponse.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/NodeStatsResponse.cs
@@ -26,30 +26,20 @@
 *  under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	public class NodeUsageInformation
+	public class NodesStatsResponse : NodesResponseBase
 	{
-		/// <summary>
-		/// Aggregation usage.
-		/// </summary>
-		[DataMember(Name ="aggregations")]
-		public IReadOnlyDictionary<string, IReadOnlyDictionary<string, long>> Aggregations { get; internal set; }
+		[DataMember(Name = "cluster_name")]
+		public string ClusterName { get; internal set; }
 
-		[DataMember(Name ="rest_actions")]
-		public IReadOnlyDictionary<string, int> RestActions { get; internal set; }
-
-		[DataMember(Name ="since")]
-		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
-		public DateTimeOffset Since { get; internal set; }
-
-		[DataMember(Name ="timestamp")]
-		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
-		public DateTimeOffset Timestamp { get; internal set; }
+		[DataMember(Name = "nodes")]
+		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, NodeStats>))]
+		public IReadOnlyDictionary<string, NodeStats> Nodes { get; internal set; } = EmptyReadOnly<string, NodeStats>.Dictionary;
 	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesStats/NodesStatsRequest.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/NodesStatsRequest.cs
@@ -26,12 +26,12 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	[MapsApi("nodes.usage.json")]
-	public partial interface INodesUsageRequest { }
+	[MapsApi("nodes.stats.json")]
+	public partial interface INodesStatsRequest { }
 
-	public partial class NodesUsageRequest { }
+	public partial class NodesStatsRequest { }
 
-	public partial class NodesUsageDescriptor { }
+	public partial class NodesStatsDescriptor { }
 }

--- a/src/OpenSearch.Client/Nodes/NodesStats/Statistics/IngestStats.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/Statistics/IngestStats.cs
@@ -31,7 +31,7 @@ using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
 	[DataContract]
 	public class IngestStats

--- a/src/OpenSearch.Client/Nodes/NodesStats/Statistics/NodeIngestStats.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/Statistics/NodeIngestStats.cs
@@ -26,12 +26,23 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using OpenSearch.Net;
+using OpenSearch.Net.Utf8Json;
+
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	[MapsApi("nodes.reload_secure_settings.json")]
-	public partial interface IReloadSecureSettingsRequest { }
+	public class NodeIngestStats
+	{
+		/// <summary> Per pipeline ingest statistics </summary>
+		[DataMember(Name = "pipelines")]
+		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, IngestStats>))]
+		public IReadOnlyDictionary<string, IngestStats> Pipelines { get; internal set; }
+			= EmptyReadOnly<string, IngestStats>.Dictionary;
 
-	public partial class ReloadSecureSettingsRequest { }
-
-	public partial class ReloadSecureSettingsDescriptor { }
+		/// <summary> Overall global ingest statistics </summary>
+		[DataMember(Name = "total")]
+		public IngestStats Total { get; set; }
+	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesUsage/NodeUsageInformation.cs
+++ b/src/OpenSearch.Client/Nodes/NodesUsage/NodeUsageInformation.cs
@@ -26,21 +26,30 @@
 *  under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	[DataContract]
-	public class NodesInfoResponse : NodesResponseBase
+	public class NodeUsageInformation
 	{
-		[DataMember(Name ="cluster_name")]
-		public string ClusterName { get; internal set; }
+		/// <summary>
+		/// Aggregation usage.
+		/// </summary>
+		[DataMember(Name ="aggregations")]
+		public IReadOnlyDictionary<string, IReadOnlyDictionary<string, long>> Aggregations { get; internal set; }
 
-		[DataMember(Name ="nodes")]
-		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, NodeInfo>))]
-		public IReadOnlyDictionary<string, NodeInfo> Nodes { get; internal set; } = EmptyReadOnly<string, NodeInfo>.Dictionary;
+		[DataMember(Name ="rest_actions")]
+		public IReadOnlyDictionary<string, int> RestActions { get; internal set; }
+
+		[DataMember(Name ="since")]
+		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
+		public DateTimeOffset Since { get; internal set; }
+
+		[DataMember(Name ="timestamp")]
+		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
+		public DateTimeOffset Timestamp { get; internal set; }
 	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesUsage/NodeUsageResponse.cs
+++ b/src/OpenSearch.Client/Nodes/NodesUsage/NodeUsageResponse.cs
@@ -30,27 +30,15 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	public abstract class NodesResponseBase : ResponseBase
+	public class NodesUsageResponse : NodesResponseBase
 	{
-		[DataMember(Name = "_nodes")]
-		public NodeStatistics NodeStatistics { get; internal set; }
-	}
+		[DataMember(Name ="cluster_name")]
+		public string ClusterName { get; internal set; }
 
-	[DataContract]
-	public class NodeStatistics
-	{
-		[DataMember(Name = "failed")]
-		public int Failed { get; internal set; }
-
-		[DataMember(Name = "successful")]
-		public int Successful { get; internal set; }
-
-		[DataMember(Name = "total")]
-		public int Total { get; internal set; }
-
-		[DataMember(Name = "failures")]
-		public IReadOnlyCollection<ErrorCause> Failures { get; internal set; } = EmptyReadOnly<ErrorCause>.Collection;
+		[DataMember(Name ="nodes")]
+		public IReadOnlyDictionary<string, NodeUsageInformation> Nodes { get; internal set; } =
+			EmptyReadOnly<string, NodeUsageInformation>.Dictionary;
 	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesUsage/NodesUsageRequest.cs
+++ b/src/OpenSearch.Client/Nodes/NodesUsage/NodesUsageRequest.cs
@@ -26,27 +26,12 @@
 *  under the License.
 */
 
-using OpenSearch.Net;
-using OpenSearch.Net.Specification.NodesApi;
-
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	[MapsApi("nodes.hot_threads.json")]
-	public partial interface INodesHotThreadsRequest { }
+	[MapsApi("nodes.usage.json")]
+	public partial interface INodesUsageRequest { }
 
-	public partial class NodesHotThreadsRequest
-	{
-		protected override string ContentType => RequestData.MimeTypeTextPlain;
+	public partial class NodesUsageRequest { }
 
-		protected sealed override void RequestDefaults(NodesHotThreadsRequestParameters parameters) =>
-			parameters.CustomResponseBuilder = NodeHotThreadsResponseBuilder.Instance;
-	}
-
-	public partial class NodesHotThreadsDescriptor
-	{
-		protected override string ContentType => RequestData.MimeTypeTextPlain;
-
-		protected sealed override void RequestDefaults(NodesHotThreadsRequestParameters parameters) =>
-			parameters.CustomResponseBuilder = NodeHotThreadsResponseBuilder.Instance;
-	}
+	public partial class NodesUsageDescriptor { }
 }

--- a/src/OpenSearch.Client/Nodes/ReloadSecureSettings/ReloadSecureSettingsRequest.cs
+++ b/src/OpenSearch.Client/Nodes/ReloadSecureSettings/ReloadSecureSettingsRequest.cs
@@ -26,20 +26,12 @@
 *  under the License.
 */
 
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using OpenSearch.Net;
-using OpenSearch.Net.Utf8Json;
-
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	public class ReloadSecureSettingsResponse : NodesResponseBase
-	{
-		[DataMember(Name = "cluster_name")]
-		public string ClusterName { get; internal set; }
+	[MapsApi("nodes.reload_secure_settings.json")]
+	public partial interface IReloadSecureSettingsRequest { }
 
-		[DataMember(Name = "nodes")]
-		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, NodeStats>))]
-		public IReadOnlyDictionary<string, NodeStats> Nodes { get; internal set; } = EmptyReadOnly<string, NodeStats>.Dictionary;
-	}
+	public partial class ReloadSecureSettingsRequest { }
+
+	public partial class ReloadSecureSettingsDescriptor { }
 }

--- a/src/OpenSearch.Client/Nodes/ReloadSecureSettings/ReloadSecureSettingsResponse.cs
+++ b/src/OpenSearch.Client/Nodes/ReloadSecureSettings/ReloadSecureSettingsResponse.cs
@@ -26,12 +26,20 @@
 *  under the License.
 */
 
-namespace OpenSearch.Client
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using OpenSearch.Net;
+using OpenSearch.Net.Utf8Json;
+
+namespace OpenSearch.Client.Specification.NodesApi
 {
-	[MapsApi("nodes.stats.json")]
-	public partial interface INodesStatsRequest { }
+	public class ReloadSecureSettingsResponse : NodesResponseBase
+	{
+		[DataMember(Name = "cluster_name")]
+		public string ClusterName { get; internal set; }
 
-	public partial class NodesStatsRequest { }
-
-	public partial class NodesStatsDescriptor { }
+		[DataMember(Name = "nodes")]
+		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, NodeStats>))]
+		public IReadOnlyDictionary<string, NodeStats> Nodes { get; internal set; } = EmptyReadOnly<string, NodeStats>.Dictionary;
+	}
 }

--- a/src/OpenSearch.Client/Requests.Nodes.cs
+++ b/src/OpenSearch.Client/Requests.Nodes.cs
@@ -41,7 +41,7 @@ using OpenSearch.Net.Specification.NodesApi;
 // ReSharper disable UnusedTypeParameter
 // ReSharper disable PartialMethodWithSinglePart
 // ReSharper disable RedundantNameQualifier
-namespace OpenSearch.Client
+namespace OpenSearch.Client.Specification.NodesApi
 {
 	[InterfaceDataContract]
 	public partial interface INodesHotThreadsRequest : IRequest<NodesHotThreadsRequestParameters>

--- a/tests/Tests/ClientConcepts/Connection/ConnectionReuseAndBalancing.cs
+++ b/tests/Tests/ClientConcepts/Connection/ConnectionReuseAndBalancing.cs
@@ -38,6 +38,7 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Core.ManagedOpenSearch;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Domain;

--- a/tests/Tests/Cluster/NodesHotThreads/NodesHotThreadsApiTests.cs
+++ b/tests/Tests/Cluster/NodesHotThreads/NodesHotThreadsApiTests.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cluster/NodesHotThreads/NodesHotThreadsUrlTests.cs
+++ b/tests/Tests/Cluster/NodesHotThreads/NodesHotThreadsUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/NodesInfo/NodesInfoApiTests.cs
+++ b/tests/Tests/Cluster/NodesInfo/NodesInfoApiTests.cs
@@ -32,6 +32,7 @@ using System.Linq;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
@@ -81,7 +82,7 @@ namespace Tests.Cluster.NodesInfo
 			nodesMetada.Successful.Should().BeGreaterThan(0);
 		}
 
-		protected void Assert(OpenSearch.Client.NodeInfo node)
+		protected void Assert(OpenSearch.Client.Specification.NodesApi.NodeInfo node)
 		{
 			node.Should().NotBeNull();
 			node.Name.Should().NotBeNullOrWhiteSpace();
@@ -159,7 +160,7 @@ namespace Tests.Cluster.NodesInfo
 			transport.PublishAddress.Should().NotBeNullOrWhiteSpace();
 		}
 
-		protected void Assert(OpenSearch.Client.NodeInfoHttp http)
+		protected void Assert(OpenSearch.Client.Specification.NodesApi.NodeInfoHttp http)
 		{
 			http.Should().NotBeNull();
 			http.BoundAddress.Should().NotBeEmpty();

--- a/tests/Tests/Cluster/NodesInfo/NodesInfoUrlTests.cs
+++ b/tests/Tests/Cluster/NodesInfo/NodesInfoUrlTests.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
+++ b/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Core.Client;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;

--- a/tests/Tests/Cluster/NodesStats/NodesStatsUrlTests.cs
+++ b/tests/Tests/Cluster/NodesStats/NodesStatsUrlTests.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 

--- a/tests/Tests/Cluster/NodesUsage/NodesUsageApiTests.cs
+++ b/tests/Tests/Cluster/NodesUsage/NodesUsageApiTests.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Core.Client;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;

--- a/tests/Tests/Cluster/NodesUsage/NodesUsageUrlTests.cs
+++ b/tests/Tests/Cluster/NodesUsage/NodesUsageUrlTests.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Framework.EndpointTests;
 
 namespace Tests.Cluster.NodesUsage

--- a/tests/Tests/Cluster/ReloadSecureSettings/ReloadSecureSettingsApiTests.cs
+++ b/tests/Tests/Cluster/ReloadSecureSettings/ReloadSecureSettingsApiTests.cs
@@ -30,6 +30,7 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Net;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;

--- a/tests/Tests/Cluster/ReloadSecureSettings/ReloadSecureSettingsUrlTests.cs
+++ b/tests/Tests/Cluster/ReloadSecureSettings/ReloadSecureSettingsUrlTests.cs
@@ -29,6 +29,7 @@
 using System.Threading.Tasks;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using OpenSearch.Client;
+using OpenSearch.Client.Specification.NodesApi;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 


### PR DESCRIPTION
### Description
Moves nodes API requests in `OpenSearch.Client` into the `.Specification.NodesApi` namespace.
Brings them inline with the rest of the parts of the client:
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Client/OpenSearchClient.Nodes.cs#L37
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Net/OpenSearchLowLevelClient.Nodes.cs#L44
- https://github.com/opensearch-project/opensearch-net/blob/main/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Nodes.cs#L37

Part of #196, but broken up by namespace to aid review-ability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
