### PR TITLE
[Backport 1.x] Bump BenchMarkDotNet from 0.13.4 to 0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `SharpZipLib` from 1.4.1 to 1.4.2
 - Bumps `AWSSDK.Core` from 3.7.103.17 to 3.7.106.29
 - Bumps `Newtonsoft.Json` from 13.0.2 to 13.0.3
+- Bumps `BenchMarkDotNet` from 0.13.4 to 0.13.5
 - Bumps `Microsoft.SourceLink.GitHub` from 1.0.0 to 1.1.1
 
 ## [1.3.0]

--- a/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
@@ -12,6 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-    <PackageReference Include="BenchMarkDotNet" Version="0.13.4" />
+    <PackageReference Include="BenchMarkDotNet" Version="0.13.5" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.ScratchPad/packages.lock.json
+++ b/tests/Tests.ScratchPad/packages.lock.json
@@ -4,11 +4,11 @@
     "net6.0": {
       "BenchmarkDotNet": {
         "type": "Direct",
-        "requested": "[0.13.4, )",
-        "resolved": "0.13.4",
-        "contentHash": "P6avThzS0HRJEjcCfnJdaMIujCMBoWQXSJiVYYFtMltrVeEMaIhg7r5qiGPyx9O2ZXuNpqIxVEg1JqgvfwnI2Q==",
+        "requested": "[0.13.5, )",
+        "resolved": "0.13.5",
+        "contentHash": "PiwINqvreKV7L+BQlaZ2qcJ90s88LbLqZoUWbKnEPzvmsWd4pUH58Yjp+mFn311n8Jz0Y0JsD+jWa+Kh67IG3A==",
         "dependencies": {
-          "BenchmarkDotNet.Annotations": "0.13.4",
+          "BenchmarkDotNet.Annotations": "0.13.5",
           "CommandLineParser": "2.4.3",
           "Gee.External.Capstone": "2.3.0",
           "Iced": "1.17.0",
@@ -40,8 +40,8 @@
       },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
-        "resolved": "0.13.4",
-        "contentHash": "bc2q4S7xvOrqh7qRaMGyDdHVv8SITtN4crx5neIU289ra+LaP+OAmHPXxCY2djrnguZ8kfDddyJSg30wt7DvKg=="
+        "resolved": "0.13.5",
+        "contentHash": "ORcRi9/fnjRfINKiAnAgIsRlQ15Gj2Lki7AluHnAVMk/lTyQ2nwaa+F+ezW8f3tElBDoZql02+J2lIwHbu1eoA=="
       },
       "Bogus": {
         "type": "Transitive",


### PR DESCRIPTION
Backport 2addb03743eadbe5355efdf022dbec5251e0b9db from #219 