### PR TITLE
Upgrade RazorLight and use embedded resource project

### DIFF
--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -15,10 +15,11 @@
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.47.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20371.2" />
-    <PackageReference Include="RazorLight" Version="2.1.0" />
+    <PackageReference Include="RazorLight" Version="2.3.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="RestSpecification\Core" />
+    <EmbeddedResource Include="Views\**\*.cshtml" />
   </ItemGroup>
 </Project>

--- a/src/ApiGenerator/CodeTemplatePage.cs
+++ b/src/ApiGenerator/CodeTemplatePage.cs
@@ -26,17 +26,16 @@
 *  under the License.
 */
 
-using System;
 using System.Threading.Tasks;
 using RazorLight;
 
-namespace ApiGenerator 
+namespace ApiGenerator
 {
-    /// <summary> This only exists to make the IDE tooling happy, not actually used to render the templates </summary>
-    public class CodeTemplatePage<TModel> : TemplatePage<TModel>
-    {
-        public override Task ExecuteAsync() => throw new NotImplementedException();
+    public abstract class CodeTemplatePage<TModel> : TemplatePage<TModel>
+	{
+		protected new Task IncludeAsync(string key, object model = null)
+			=> base.IncludeAsync(key.Replace('/', '.'), model);
 
-        public Task Execute() => Task.CompletedTask;
-    }
+		protected async Task IncludeGeneratorNotice() => await IncludeAsync("GeneratorNotice");
+	}
 }

--- a/src/ApiGenerator/Configuration/ViewLocations.cs
+++ b/src/ApiGenerator/Configuration/ViewLocations.cs
@@ -26,15 +26,12 @@
 *  under the License.
 */
 
-namespace ApiGenerator.Configuration 
+namespace ApiGenerator.Configuration
 {
     public static class ViewLocations
     {
-        public static string Root { get; } = $@"{GeneratorLocations.Root}Views/";
-        private static string HighLevelRoot { get; } = $@"{Root}/HighLevel/";
-        public static string HighLevel(params string[] paths) => HighLevelRoot + string.Join("/", paths);
-        
-        private static string LowLevelRoot { get; } = $@"{Root}/LowLevel/";
-        public static string LowLevel(params string[] paths) => LowLevelRoot + string.Join("/", paths);
+        public static string HighLevel(params string[] paths) => "HighLevel." + string.Join(".", paths);
+
+        public static string LowLevel(params string[] paths) => "LowLevel." + string.Join(".", paths);
     }
 }

--- a/src/ApiGenerator/Generator/Razor/ApiUrlsLookupsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/ApiUrlsLookupsGenerator.cs
@@ -43,7 +43,7 @@ namespace ApiGenerator.Generator.Razor
             var view = ViewLocations.HighLevel("Requests", "ApiUrlsLookup.cshtml");
             var target = GeneratorLocations.HighLevel("_Generated", "ApiUrlsLookup.generated.cs");
 
-            await DoRazor(spec, view, target, null, token);
+            await DoRazor(spec, view, target, token);
         }
     }
 }

--- a/src/ApiGenerator/Generator/Razor/DescriptorsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/DescriptorsGenerator.cs
@@ -48,7 +48,7 @@ namespace ApiGenerator.Generator.Razor
 
             var view = ViewLocations.HighLevel("Descriptors", "RequestDescriptorBase.cshtml");
             var target = GeneratorLocations.HighLevel("Descriptors.cs");
-            await DoRazor(spec, view, target, null, token);
+            await DoRazor(spec, view, target, token);
 
             var dependantView = ViewLocations.HighLevel("Descriptors", "Descriptors.cshtml");
             string Target(string id) => GeneratorLocations.HighLevel($"Descriptors.{id}.cs");

--- a/src/ApiGenerator/Generator/Razor/EnumsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/EnumsGenerator.cs
@@ -43,7 +43,7 @@ namespace ApiGenerator.Generator.Razor
             var view = ViewLocations.LowLevel("Enums.Generated.cshtml");
             var target = GeneratorLocations.LowLevel("Api", "Enums.Generated.cs");
 
-            await DoRazor(spec, view, target, null, token);
+            await DoRazor(spec, view, target, token);
         }
     }
 }

--- a/src/ApiGenerator/Generator/Razor/HighLevelClientImplementationGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/HighLevelClientImplementationGenerator.cs
@@ -49,7 +49,7 @@ namespace ApiGenerator.Generator.Razor
 
             var view = ViewLocations.HighLevel("Client", "Implementation", "OpenSearchClient.cshtml");
             var target = GeneratorLocations.HighLevel($"OpenSearchClient.{CsharpNames.RootNamespace}.cs");
-            await DoRazor(spec, view, target, null, token);
+            await DoRazor(spec, view, target, token);
 
             string Target(string id) => GeneratorLocations.HighLevel($"OpenSearchClient.{id}.cs");
 

--- a/src/ApiGenerator/Generator/Razor/HighLevelClientInterfaceGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/HighLevelClientInterfaceGenerator.cs
@@ -43,7 +43,7 @@ namespace ApiGenerator.Generator.Razor
             var view = ViewLocations.HighLevel("Client", "Interface", "IOpenSearchClient.cshtml");
             var target = GeneratorLocations.HighLevel("IOpenSearchClient.Generated.cs");
 
-            await DoRazor(spec, view, target, null, token);
+            await DoRazor(spec, view, target, token);
         }
     }
 }

--- a/src/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
@@ -49,7 +49,7 @@ namespace ApiGenerator.Generator.Razor
 
             var view = ViewLocations.LowLevel("Client", "Implementation", "OpenSearchLowLevelClient.cshtml");
             var target = GeneratorLocations.LowLevel($"OpenSearchLowLevelClient.{CsharpNames.RootNamespace}.cs");
-            await DoRazor(spec, view, target, null, token);
+            await DoRazor(spec, view, target, token);
 
             var namespaced = spec.EndpointsPerNamespaceLowLevel.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
             var namespacedView = ViewLocations.LowLevel("Client", "Implementation", "OpenSearchLowLevelClient.Namespace.cshtml");

--- a/src/ApiGenerator/Generator/Razor/LowLevelClientInterfaceGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/LowLevelClientInterfaceGenerator.cs
@@ -43,7 +43,7 @@ namespace ApiGenerator.Generator.Razor
             var view = ViewLocations.LowLevel("Client", "Interface", "IOpenSearchLowLevelClient.cshtml");
             var target = GeneratorLocations.LowLevel("IOpenSearchLowLevelClient.Generated.cs");
 
-            await DoRazor(spec, view, target, null, token);
+            await DoRazor(spec, view, target, token);
         }
     }
 }

--- a/src/ApiGenerator/Generator/Razor/RequestsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/RequestsGenerator.cs
@@ -48,7 +48,7 @@ namespace ApiGenerator.Generator.Razor
 
             var view = ViewLocations.HighLevel("Requests", "PlainRequestBase.cshtml");
             var target = GeneratorLocations.HighLevel("Requests.cs");
-            await DoRazor(spec, view, target, null, token);
+            await DoRazor(spec, view, target, token);
 
             var dependantView = ViewLocations.HighLevel("Requests", "Requests.cshtml");
             string Target(string id) => GeneratorLocations.HighLevel($"Requests.{id}.cs");

--- a/src/ApiGenerator/Program.cs
+++ b/src/ApiGenerator/Program.cs
@@ -77,7 +77,7 @@ namespace ApiGenerator
                 AnsiConsole.WriteLine();
                 AnsiConsole.Write(new Rule("[b white on darkred] Exception [/]").LeftJustified());
                 AnsiConsole.WriteLine();
-                AnsiConsole.WriteException(ex);
+                AnsiConsole.WriteException(ex, ExceptionFormats.ShowLinks);
                 return 1;
             }
             return 0;

--- a/src/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentMethod.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentMethod.cshtml
@@ -2,19 +2,17 @@
 @using ApiGenerator.Domain.Code.HighLevel.Methods
 @inherits ApiGenerator.CodeTemplatePage<FluentSyntaxView>
 @{
-    FluentSyntaxBase syntax = Model.Syntax;
-    
-    var method = !Model.Async ? syntax.MethodName : string.Format("{0}Async", syntax.MethodName);
+	var method = !Model.Async ? Model.Syntax.MethodName : string.Format("{0}Async", Model.Syntax.MethodName);
     var asyncKeyword = Model.Syntax.InterfaceResponse && Model.Async ? "async " : String.Empty;
     var awaitKeyWord = Model.Syntax.InterfaceResponse && Model.Async ? "await ": string.Empty;
     var configureAwait = Model.Syntax.InterfaceResponse && Model.Async ? ".ConfigureAwait(false)" : String.Empty;
     
-    var requestMethodGenerics = syntax.RequestMethodGenerics;
-    var descriptor = syntax.DescriptorName;
-    var selectorArgs = syntax.SelectorArguments();
-    var selectorChained = syntax.SelectorChainedDefaults();
+    var requestMethodGenerics = Model.Syntax.RequestMethodGenerics;
+    var descriptor = Model.Syntax.DescriptorName;
+    var selectorArgs = Model.Syntax.SelectorArguments();
+    var selectorChained = Model.Syntax.SelectorChainedDefaults();
     var cancellationToken = !Model.Async ? string.Empty : ", ct";
 }
-@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", syntax); }
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", Model.Syntax); }
 public @(asyncKeyword)@{ await IncludeAsync("HighLevel/Client/FluentSyntax/FluentMethodHeader.cshtml", Model);} @Raw("=>")
     @(awaitKeyWord)@(method)@(Raw(requestMethodGenerics))(selector.InvokeOrDefault(new @(Raw(descriptor))(@Raw(selectorArgs))@(@selectorChained))@cancellationToken)@Raw(configureAwait);

--- a/src/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentMethodHeader.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentMethodHeader.cshtml
@@ -1,16 +1,14 @@
 @using ApiGenerator.Domain.Code.HighLevel.Methods
 @inherits ApiGenerator.CodeTemplatePage<FluentSyntaxView>
 @{
-    FluentSyntaxBase syntax = Model.Syntax;
-
-    var response = !Model.Async ? syntax.ResponseName : string.Format("Task<{0}>", syntax.ResponseName);
-    var method = !Model.Async ? syntax.MethodName : string.Format("{0}Async", syntax.MethodName);
+	var response = !Model.Async ? Model.Syntax.ResponseName : string.Format("Task<{0}>", Model.Syntax.ResponseName);
+    var method = !Model.Async ? Model.Syntax.MethodName : string.Format("{0}Async", Model.Syntax.MethodName);
     
-    var methodGenerics = syntax.MethodGenerics;
-    var descriptorArgs = syntax.DescriptorArguments();
-    var selector = syntax.Selector;
-    var optionalSelector = syntax.OptionalSelectorSuffix;
-    var whereClause = syntax.GenericWhereClause;
+    var methodGenerics = Model.Syntax.MethodGenerics;
+    var descriptorArgs = Model.Syntax.DescriptorArguments();
+    var selector = Model.Syntax.Selector;
+    var optionalSelector = Model.Syntax.OptionalSelectorSuffix;
+    var whereClause = Model.Syntax.GenericWhereClause;
     var cancellationToken = !Model.Async ? string.Empty : ", CancellationToken ct = default";
 }
 @Raw(response) @(method)@(Raw(methodGenerics))(@(Raw(descriptorArgs))@(Raw(selector)) selector@(optionalSelector)@(cancellationToken))@whereClause

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/MethodImplementation.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/MethodImplementation.cshtml
@@ -3,18 +3,17 @@
 @using HighLevelModel = ApiGenerator.Domain.Code.HighLevel.Methods.HighLevelModel
 @inherits CodeTemplatePage<HighLevelModel>
 @{
-    HighLevelModel model = Model;
-    var fluentPath = "HighLevel/Client/FluentSyntax/FluentMethod.cshtml";
-    var initializerPath = "HighLevel/Client/InitializerSyntax/InitializerMethod.cshtml";
+	const string fluentPath = "HighLevel/Client/FluentSyntax/FluentMethod.cshtml";
+	const string initializerPath = "HighLevel/Client/InitializerSyntax/InitializerMethod.cshtml";
 }
-@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: false)); }
-@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: true)); }
-@if (model.FluentBound != null)
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.Fluent, async: false)); }
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.Fluent, async: true)); }
+@if (Model.FluentBound != null)
 {
 <text>
-    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: false)); }
-    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: true)); }
+    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.FluentBound, async: false)); }
+    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.FluentBound, async: true)); }
 </text>
 }
-@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: false)); }
-@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: true)); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(Model.Initializer, async: false)); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(Model.Initializer, async: true)); }

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.Namespace.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.Namespace.cshtml
@@ -5,30 +5,28 @@
 @using ApiGenerator.Domain.Specification
 @inherits ApiGenerator.CodeTemplatePage<KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>>>
 @{
-    KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>> model = Model;
-    string ns = model.Key;
-    var endpoints = model.Value;
+	var (ns, endpoints) = Model;
 }
-@{ await IncludeAsync("GeneratorNotice.cshtml", model); }
+@{ await IncludeGeneratorNotice(); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenSearch.Net.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamespaceSuffix);
+using OpenSearch.Net.@(CsharpNames.ApiNamespace).@ns@(CsharpNames.ApiNamespaceSuffix);
 
 // ReSharper disable once CheckNamespace
 // ReSharper disable RedundantTypeArgumentsOfMethod
-namespace OpenSearch.Client.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamespaceSuffix)
+namespace OpenSearch.Client.@(CsharpNames.ApiNamespace).@ns@(CsharpNames.ApiNamespaceSuffix)
 {
     ///<summary>
-    /// @(ns.SplitPascalCase()) APIs.
+    /// @ns.SplitPascalCase() APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.@ns"/> property
     /// on <see cref="IOpenSearchClient"/>.
     ///</para>
     ///</summary>
-    public class @(CsharpNames.HighLevelClientNamespacePrefix)@(model.Key)@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy
+    public class @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy
     {
-        internal @(CsharpNames.HighLevelClientNamespacePrefix)@(model.Key)@(CsharpNames.ClientNamespaceSuffix)(OpenSearchClient client) : base(client) {}
+        internal @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix)(OpenSearchClient client) : base(client) {}
         @foreach(var e in endpoints)
         {
             await IncludeAsync("HighLevel/Client/Implementation/MethodImplementation.cshtml", e.HighLevelModel);

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.cshtml
@@ -3,7 +3,7 @@
 @using ApiGenerator 
 @using ApiGenerator.Domain.Code
 @inherits CodeTemplatePage<RestApiSpec>
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Threading;
@@ -12,8 +12,7 @@ using OpenSearch.Client;
 @{ await IncludeAsync("HighLevel/Client/Usings.cshtml", Model);}
 
 @{
-    RestApiSpec model = Model;
-    var namespaces = model.EndpointsPerNamespaceHighLevel.Keys.Where(k => k != CsharpNames.RootNamespace).ToList();
+	var namespaces = Model.EndpointsPerNamespaceHighLevel.Keys.Where(k => k != CsharpNames.RootNamespace).ToList();
 <text>
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client
@@ -44,7 +43,7 @@ namespace OpenSearch.Client
 </text>
     
 
-    foreach (var kv in model.EndpointsPerNamespaceHighLevel)
+    foreach (var kv in Model.EndpointsPerNamespaceHighLevel)
     {
         if (kv.Key != CsharpNames.RootNamespace)
         {

--- a/src/ApiGenerator/Views/HighLevel/Client/InitializerSyntax/InitializerMethod.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/InitializerSyntax/InitializerMethod.cshtml
@@ -2,11 +2,9 @@
 @using ApiGenerator.Domain.Code.HighLevel.Methods
 @inherits ApiGenerator.CodeTemplatePage<InitializerSyntaxView>
 @{
-    InitializerMethod syntax = Model.Syntax;
-    
-    var dispatchMethod = !Model.Async ? syntax.DispatchMethod : string.Format("{0}Async", syntax.DispatchMethod);
-    var dispatchGenerics = syntax.DispatchGenerics;
-    var dispatchParameters = syntax.DispatchParameters;
+	var dispatchMethod = !Model.Async ? Model.Syntax.DispatchMethod : string.Format("{0}Async", Model.Syntax.DispatchMethod);
+    var dispatchGenerics = Model.Syntax.DispatchGenerics;
+    var dispatchParameters = Model.Syntax.DispatchParameters;
     var asyncKeyword = Model.Syntax.InterfaceResponse && Model.Async ? "async " : String.Empty;
     var awaitKeyWord = Model.Syntax.InterfaceResponse && Model.Async ? "await ": string.Empty;
     var configureAwait = Model.Syntax.InterfaceResponse && Model.Async ? ".ConfigureAwait(false)" : String.Empty;
@@ -15,7 +13,7 @@
         dispatchParameters += ", ct";
     }
 }
-@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", syntax); }
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", Model.Syntax); }
 public @Raw(asyncKeyword)@{ await IncludeAsync("HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml", Model); } @Raw("=>")
     @(awaitKeyWord)@(dispatchMethod)@(Raw(dispatchGenerics))(@Raw(dispatchParameters))@Raw(configureAwait);
 

--- a/src/ApiGenerator/Views/HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml
@@ -1,17 +1,15 @@
 @using ApiGenerator.Domain.Code.HighLevel.Methods
 @inherits ApiGenerator.CodeTemplatePage<InitializerSyntaxView>
 @{
-    InitializerMethod syntax = Model.Syntax;
-    
-    var response = !Model.Async ? syntax.ResponseName : string.Format("Task<{0}>", syntax.ResponseName);
-    var method = !Model.Async ? syntax.MethodName : string.Format("{0}Async", syntax.MethodName);
-    var requestMethodGenerics = syntax.MethodGenerics;
+	var response = !Model.Async ? Model.Syntax.ResponseName : string.Format("Task<{0}>", Model.Syntax.ResponseName);
+    var method = !Model.Async ? Model.Syntax.MethodName : string.Format("{0}Async", Model.Syntax.MethodName);
+    var requestMethodGenerics = Model.Syntax.MethodGenerics;
 
-    var methodsArgs = string.Format("{0} request", syntax.ArgumentType);
+    var methodsArgs = string.Format("{0} request", Model.Syntax.ArgumentType);
     if (Model.Async)
     {
         methodsArgs += ", CancellationToken ct = default";
     }
-    var whereClause = syntax.GenericWhereClause;
+    var whereClause = Model.Syntax.GenericWhereClause;
 }
 @Raw(response) @(method)@(Raw(requestMethodGenerics))(@Raw(methodsArgs))@whereClause

--- a/src/ApiGenerator/Views/HighLevel/Client/Interface/IOpenSearchClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Interface/IOpenSearchClient.cshtml
@@ -3,7 +3,7 @@
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -20,17 +20,16 @@ namespace OpenSearch.Client
     ///</summary>
     public partial interface IOpenSearchClient 
     {
-        @foreach(var kv in Model.EndpointsPerNamespaceHighLevel)
+        @foreach(var (ns, endpoints) in Model.EndpointsPerNamespaceHighLevel)
         {
-        if (kv.Key != CsharpNames.RootNamespace)
+        if (ns != CsharpNames.RootNamespace)
         {
-<text>      ///<summary>@(kv.Key.SplitPascalCase()) APIs</summary>
-            @CsharpNames.HighLevelClientNamespacePrefix@(kv.Key)@CsharpNames.ClientNamespaceSuffix @kv.Key { get; }
+<text>      ///<summary>@ns.SplitPascalCase() APIs</summary>
+            @CsharpNames.HighLevelClientNamespacePrefix@(ns)@CsharpNames.ClientNamespaceSuffix @ns { get; }
 </text>
             continue;
         }
-            var endpoints = kv.Value;
-            var models = endpoints.Select(e=>e.HighLevelModel).ToList();
+	        var models = endpoints.Select(e=>e.HighLevelModel).ToList();
             foreach(var m in models)
             {
                 await IncludeAsync("HighLevel/Client/Interface/MethodInterface.cshtml", m);

--- a/src/ApiGenerator/Views/HighLevel/Client/Interface/MethodInterface.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Interface/MethodInterface.cshtml
@@ -3,27 +3,27 @@
 @using HighLevelModel = ApiGenerator.Domain.Code.HighLevel.Methods.HighLevelModel
 @inherits CodeTemplatePage<HighLevelModel>
 @{
-    HighLevelModel model = Model;
-    var fluentPath = "HighLevel/Client/FluentSyntax/FluentMethodHeader.cshtml";
-    var initializerPath = "HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml";
+	const string fluentPath = "HighLevel/Client/FluentSyntax/FluentMethodHeader.cshtml";
+	const string initializerPath = "HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml";
+	const string xmlDocsPath = "HighLevel/Client/MethodXmlDocs.cshtml";
 }
 
-@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Fluent); }
-@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: false)); };
-@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Fluent); }
-@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: true)); };
+@{ await IncludeAsync(xmlDocsPath, Model.Fluent); }
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.Fluent, async: false)); };
+@{ await IncludeAsync(xmlDocsPath, Model.Fluent); }
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.Fluent, async: true)); };
 
-@if (model.FluentBound != null)
+@if (Model.FluentBound != null)
 {
 <text>
-    @{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.FluentBound); }
-    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: false)); };
-    @{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.FluentBound); }
-    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: true)); };
+    @{ await IncludeAsync(xmlDocsPath, Model.FluentBound); }
+    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.FluentBound, async: false)); };
+    @{ await IncludeAsync(xmlDocsPath, Model.FluentBound); }
+    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.FluentBound, async: true)); };
 </text>
 }
-@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Initializer); }
-@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: false)); };
-@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Initializer); }
-@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: true)); };
+@{ await IncludeAsync(xmlDocsPath, Model.Initializer); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(Model.Initializer, async: false)); };
+@{ await IncludeAsync(xmlDocsPath, Model.Initializer); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(Model.Initializer, async: true)); };
 

--- a/src/ApiGenerator/Views/HighLevel/Client/MethodXmlDocs.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/MethodXmlDocs.cshtml
@@ -1,11 +1,8 @@
 @using ApiGenerator
 @using ApiGenerator.Domain.Code.HighLevel.Methods;
 @inherits CodeTemplatePage<MethodSyntaxBase>
-@{
-    var syntax = Model;
-}
 /// <summary>
-/// @Raw(syntax.XmlDocSummary)
+/// @Raw(Model.XmlDocSummary)
 /// @Raw("<para></para>")
-/// <a href="@syntax.DocumentationLink">@syntax.DocumentationLink</a>
+/// <a href="@Model.DocumentationLink">@Model.DocumentationLink</a>
 /// </summary>

--- a/src/ApiGenerator/Views/HighLevel/Client/Usings.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Usings.cshtml
@@ -1,11 +1,11 @@
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@foreach(var kv in Model.EndpointsPerNamespaceHighLevel)
+@foreach(var ns in Model.EndpointsPerNamespaceHighLevel.Keys)
 {
-    if (kv.Key != CsharpNames.RootNamespace)
+    if (ns != CsharpNames.RootNamespace)
     {
-<text>using OpenSearch.Client.@(CsharpNames.ApiNamespace).@(kv.Key)@(CsharpNames.ApiNamespaceSuffix);
+<text>using OpenSearch.Client.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamespaceSuffix);
 </text>
     }
 }

--- a/src/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
@@ -1,33 +1,31 @@
 @using System.Linq
 @using ApiGenerator
 @using ApiGenerator.Domain.Code.HighLevel.Requests
-@using ApiGenerator.Domain.Specification
 @using ApiGenerator.Generator
 @inherits global::ApiGenerator.CodeTemplatePage<DescriptorPartialImplementation>
 @{
-    DescriptorPartialImplementation d = Model;
-    var names = d.CsharpNames;
+	var names = Model.CsharpNames;
     var type = names.GenericOrNonGenericDescriptorName;
     var concreteInterface = names.GenericOrNonGenericInterfaceName;
     var baseInterface = names.GenericOrNonGenericInterfacePreference;
-    var apiLookup = $"ApiUrlsLookups.{d.CsharpNames.Namespace}{d.CsharpNames.MethodName}";
+    var apiLookup = $"ApiUrlsLookups.{Model.CsharpNames.Namespace}{Model.CsharpNames.MethodName}";
 }
-    ///<summary>Descriptor for @names.MethodName@Raw(d.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + d.OfficialDocumentationLink + "</para>")</summary>
+    ///<summary>Descriptor for @names.MethodName@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
     public partial class @Raw(type) @(Raw(string.Format(" : RequestDescriptorBase<{0},{1}, {2}>, {2}", type,names.ParametersName, concreteInterface)))
     { 
         internal override ApiUrls ApiUrls => @apiLookup;
-@foreach (Constructor c in d.Constructors)
+@foreach (var c in Model.Constructors)
 {
 <text>      @(Raw(CodeGenerator.Constructor(c)))
 </text>
 }
         // values part of the url path
-@foreach (UrlPart part in d.Parts)
+@foreach (var part in Model.Parts)
 {
 <text>      @(Raw(part.HighLevelTypeName)) @(Raw(baseInterface)).@(part.InterfaceName) => Self.RouteValues.Get@(Raw(string.Format("<{0}>",part.HighLevelTypeName)))("@(part.Name)");
 </text>
 }
-@foreach (FluentRouteSetter c in d.GetFluentRouteSetters())
+@foreach (var c in Model.GetFluentRouteSetters())
 {
 <text>
         @(Raw(c.XmlDoc))
@@ -35,16 +33,16 @@
 </text>
 }
         // Request parameters
-@foreach (var param in d.Params)
+@foreach (var param in Model.Params)
 {
     var original = param.QueryStringKey;
     //skip parameters already part of the path portion of the url
-    if (d.Parts.Any(p=>p.Name == original))
+    if (Model.Parts.Any(p=>p.Name == original))
     {
         continue;
     }
     //we prefer this parameter to be explictly implemented on the request body
-    if (param.RenderPartial && (d.HasBody))
+    if (param.RenderPartial && (Model.HasBody))
     {
         continue;
     }

--- a/src/ApiGenerator/Views/HighLevel/Descriptors/Descriptors.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Descriptors/Descriptors.cshtml
@@ -1,15 +1,13 @@
-@using System.Collections.Generic
 @using System.Collections.ObjectModel
 @using ApiGenerator
 @using ApiGenerator.Domain.Specification
 @using ApiGenerator.Domain.Code
 @inherits CodeTemplatePage<KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>>>
 @{
-    KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>> model = Model;
-    string ns = model.Key != CsharpNames.RootNamespace ? "."+CsharpNames.ApiNamespace+"." + model.Key + CsharpNames.ApiNamespaceSuffix : null;
-    var endpoints = model.Value;
+	var (ns, endpoints) = Model;
+	ns = ns != CsharpNames.RootNamespace ? $".{CsharpNames.ApiNamespace}.{ns}{CsharpNames.ApiNamespaceSuffix}" : null;
 }
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -19,7 +17,7 @@ using System.Linq.Expressions;
 
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
-@if (model.Key != CsharpNames.RootNamespace)
+@if (ns != CsharpNames.RootNamespace)
 {
     <text>using OpenSearch.Net@(ns);
 </text>

--- a/src/ApiGenerator/Views/HighLevel/Descriptors/XmlDocs.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Descriptors/XmlDocs.cshtml
@@ -1,11 +1,8 @@
-@using System
 @using System.Linq
-@using System.Collections.Generic
 @inherits ApiGenerator.CodeTemplatePage<List<string>>
 @{
-    List<string> summary = Model;
-    var description = summary.Count == 1 ? summary.First() : string.Join($"{Environment.NewLine}\t\t", summary.Select(d => "/// " + d));
-    if (summary.Count == 1)
+	var description = Model.Count == 1 ? Model.First() : string.Join($"{Environment.NewLine}\t\t", Model.Select(d => "/// " + d));
+    if (Model.Count == 1)
     {
 <text>      ///<summary>@Raw(description)</summary></text>
     }

--- a/src/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
@@ -3,15 +3,12 @@
 @using ApiGenerator
 @using ApiGenerator.Configuration
 @inherits CodeTemplatePage<RestApiSpec>
-@{
-    RestApiSpec m = Model;
-}
-@{ await IncludeAsync("GeneratorNotice.cshtml", m); }
+@{ await IncludeGeneratorNotice(); }
 namespace OpenSearch.Client
 {
     internal static class ApiUrlsLookups 
     {
-@foreach (var endpoint in m.Endpoints.Values)
+@foreach (var endpoint in Model.Endpoints.Values)
 {
     if (CodeConfiguration.IgnoreHighLevelApi(endpoint.Name))
     {

--- a/src/ApiGenerator/Views/HighLevel/Requests/PlainRequestBase.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/PlainRequestBase.cshtml
@@ -1,7 +1,6 @@
-@using System.Linq
 @using ApiGenerator.Domain
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;

--- a/src/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
@@ -1,20 +1,17 @@
 @using System.Linq
 @using ApiGenerator
-@using ApiGenerator.Domain.Code
 @using ApiGenerator.Domain.Code.HighLevel.Requests
 @using ApiGenerator.Domain.Specification
 @using ApiGenerator.Generator
 @inherits global::ApiGenerator.CodeTemplatePage<RequestPartialImplementation>
 @{
-    RequestPartialImplementation r = Model;
-    CsharpNames names = r.CsharpNames;
-    var apiLookup = $"ApiUrlsLookups.{r.CsharpNames.Namespace}{r.CsharpNames.MethodName}";
+	var apiLookup = $"ApiUrlsLookups.{Model.CsharpNames.Namespace}{Model.CsharpNames.MethodName}";
 }
-///<summary>Request for @names.MethodName@Raw(r.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + r.OfficialDocumentationLink + "</para>")</summary>
-@if (r.Stability != Stability.Stable)
+///<summary>Request for @Model.CsharpNames.MethodName@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
+@if (Model.Stability != Stability.Stable)
 {
     string warningMessage = "";
-    switch (r.Stability)
+    switch (Model.Stability)
     {
         case Stability.Experimental:
             warningMessage = "this functionality is experimental and may be changed or removed completely in a future release. OpenSearch will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.";
@@ -24,59 +21,58 @@
             break;
     }
             
-<text>///@Raw("<remarks>Note: " + r.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
-    </text>
-}
-    public partial class @Raw(r.Name) @Raw(string.Format(": PlainRequestBase<{0}>, {1}", names.ParametersName, r.InterfaceName))
-    {
-        protected @(Raw(r.InterfaceName)) Self => this;
+<text>///@Raw("<remarks>Note: " + Model.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
+
+</text>}
+    public partial class @Raw(Model.Name) @Raw(string.Format(": PlainRequestBase<{0}>, {1}", Model.CsharpNames.ParametersName, Model.InterfaceName))
+{
+        protected @Raw(Model.InterfaceName) Self => this;
         internal override ApiUrls ApiUrls => @apiLookup;
-@foreach (Constructor c in r.Constructors)
+@foreach (var c in Model.Constructors)
 {
 <text>      @(Raw(CodeGenerator.Constructor(c)))
 </text>
 }
         // values part of the url path
-@foreach (var part in r.Parts)
+@foreach (var part in Model.Parts)
 {
 <text>      [IgnoreDataMember]
-        @(Raw(part.HighLevelTypeName)) @(Raw(r.InterfaceName)).@(part.InterfaceName) => Self.RouteValues.Get@(Raw(string.Format("<{0}>", part.HighLevelTypeName)))("@(part.Name)");
+        @(Raw(part.HighLevelTypeName)) @(Raw(Model.InterfaceName)).@(part.InterfaceName) => Self.RouteValues.Get@(Raw(string.Format("<{0}>", part.HighLevelTypeName)))("@(part.Name)");
 </text>
 }
 
         // Request parameters
-@foreach (var param in r.Params)
+@foreach (var param in Model.Params)
 {
     var original = param.QueryStringKey;
     //skip parameters already part of the path portion of the url
-    if (r.Parts.Any(p=>p.Name == original))
+    if (Model.Parts.Any(p=>p.Name == original))
     {
         continue;
     }
     // We prefer to map these explicitly in our own hand written classes.
     // The interface generation will generate properties for these so code won't compile until we do
-    if (param.RenderPartial && (r.HasBody))
+    if (param.RenderPartial && (Model.HasBody))
     {
         continue;
     }
     var doc = param.DescriptionHighLevel.ToArray();
-<text>      @Raw(param.InitializerGenerator(r.CsharpNames.Namespace, param.TypeHighLevel, param.ClsName, original, param.SetterHighLevel, doc))
-</text>
+	@Raw(param.InitializerGenerator(Model.CsharpNames.Namespace, param.TypeHighLevel, param.ClsName, original, param.SetterHighLevel, doc))
 }
-@if (names.DescriptorNotFoundInCodebase)
+@if (Model.CsharpNames.DescriptorNotFoundInCodebase)
 {<text>
-        [Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement @names.DescriptorName and @names.RequestName in a file called @(names.RequestName).cs in OSC's codebase", true)]
+        [Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement @Model.CsharpNames.DescriptorName and @Model.CsharpNames.RequestName in a file called @(Model.CsharpNames.RequestName).cs in OSC's codebase", true)]
         public bool IsUnmapped => true;
         public bool UseIsUnmapped => IsUnmapped;
  </text>
 }
     }
-@if (r.NeedsGenericImplementation)
+@if (Model.NeedsGenericImplementation)
     {<text>
-    public partial class @Raw(names.GenericRequestName) @Raw(string.Format(": {0}, {1}", names.RequestName, names.GenericInterfaceName))
+    public partial class @Raw(Model.CsharpNames.GenericRequestName) @Raw(string.Format(": {0}, {1}", Model.CsharpNames.RequestName, Model.CsharpNames.GenericInterfaceName))
     {
-        protected @(Raw(names.GenericInterfaceName)) TypedSelf => this;
-@foreach (Constructor c in r.GenericConstructors)
+        protected @Raw(Model.CsharpNames.GenericInterfaceName) TypedSelf => this;
+@foreach (Constructor c in Model.GenericConstructors)
 {
 <text>      @(Raw(CodeGenerator.Constructor(c)))
 </text>

--- a/src/ApiGenerator/Views/HighLevel/Requests/RequestInterface.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/RequestInterface.cshtml
@@ -1,27 +1,25 @@
 @using ApiGenerator.Domain.Code.HighLevel.Requests
-@using ApiGenerator.Domain.Specification
 @inherits ApiGenerator.CodeTemplatePage<RequestInterface>
 @{
-    RequestInterface i = Model;
-    string name = i.CsharpNames.RequestInterfaceName;
+	var name = Model.CsharpNames.RequestInterfaceName;
 }
     [InterfaceDataContract]
-    public partial interface @(Raw(i.Name)) : IRequest@(Raw(string.Format("<{0}>", i.CsharpNames.ParametersName)))
-    {
-@foreach (UrlPart part in i.UrlParts)
+    public partial interface @Raw(Model.Name) : IRequest@(Raw(string.Format("<{0}>", Model.CsharpNames.ParametersName)))
+{
+@foreach (var part in Model.UrlParts)
 {
 <text>      [IgnoreDataMember]
             @(Raw(part.HighLevelTypeName)) @(part.InterfaceName) { get; }
 </text>
 }
-@foreach (var partialParam in i.PartialParameters)
+@foreach (var partialParam in Model.PartialParameters)
 {
 <text>      [DataMember(Name = "@(partialParam.QueryStringKey)")] @(Raw(partialParam.TypeHighLevel)) @(partialParam.ClsName) { get; set; }</text>
 }
     }
-@if (i.NeedsGenericInterface)
+@if (Model.NeedsGenericInterface)
 {
 <text>
-        public partial interface @(name)@(Raw(i.CsharpNames.GenericsDeclaredOnRequest)) : @(Raw(name)) { }
+        public partial interface @(name)@Raw(Model.CsharpNames.GenericsDeclaredOnRequest) : @(Raw(name)) { }
 </text>
 }

--- a/src/ApiGenerator/Views/HighLevel/Requests/Requests.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/Requests.cshtml
@@ -1,15 +1,13 @@
-@using System.Collections.Generic
 @using System.Collections.ObjectModel
 @using ApiGenerator
 @using ApiGenerator.Domain.Specification
 @using ApiGenerator.Domain.Code
 @inherits CodeTemplatePage<KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>>>
 @{
-    KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>> model = Model;
-    string ns = model.Key != CsharpNames.RootNamespace ? "."+CsharpNames.ApiNamespace+"." + model.Key + CsharpNames.ApiNamespaceSuffix : null;
-    var endpoints = model.Value;
+	var (ns, endpoints) = Model;
+	ns = ns != CsharpNames.RootNamespace ? $".{CsharpNames.ApiNamespace}.{ns}{CsharpNames.ApiNamespaceSuffix}" : null;
 }
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -19,7 +17,7 @@ using System.Linq.Expressions;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
-@if (model.Key != CsharpNames.RootNamespace)
+@if (ns != CsharpNames.RootNamespace)
 {
     <text>using OpenSearch.Net@(ns);
 </text>

--- a/src/ApiGenerator/Views/LowLevel/Client/Implementation/OpenSearchLowLevelClient.Namespace.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Implementation/OpenSearchLowLevelClient.Namespace.cshtml
@@ -1,15 +1,12 @@
-@using System.Collections.Generic
 @using System.Collections.ObjectModel
 @using System.Linq
 @using ApiGenerator 
 @using ApiGenerator.Domain.Code
 @using ApiGenerator.Domain.Specification
 @inherits CodeTemplatePage<KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>>>
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 @{
-    KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>> model = Model;
-    string ns = model.Key;
-    var endpoints = model.Value;
+	var (ns, endpoints) = Model;
 }
 // ReSharper disable RedundantUsingDirective
 using System;
@@ -26,17 +23,17 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable once CheckNamespace
 // ReSharper disable InterpolatedStringExpressionIsNotIFormattable
 // ReSharper disable RedundantExtendsListEntry
-namespace OpenSearch.Net.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamespaceSuffix)
+namespace OpenSearch.Net.@(CsharpNames.ApiNamespace).@ns@(CsharpNames.ApiNamespaceSuffix)
 {
     ///<summary>
-    /// @(ns.SplitPascalCase()) APIs.
+    /// @ns.SplitPascalCase() APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchLowLevelClient.@ns"/> property
     /// on <see cref="IOpenSearchLowLevelClient"/>.
     ///</para>
     ///</summary>
-    public partial class @(CsharpNames.LowLevelClientNamespacePrefix)@(model.Key)@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy
+    public partial class @(CsharpNames.LowLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy
     {
-        internal @(CsharpNames.LowLevelClientNamespacePrefix)@(model.Key)@(CsharpNames.ClientNamespaceSuffix)(OpenSearchLowLevelClient client) : base(client) {}
+        internal @(CsharpNames.LowLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix)(OpenSearchLowLevelClient client) : base(client) {}
 @if (ns == "Cat")
 {
     <text>protected override string ContentType { get; } = "text/plain";</text>

--- a/src/ApiGenerator/Views/LowLevel/Client/Implementation/OpenSearchLowLevelClient.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Implementation/OpenSearchLowLevelClient.cshtml
@@ -3,7 +3,7 @@
 @using ApiGenerator 
 @using ApiGenerator.Domain.Code
 @inherits CodeTemplatePage<RestApiSpec>
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -17,8 +17,7 @@ using OpenSearch.Net;
 using static OpenSearch.Net.HttpMethod;
 
 @{
-    RestApiSpec model = Model;
-    var namespaces = model.EndpointsPerNamespaceLowLevel.Keys.Where(k => k != CsharpNames.RootNamespace).ToList();
+	var namespaces = Model.EndpointsPerNamespaceLowLevel.Keys.Where(k => k != CsharpNames.RootNamespace).ToList();
 <text>
 // ReSharper disable InterpolatedStringExpressionIsNotIFormattable
 // ReSharper disable RedundantExtendsListEntry
@@ -49,14 +48,13 @@ namespace OpenSearch.Net
 </text>
     
 
-    foreach (var kv in model.EndpointsPerNamespaceLowLevel)
+    foreach (var (ns, endpoints) in Model.EndpointsPerNamespaceLowLevel)
     {
-        if (kv.Key != CsharpNames.RootNamespace)
+        if (ns != CsharpNames.RootNamespace)
         {
             continue;
         }
-        var endpoints = kv.Value;
-        var methods = endpoints.SelectMany(e=>e.LowLevelClientMethods).ToList();
+	    var methods = endpoints.SelectMany(e=>e.LowLevelClientMethods).ToList();
         foreach (var method in methods)
         {
             await IncludeAsync("LowLevel/Client/Methods/MethodImplementation.cshtml", method);

--- a/src/ApiGenerator/Views/LowLevel/Client/Interface/IOpenSearchLowLevelClient.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Interface/IOpenSearchLowLevelClient.cshtml
@@ -3,7 +3,7 @@
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -22,18 +22,17 @@ namespace OpenSearch.Net
     ///</summary>
     public partial interface IOpenSearchLowLevelClient 
     {
-        @foreach(var kv in Model.EndpointsPerNamespaceLowLevel)
+        @foreach(var (ns, endpoints) in Model.EndpointsPerNamespaceLowLevel)
         {
-        if (kv.Key != CsharpNames.RootNamespace)
+        if (ns != CsharpNames.RootNamespace)
         {
 <text>
-            ///<summary>@(kv.Key.SplitPascalCase()) APIs</summary>
-            @CsharpNames.LowLevelClientNamespacePrefix@(kv.Key)@CsharpNames.ClientNamespaceSuffix @kv.Key { get; }
+            ///<summary>@ns.SplitPascalCase() APIs</summary>
+            @CsharpNames.LowLevelClientNamespacePrefix@(ns)@CsharpNames.ClientNamespaceSuffix @ns { get; }
 </text>
             continue;
         }
-            var endpoints = kv.Value;
-            var methods = endpoints.SelectMany(e=>e.LowLevelClientMethods).ToList();
+	        var methods = endpoints.SelectMany(e=>e.LowLevelClientMethods).ToList();
             foreach(var method in methods)
             {
                 await IncludeAsync("LowLevel/Client/Methods/MethodInterface.cshtml", method);

--- a/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodDocs.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodDocs.cshtml
@@ -2,20 +2,17 @@
 @using ApiGenerator.Domain.Code.LowLevel
 @using ApiGenerator.Domain.Specification
 @inherits ApiGenerator.CodeTemplatePage<LowLevelClientMethod>
-@{
-    LowLevelClientMethod method = Model;
-}
-        ///<summary>@method.HttpMethod on @method.Path@Raw(method.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + method.OfficialDocumentationLink + "</para>")</summary>
-@foreach (var part in method.Parts)
+///<summary>@Model.HttpMethod on @Model.Path@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
+@foreach (var part in Model.Parts)
 {
 <text>      ///@Raw("<param name=\""+part.NameAsArgument+"\">")@part.Description@Raw("</param>")
 </text>
 }
         ///@Raw(@"<param name=""requestParameters"">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>")
-        @if (method.Stability != Stability.Stable)
+        @if (Model.Stability != Stability.Stable)
         {
             string warningMessage = "";
-            switch (method.Stability)
+            switch (Model.Stability)
             {
                 case Stability.Experimental:
                     warningMessage = "this functionality is Experimental and may be changed or removed completely in a future release. OpenSearch will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.";
@@ -27,10 +24,10 @@
 
             warningMessage += " This functionality is subject to potential breaking changes within a minor version, meaning that your referencing code may break when this library is upgraded.";
             
-<text>      ///@Raw("<remarks>Note: " + method.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
-            </text>
-        }
-        @if (method.DeprecatedPath != null)
+<text>      ///@Raw("<remarks>Note: " + Model.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
+
+</text>}
+        @if (Model.DeprecatedPath != null)
         {
-<text>      [Obsolete("Deprecated in version @(method.DeprecatedPath.Version): @Raw(method.DeprecatedPath.Description)")]
+<text>      [Obsolete("Deprecated in version @Model.DeprecatedPath.Version: @Raw(Model.DeprecatedPath.Description)")]
 </text>}

--- a/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodImplementation.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodImplementation.cshtml
@@ -1,14 +1,13 @@
 @using ApiGenerator.Domain.Code.LowLevel
 @inherits ApiGenerator.CodeTemplatePage<LowLevelClientMethod>
 @{
-    LowLevelClientMethod method = Model;
-    var contentType = method.CsharpNames.RestSpecName.Contains(".cat_") ? ", contentType: \"text/plain\"" : string.Empty;
+	var contentType = Model.CsharpNames.RestSpecName.Contains(".cat_") ? ", contentType: \"text/plain\"" : string.Empty;
 }
-@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
-        public TResponse @(method.PerPathMethodName)@(Raw("<TResponse>"))(@Raw(method.Arguments))
-            where TResponse : class, IOpenSearchResponse, new() => DoRequest@(Raw("<TResponse>"))(@method.HttpMethod, @Raw(method.UrlInCode), @(method.HasBody ? "body" : "null"), RequestParams(requestParameters@(Raw(contentType))));
+@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", Model); }
+        public TResponse @Model.PerPathMethodName@(Raw("<TResponse>"))(@Raw(Model.Arguments))
+            where TResponse : class, IOpenSearchResponse, new() => DoRequest@(Raw("<TResponse>"))(@Model.HttpMethod, @Raw(Model.UrlInCode), @(Model.HasBody ? "body" : "null"), RequestParams(requestParameters@(Raw(contentType))));
 
-@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
-        [MapsApi("@(method.CsharpNames.RestSpecName)", "@(method.MapsApiArguments)")]
-        public Task@(Raw("<TResponse>")) @(method.PerPathMethodName)Async@(Raw("<TResponse>"))(@Raw(method.Arguments), CancellationToken ctx = default)
-            where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync@(Raw("<TResponse>"))(@method.HttpMethod, @Raw(method.UrlInCode), ctx, @(method.HasBody ? "body" : "null"), RequestParams(requestParameters@(Raw(contentType))));
+@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", Model); }
+        [MapsApi("@Model.CsharpNames.RestSpecName", "@Model.MapsApiArguments")]
+        public Task@(Raw("<TResponse>")) @(Model.PerPathMethodName)Async@(Raw("<TResponse>"))(@Raw(Model.Arguments), CancellationToken ctx = default)
+            where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync@(Raw("<TResponse>"))(@Model.HttpMethod, @Raw(Model.UrlInCode), ctx, @(Model.HasBody ? "body" : "null"), RequestParams(requestParameters@(Raw(contentType))));

--- a/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodInterface.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodInterface.cshtml
@@ -1,10 +1,7 @@
 @using ApiGenerator.Domain.Code.LowLevel
 @inherits ApiGenerator.CodeTemplatePage<LowLevelClientMethod>
-@{
-    LowLevelClientMethod method = Model;
-}
-@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
-        TResponse @(method.PerPathMethodName)@(Raw("<TResponse>"))(@Raw(method.Arguments)) where TResponse : class, IOpenSearchResponse, new();
+@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", Model); }
+        TResponse @Model.PerPathMethodName@(Raw("<TResponse>"))(@Raw(Model.Arguments)) where TResponse : class, IOpenSearchResponse, new();
 
-@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
-        Task@(Raw("<TResponse>")) @(method.PerPathMethodName)Async@(Raw("<TResponse>"))(@Raw(method.Arguments), CancellationToken ctx = default) where TResponse : class, IOpenSearchResponse, new();
+@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", Model); }
+        Task@(Raw("<TResponse>")) @(Model.PerPathMethodName)Async@(Raw("<TResponse>"))(@Raw(Model.Arguments), CancellationToken ctx = default) where TResponse : class, IOpenSearchResponse, new();

--- a/src/ApiGenerator/Views/LowLevel/Client/Usings.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Usings.cshtml
@@ -1,11 +1,11 @@
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@foreach(var kv in Model.EndpointsPerNamespaceLowLevel)
+@foreach(var ns in Model.EndpointsPerNamespaceLowLevel.Keys)
 {
-    if (kv.Key != CsharpNames.RootNamespace)
+    if (ns != CsharpNames.RootNamespace)
     {
-<text>using OpenSearch.Net.@(CsharpNames.ApiNamespace).@(kv.Key)@(CsharpNames.ApiNamespaceSuffix);
+<text>using OpenSearch.Net.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamespaceSuffix);
 </text>
     }
 }

--- a/src/ApiGenerator/Views/LowLevel/Enums.Generated.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Enums.Generated.cshtml
@@ -1,11 +1,10 @@
-@using System
 @using System.Linq
 @using System.Text
 @using ApiGenerator.Domain
 @using ApiGenerator
 @using ApiGenerator.Configuration.Overrides
 @inherits CodeTemplatePage<RestApiSpec>
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 @functions {
     private const string RawSize = "Raw";
     private const string SizeEnum = "Size";
@@ -54,7 +53,7 @@ using System.Runtime.Serialization;
 
 namespace OpenSearch.Net
 {
-@foreach (EnumDescription e in Model.EnumsInTheSpec)
+@foreach (var e in Model.EnumsInTheSpec)
 {
     var isFlag = IsFlag(e.Name);
     <text>
@@ -70,7 +69,7 @@ namespace OpenSearch.Net
 
         static KnownEnums()
         {
-        @foreach (EnumDescription e in Model.EnumsInTheSpec)
+        @foreach (var e in Model.EnumsInTheSpec)
         {
 <text>          EnumStringResolvers.TryAdd(typeof(@(e.Name)), (e) => GetStringValue((@(e.Name))e));
 </text>
@@ -83,7 +82,7 @@ namespace OpenSearch.Net
             public @(Raw("Func<Enum, string>")) Resolver { get; set; }
         }   
 
-    @foreach (EnumDescription e in Model.EnumsInTheSpec)
+    @foreach (var e in Model.EnumsInTheSpec)
     {
         var isFlag = IsFlag(e.Name);
         <text>

--- a/src/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
@@ -1,14 +1,12 @@
-@using System.Collections.Generic
 @using System.Collections.ObjectModel
 @using ApiGenerator
 @using ApiGenerator.Domain.Code
 @using ApiGenerator.Domain.Specification
 @inherits CodeTemplatePage<KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>>>
-@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeGeneratorNotice(); }
 @{
-    KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>> model = Model;
-    string ns = model.Key != CsharpNames.RootNamespace ? "."+CsharpNames.ApiNamespace+"." + model.Key + CsharpNames.ApiNamespaceSuffix : null;
-    var endpoints = model.Value;
+	var (ns, endpoints) = Model;
+	ns = ns != CsharpNames.RootNamespace ? $".{CsharpNames.ApiNamespace}.{ns}{CsharpNames.ApiNamespaceSuffix}" : null;
 }
 
 // ReSharper disable RedundantUsingDirective

--- a/src/ApiGenerator/packages.lock.json
+++ b/src/ApiGenerator/packages.lock.json
@@ -39,9 +39,9 @@
       },
       "RazorLight": {
         "type": "Direct",
-        "requested": "[2.1.0, )",
-        "resolved": "2.1.0",
-        "contentHash": "WUJUsOJXUXrRpMrlWunn2QsOigF07S+lP2QxuOEBlfswDtuO4SAGaL97tOn0Hq24lMNqR4SWepOMj4Rlx+OfsQ==",
+        "requested": "[2.3.1, )",
+        "resolved": "2.3.1",
+        "contentHash": "Eegx5xEQ2AvydJB5lHTZgIQQyCZJ6NLJb1ePinAGmv5S42rvj8o/FRZFxrB0jQhXmA4uu93x+J/ZVE1qBv4dLw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Razor.Extensions": "6.0.0",
           "Microsoft.CodeAnalysis.Razor": "6.0.0",


### PR DESCRIPTION
### Description
Updates the RazorLight dependency of ApiGenerator and changes the logic to use `EmbeddedResource`s for the templates to IDE code completion and reference tracking in templates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
