### PR TITLE
Add bump-version workflow

### DIFF
--- a/.github/bump-version.sh
+++ b/.github/bump-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -ex
+
+IFS='.' read -r -a VERSION_COMPONENTS <<< "$1"
+MAJOR="${VERSION_COMPONENTS[0]}"
+MINOR="${VERSION_COMPONENTS[1]}"
+PATCH="${VERSION_COMPONENTS[2]}"
+
+if [[ -z "$MAJOR" || -z "$MINOR" || -z "$PATCH" ]]; then
+  echo "Usage: $0 <major>.<minor>.<patch>"
+  exit 1
+fi
+
+VERSION="$MAJOR.$MINOR.$PATCH"
+
+AUTO_LABEL_JSON=$(jq \
+	--arg v "$VERSION" \
+	'.rules |= with_entries(if .key | test("^v\\d+\\.\\d+\\.\\d+$") then .key |= "v\($v)" else . end)' \
+	.github/auto-label.json)
+echo "$AUTO_LABEL_JSON" > .github/auto-label.json
+
+GLOBAL_JSON=$(jq \
+	--arg v "$VERSION" \
+	--arg maj "$MAJOR" \
+	--arg min "$MINOR" \
+	'.version = "\($v)" | .doc_current = "\($maj).\($min)" | .doc_branch = "\($maj).x"' \
+	global.json)
+echo "$GLOBAL_JSON" > global.json
+
+sed -i '' -E "s/^([[:space:]]+VERSION: )([0-9]+\.){2}[0-9]+$/\1$VERSION/" .github/workflows/release.yml
+sed -i '' -E "s/(<Current(Assembly(File)?)?Version>)([0-9]+\.){2}[0-9]+<\//\1$VERSION<\//" Directory.Build.props

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,44 @@
+on:
+  workflow_dispatch: 
+    inputs:
+      branch:
+        description: 'Branch to bump version on'
+        required: true
+      version:
+        description: 'Version to bump to'
+        required: true
+
+jobs:
+  bump-version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub App Token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+          
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ steps.github_app_token.outputs.token }}
+      
+      - name: Bump Version
+        run: bash .github/bump-version.sh "${{ github.event.inputs.version }}"
+        
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ steps.github_app_token.outputs.token }}
+          base: ${{ github.event.inputs.branch }}
+          branch: "feat/${{ github.event.inputs.branch }}/bump-version"
+          commit-message: Bump version to ${{ github.event.inputs.version }}
+          signoff: true
+          delete-branch: true
+          title: 'Bump version on ${{ github.event.inputs.branch }} to ${{ github.event.inputs.version }}.'
+          body: |
+            Bumping version on `${{ github.event.inputs.branch }}` to `${{ github.event.inputs.version }}`.
+


### PR DESCRIPTION
### Description
Adds a workflow that can be manually run to create version bump PRs.
Not fully automated off tag push as we don't pre-emptively branch the (e.g) `1.4` branch to do patch increases, as well as our release throughput being generally low. And is more useful for doing minor bump on `1.x` and major bump on main.
Can be further automated in future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
