### PR TITLE
Fixes #321: fix highlight max_analyzer_offset field name to match OS 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Moved `OpenSearch.Client` request classes into their respective namespaces to match those in `OpenSearch.Net` ([#200](https://github.com/opensearch-project/opensearch-net/pull/200), [#202](https://github.com/opensearch-project/opensearch-net/pull/202), [#203](https://github.com/opensearch-project/opensearch-net/pull/203), [#205](https://github.com/opensearch-project/opensearch-net/pull/205), [#206](https://github.com/opensearch-project/opensearch-net/pull/206), [#207](https://github.com/opensearch-project/opensearch-net/pull/207), [#208](https://github.com/opensearch-project/opensearch-net/pull/208), [#209](https://github.com/opensearch-project/opensearch-net/pull/209))
 - Removed support for the `net461` target ([#256](https://github.com/opensearch-project/opensearch-net/pull/256))
 
+### Fixed
+- Fix highlight max_analyzer_offset field name to match with the one introduced in OpenSearch 2.2.0 ([#322](https://github.com/opensearch-project/opensearch-net/pull/322))
+
 ### Dependencies
 - Bumps `Microsoft.CodeAnalysis.CSharp` from 4.2.0 to 4.6.0
 - Bumps `Microsoft.TestPlatform.ObjectModel` from 17.5.0 to 17.6.3

--- a/src/OpenSearch.Client/Search/Search/Highlighting/Highlight.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/Highlight.cs
@@ -107,6 +107,7 @@ namespace OpenSearch.Client
 		/// If this setting is set to a non-negative value, the highlighting stops at this defined maximum limit, and the
 		/// rest of the text is not processed, thus not highlighted and no error is returned.
 		/// </summary>
+		/// <remarks>Introduced in OpenSearch 2.2</remarks>
 		[DataMember(Name ="max_analyzer_offset")]
 		int? MaxAnalyzerOffset { get; set; }
 

--- a/src/OpenSearch.Client/Search/Search/Highlighting/Highlight.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/Highlight.cs
@@ -107,8 +107,8 @@ namespace OpenSearch.Client
 		/// If this setting is set to a non-negative value, the highlighting stops at this defined maximum limit, and the
 		/// rest of the text is not processed, thus not highlighted and no error is returned.
 		/// </summary>
-		[DataMember(Name ="max_analyzed_offset")]
-		int? MaxAnalyzedOffset { get; set; }
+		[DataMember(Name ="max_analyzer_offset")]
+		int? MaxAnalyzerOffset { get; set; }
 
 		[DataMember(Name ="max_fragment_length")]
 		int? MaxFragmentLength { get; set; }
@@ -210,7 +210,7 @@ namespace OpenSearch.Client
 		public QueryContainer HighlightQuery { get; set; }
 
 		/// <inheritdoc/>
-		public int? MaxAnalyzedOffset { get; set; }
+		public int? MaxAnalyzerOffset { get; set; }
 
 		/// <inheritdoc/>
 		public int? MaxFragmentLength { get; set; }
@@ -258,7 +258,7 @@ namespace OpenSearch.Client
 		int? IHighlight.FragmentOffset { get; set; }
 		int? IHighlight.FragmentSize { get; set; }
 		QueryContainer IHighlight.HighlightQuery { get; set; }
-		int? IHighlight.MaxAnalyzedOffset { get; set; }
+		int? IHighlight.MaxAnalyzerOffset { get; set; }
 		int? IHighlight.MaxFragmentLength { get; set; }
 		int? IHighlight.NoMatchSize { get; set; }
 		int? IHighlight.NumberOfFragments { get; set; }
@@ -323,8 +323,8 @@ namespace OpenSearch.Client
 		/// <inheritdoc cref="IHighlight.BoundaryMaxScan" />
 		public HighlightDescriptor<T> BoundaryMaxScan(int? boundaryMaxScan) => Assign(boundaryMaxScan, (a, v) => a.BoundaryMaxScan = v);
 
-		/// <inheritdoc cref="IHighlight.MaxAnalyzedOffset" />
-		public HighlightDescriptor<T> MaxAnalyzedOffset(int? maxAnalyzedOffset) => Assign(maxAnalyzedOffset, (a, v) => a.MaxAnalyzedOffset = v);
+		/// <inheritdoc cref="IHighlight.MaxAnalyzerOffset" />
+		public HighlightDescriptor<T> MaxAnalyzerOffset(int? maxAnalyzerOffset) => Assign(maxAnalyzerOffset, (a, v) => a.MaxAnalyzerOffset = v);
 
 		/// <inheritdoc cref="IHighlight.MaxFragmentLength" />
 		public HighlightDescriptor<T> MaxFragmentLength(int? maxFragmentLength) => Assign(maxFragmentLength, (a, v) => a.MaxFragmentLength = v);

--- a/src/OpenSearch.Client/Search/Search/Highlighting/HighlightField.cs
+++ b/src/OpenSearch.Client/Search/Search/Highlighting/HighlightField.cs
@@ -116,6 +116,15 @@ namespace OpenSearch.Client
 		[DataMember(Name = "matched_fields")]
 		Fields MatchedFields { get; set; }
 
+
+		/// <summary>
+		/// If this setting is set to a non-negative value, the highlighting stops at this defined maximum limit, and the
+		/// rest of the text is not processed, thus not highlighted and no error is returned.
+		/// </summary>
+		/// <remarks>Introduced in OpenSearch 2.2</remarks>
+		[DataMember(Name = "max_analyzer_offset")]
+		int? MaxAnalyzerOffset { get; set; }
+
 		[DataMember(Name = "max_fragment_length")]
 		int? MaxFragmentLength { get; set; }
 
@@ -191,6 +200,7 @@ namespace OpenSearch.Client
 		/// </summary>
 		[DataMember(Name = "type")]
 		Union<HighlighterType, string> Type { get; set; }
+
 	}
 
 	public class HighlightField : IHighlightField
@@ -227,6 +237,9 @@ namespace OpenSearch.Client
 
 		/// <inheritdoc />
 		public Fields MatchedFields { get; set; }
+
+		/// <inheritdoc/>
+		public int? MaxAnalyzerOffset { get; set; }
 
 		/// <inheritdoc />
 		public int? MaxFragmentLength { get; set; }
@@ -273,6 +286,9 @@ namespace OpenSearch.Client
 		int? IHighlightField.FragmentSize { get; set; }
 		QueryContainer IHighlightField.HighlightQuery { get; set; }
 		Fields IHighlightField.MatchedFields { get; set; }
+
+		int? IHighlightField.MaxAnalyzerOffset { get; set; }
+
 		int? IHighlightField.MaxFragmentLength { get; set; }
 		int? IHighlightField.NoMatchSize { get; set; }
 		int? IHighlightField.NumberOfFragments { get; set; }
@@ -348,6 +364,9 @@ namespace OpenSearch.Client
 		/// <inheritdoc />
 		public HighlightFieldDescriptor<T> HighlightQuery(Func<QueryContainerDescriptor<T>, QueryContainer> querySelector) =>
 			Assign(querySelector, (a, v) => a.HighlightQuery = v?.Invoke(new QueryContainerDescriptor<T>()));
+
+		/// <inheritdoc />
+		public HighlightFieldDescriptor<T> MaxAnalyzerOffset(int? maxAnalyzerOffset) => Assign(maxAnalyzerOffset, (a, v) => a.MaxAnalyzerOffset = v);
 
 		/// <inheritdoc />
 		public HighlightFieldDescriptor<T> MaxFragmentLength(int? maxFragmentLength) => Assign(maxFragmentLength, (a, v) => a.MaxFragmentLength = v);

--- a/tests/Tests/Search/Request/HighlightingUsageTests.cs
+++ b/tests/Tests/Search/Request/HighlightingUsageTests.cs
@@ -145,7 +145,9 @@ namespace Tests.Search.Request
 							}
 						}
 					}
-				}
+				},
+				max_analyzer_offset = 1_000_000
+				
 			}
 		};
 
@@ -200,6 +202,7 @@ namespace Tests.Search.Request
 							)
 						)
 				)
+				.MaxAnalyzerOffset(1_000_000) //the default value
 			);
 
 		protected override SearchRequest<Project> Initializer =>
@@ -261,7 +264,8 @@ namespace Tests.Search.Request
 								}
 							}
 						}
-					}
+					},
+					MaxAnalyzerOffset = 1_000_000
 				}
 			};
 

--- a/tests/Tests/Search/Request/HighlightingUsageTestsWithMaxAnalyzerOffset.cs
+++ b/tests/Tests/Search/Request/HighlightingUsageTestsWithMaxAnalyzerOffset.cs
@@ -31,9 +31,11 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using OpenSearch.Client;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedOpenSearch.Clusters;
 using Tests.Domain;
+using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;
 using Xunit;
 
@@ -45,13 +47,13 @@ namespace Tests.Search.Request
 	*
 	* See the OpenSearch documentation on {ref_current}/search-request-body.html#request-body-search-highlighting[highlighting] for more detail.
 	*/
-	public class HighlightingUsageTests : SearchUsageTestBase
+	[SkipVersion("<2.2.0", "MaxAnalyzerOffset field was introduced in 2.2.0")]
+	public class HighlightingUsageTestsWithMaxAnalyzerOffset : HighlightingUsageTests
 	{
-		public HighlightingUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public HighlightingUsageTestsWithMaxAnalyzerOffset(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
-		public string LastNameSearch { get; } = Project.First.LeadDeveloper.LastName;
-
-		protected override object ExpectJson => new
+		protected override object ExpectJson =>
+		 new
 		{
 			query = new
 			{
@@ -145,11 +147,14 @@ namespace Tests.Search.Request
 							}
 						}
 					}
-				}
+				},
+				max_analyzer_offset = 1_000_000
 			}
 		};
 
 		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			
+			
 			.Query(q => q
 				.Match(m => m
 					.Field(f => f.Name.Suffix("standard"))
@@ -200,6 +205,7 @@ namespace Tests.Search.Request
 							)
 						)
 				)
+				.MaxAnalyzerOffset(1_000_000) //the default value
 			);
 
 		protected override SearchRequest<Project> Initializer =>
@@ -261,7 +267,8 @@ namespace Tests.Search.Request
 								}
 							}
 						}
-					}
+					},
+					MaxAnalyzerOffset = 1_000_000
 				}
 			};
 

--- a/tests/Tests/Search/Request/HighlightingUsageTestsWithMaxAnalyzerOffset.cs
+++ b/tests/Tests/Search/Request/HighlightingUsageTestsWithMaxAnalyzerOffset.cs
@@ -94,7 +94,8 @@ namespace Tests.Search.Request
 							{ "fragment_size", 150 },
 							{ "fragmenter", "span" },
 							{ "number_of_fragments", 3 },
-							{ "no_match_size", 150 }
+							{ "no_match_size", 150 },
+							{ "max_analyzer_offset", 500 }
 						}
 					},
 					{
@@ -179,7 +180,8 @@ namespace Tests.Search.Request
 						.FragmentSize(150)
 						.Fragmenter(HighlighterFragmenter.Span)
 						.NumberOfFragments(3)
-						.NoMatchSize(150),
+						.NoMatchSize(150)
+						.MaxAnalyzerOffset(500),
 					fs => fs
 						.Field(p => p.LeadDeveloper.FirstName)
 						.Type(HighlighterType.Fvh)
@@ -236,7 +238,8 @@ namespace Tests.Search.Request
 								FragmentSize = 150,
 								Fragmenter = HighlighterFragmenter.Span,
 								NumberOfFragments = 3,
-								NoMatchSize = 150
+								NoMatchSize = 150,
+								MaxAnalyzerOffset = 500
 							}
 						},
 						{


### PR DESCRIPTION
Fix field `max_analyzed_offset` to `max_analyzer_offset`  

### Description
The current field `max_analyzed_offset` used in ElasticSearch doesn't match the field added to OpenSearch version 2.2.0, `max_analyzer_offset`.
This means the current client implementation have two problems:

It doesn't work for versions before version 2.2.0, because no equivalent field exist on OpenSearch.
It doesn't work for version after 2.2.0, because the field is misspelled.

Even though the Property changes, which is normally a breaking change, since the current field is unusable, this change is not "breaking" anything.


For further information see:
- https://github.com/opensearch-project/opensearch-java/pull/555
- https://github.com/opensearch-project/OpenSearch/pull/4031
- https://github.com/opensearch-project/OpenSearch/pull/3893


### Issues Resolved:

- #321 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).