### PR TITLE
[Backport 1.x] Bump Microsoft.TestPlatform.ObjectModel from 17.5.0 to 17.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Dependencies
+- Bumps `Microsoft.TestPlatform.ObjectModel` from 17.5.0 to 17.6.3
 
 ## [1.4.0]
 ### Added

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.5.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.6.3" />
     
     <PackageReference Include="xunit" Version="2.4.2" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Xunit\OpenSearch.OpenSearch.Xunit.csproj" />


### PR DESCRIPTION
Backport b3312fcfcdf33f102837a0a984b0f781ec5e4acb from #271 
