### PR TITLE
[Backport 1.x] Bump Microsoft.TestPlatform.ObjectModel from 17.6.3 to 17.7.1 (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Dependencies
-- Bumps `Microsoft.TestPlatform.ObjectModel` from 17.5.0 to 17.6.3
+- Bumps `Microsoft.TestPlatform.ObjectModel` from 17.5.0 to 17.7.1
 - Bumps `JunitXml.TestLogger` from 3.0.124 to 3.0.134
 - Bumps `System.Reflection.Emit.Lightweight` from 4.3.0 to 4.7.0
 - Bumps `BenchMarkDotNet` from 0.13.5 to 0.13.7

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.6.3" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.1" />
     
     <PackageReference Include="xunit" Version="2.4.2" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Xunit\OpenSearch.OpenSearch.Xunit.csproj" />


### PR DESCRIPTION
### Description
Backport 828ae3aca8d83d90ae8aba90d3727b991f999273 from #326 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
