### PR TITLE
[Backport 1.x] Bump FSharp.Core from 6.0.7 to 7.0.300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `SharpZipLib` from 1.4.1 to 1.4.2
 - Bumps `AWSSDK.Core` from 3.7.103.17 to 3.7.106.29
 - Bumps `Newtonsoft.Json` from 13.0.2 to 13.0.3
+- Bumps `FSharp.Core` from 6.0.7 to 7.0.300
 - Bumps `Microsoft.SourceLink.GitHub` from 1.0.0 to 1.1.1
 
 ## [1.3.0]

--- a/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
+++ b/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
@@ -30,7 +30,7 @@
   </ItemGroup>
  
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="6.0.7" />
+    <PackageReference Update="FSharp.Core" Version="7.0.300" />
     
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="FSharp.Data" Version="5.0.2" />

--- a/tests/Tests.YamlRunner/packages.lock.json
+++ b/tests/Tests.YamlRunner/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[6.0.7, )",
-        "resolved": "6.0.7",
-        "contentHash": "e6wGrq5smV3Yk2fBE/Y0nBG5oFyF59k5Je0a0QDydUpg6liyaafGjD3xvutciKepCP2knspZ/sWViC/F1OyyQQ=="
+        "requested": "[7.0.300, )",
+        "resolved": "7.0.300",
+        "contentHash": "8vvItREJ1l5lcp3vBCSJ1mFevVAhR48I34DuF/EoUa7o1KlFpQpagyuZkVYMAsHPIjdp47ZxM9sI4eqeXaeWkA=="
       },
       "FSharp.Data": {
         "type": "Direct",

--- a/tests/Tests/Tests.csproj
+++ b/tests/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="FSharp.Core" Version="6.0.7" />
+    <PackageReference Include="FSharp.Core" Version="7.0.300" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/tests/Tests/packages.lock.json
+++ b/tests/Tests/packages.lock.json
@@ -13,9 +13,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[6.0.7, )",
-        "resolved": "6.0.7",
-        "contentHash": "e6wGrq5smV3Yk2fBE/Y0nBG5oFyF59k5Je0a0QDydUpg6liyaafGjD3xvutciKepCP2knspZ/sWViC/F1OyyQQ=="
+        "requested": "[7.0.300, )",
+        "resolved": "7.0.300",
+        "contentHash": "8vvItREJ1l5lcp3vBCSJ1mFevVAhR48I34DuF/EoUa7o1KlFpQpagyuZkVYMAsHPIjdp47ZxM9sI4eqeXaeWkA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",


### PR DESCRIPTION
Backport e08b5c32efdf96754d4133ae5e06ec814539c346 from #223 