### PR TITLE
Install k-NN plugin for unreleased OpenSearch integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,6 +140,14 @@ jobs:
             for plugin in ${PluginList[*]}; do
               ./gradlew :plugins:$plugin:assemble
             done
+            
+      - name: Determine OpenSearch distribution path and version
+        shell: bash -eo pipefail {0}
+        run: |
+          distribution=`ls -1 $PWD/opensearch/distribution/archives/linux-tar/build/distributions/opensearch-*.tar.gz | head -1`
+          version=`basename $distribution | cut -d'-' -f3,4`
+          echo "OPENSEARCH_DISTRIBUTION=$distribution" >> $GITHUB_ENV
+          echo "OPENSEARCH_VERSION=$version" >> $GITHUB_ENV
         
       - name: Restore or Build OpenSearch Security
         uses: ./client/.github/actions/cached-git-build
@@ -150,22 +158,42 @@ jobs:
           path: opensearch-security
           cached_paths: |
             ./opensearch-security/build/distributions/opensearch-security-*-SNAPSHOT.zip
-          build_script: ./gradlew assemble
+          build_script: ./gradlew assemble -Dopensearch.version=$OPENSEARCH_VERSION
+      
+      - name: Restore or Build OpenSearch k-NN
+        uses: ./client/.github/actions/cached-git-build
+        with:
+          repository: opensearch-project/k-NN
+          ref: ${{ matrix.opensearch_ref }}
+          path: opensearch-knn
+          cached_paths: |
+            ./opensearch-knn/build/distributions/opensearch-knn-*-SNAPSHOT.zip
+          build_script: |
+            sudo apt-get install -y libopenblas-dev libomp-dev
+            ./gradlew buildJniLib assemble -Dopensearch.version=$OPENSEARCH_VERSION
+            distributions=./build/distributions
+            lib_dir=$distributions/lib
+            mkdir $lib_dir
+            cp -v $(ldconfig -p | grep libgomp | cut -d ' ' -f 4) $lib_dir
+            cp -v ./jni/release/libopensearchknn_* $lib_dir
+            ls -l $lib_dir
+            cd $distributions
+            zip -ur opensearch-knn-*.zip lib
         
-      - name: Determine OpenSearch distribution path
+      - name: Copy OpenSearch plugins
         shell: bash -eo pipefail {0}
         run: |
-          distribution=`ls -1 $PWD/opensearch/distribution/archives/linux-tar/build/distributions/opensearch-*.tar.gz | head -1`
-          version=`basename $distribution | cut -d'-' -f3,4`
-          echo "OPENSEARCH_DISTRIBUTION=$distribution" >> $GITHUB_ENV
-          echo "OPENSEARCH_VERSION=$version" >> $GITHUB_ENV
-          
           mkdir -p $OPENSEARCH_PLUGINS_DIRECTORY
-          cp ./opensearch/plugins/*/build/distributions/*-$version.zip $OPENSEARCH_PLUGINS_DIRECTORY/
+          cp -v ./opensearch/plugins/*/build/distributions/*-$OPENSEARCH_VERSION.zip $OPENSEARCH_PLUGINS_DIRECTORY/
           
-          if [[ -d "./opensearch-security" ]]; then 
-            cp ./opensearch-security/build/distributions/opensearch-security-*-SNAPSHOT.zip $OPENSEARCH_PLUGINS_DIRECTORY/
-          fi
+          plugins=("opensearch-knn" "opensearch-security")
+          for plugin in ${plugins[*]}; do
+            if [[ -d "./$plugin" ]]; then
+              cp -v ./$plugin/build/distributions/$plugin-*-SNAPSHOT.zip $OPENSEARCH_PLUGINS_DIRECTORY/
+            fi
+          done
+          
+          ls -l $OPENSEARCH_PLUGINS_DIRECTORY
       
       - run: "./build.sh integrate ${{ env.OPENSEARCH_VERSION }} readonly,writable random:test_only_one --report"
         name: Integration Tests

--- a/abstractions/src/OpenSearch.OpenSearch.Managed/OpenSearchNode.cs
+++ b/abstractions/src/OpenSearch.OpenSearch.Managed/OpenSearchNode.cs
@@ -95,7 +95,7 @@ namespace OpenSearch.OpenSearch.Managed
 			if (!string.IsNullOrWhiteSpace(config.FileSystem.OpenSearchHome))
 				environmentVariables.Add("OPENSEARCH_HOME", config.FileSystem.OpenSearchHome);
 
-			var knnLibDir = Path.Combine(config.FileSystem.OpenSearchHome, "plugins", "opensearch-knn", config.Version.Major >= 2 ? "lib" : "knnlib");
+			var knnLibDir = Path.Combine(config.FileSystem.OpenSearchHome, "plugins", "opensearch-knn", config.Version >= "1.3.10" ? "lib" : "knnlib");
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
 				AppendPathEnvVar("JAVA_LIBRARY_PATH", knnLibDir);
 			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/abstractions/src/OpenSearch.Stack.ArtifactsApi/Products/OpenSearchPlugin.cs
+++ b/abstractions/src/OpenSearch.Stack.ArtifactsApi/Products/OpenSearchPlugin.cs
@@ -79,5 +79,7 @@ namespace OpenSearch.Stack.ArtifactsApi.Products
 		public static OpenSearchPlugin StoreSMB { get; } = new("store-smb");
 
 		public static OpenSearchPlugin DeleteByQuery { get; } = new("delete-by-query", version => version < "1.0.0");
+
+		public static OpenSearchPlugin Knn { get; } = new("opensearch-knn");
 	}
 }

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/ReadOnlyCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/ReadOnlyCluster.cs
@@ -33,7 +33,7 @@ namespace Tests.Core.ManagedOpenSearch.Clusters
 {
 	public class ReadOnlyCluster : ClientTestClusterBase
 	{
-		public ReadOnlyCluster() : base(MapperMurmur3, Security) { }
+		public ReadOnlyCluster() : base(Knn, MapperMurmur3, Security) { }
 
 		protected override void SeedNode() => new DefaultSeeder(Client).SeedNode();
 	}

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/WritableCluster.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/WritableCluster.cs
@@ -46,6 +46,7 @@ namespace Tests.Core.ManagedOpenSearch.Clusters
 			new(
 				AnalysisIcu, AnalysisKuromoji, AnalysisNori, AnalysisPhonetic,
 				IngestAttachment, IngestGeoIp,
+				Knn,
 				MapperMurmur3,
 				Security)
 			{


### PR DESCRIPTION
### Description
Installs the k-NN plugin for unreleased OpenSearch integration tests. Also corrects knn lib dir for 1.3.10+.

### Issues Resolved
Fixes CI failures seen on merging k-NN feature: https://github.com/opensearch-project/opensearch-net/actions/runs/5373470729

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
