### PR TITLE
Fix null-ref exception when track total hits is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix highlight max_analyzer_offset field name to match with the one introduced in OpenSearch 2.2.0 ([#322](https://github.com/opensearch-project/opensearch-net/pull/322))
+- Fix null-ref exception when track total hits is disabled ([#341](https://github.com/opensearch-project/opensearch-net/pull/341))
 
 ### Removed
 - Removed the `Features` API which is not supported by OpenSearch from the low-level client ([#331](https://github.com/opensearch-project/opensearch-net/pull/331))

--- a/src/OpenSearch.Client/Search/Search/SearchResponse.cs
+++ b/src/OpenSearch.Client/Search/Search/SearchResponse.cs
@@ -50,7 +50,8 @@ namespace OpenSearch.Client
 		ClusterStatistics Clusters { get; }
 
 		/// <summary>
-		/// Gets the documents inside the hits, by deserializing <see cref="IHitMetadata{T}.Source" /> into <typeparamref name="TDocument" />
+		/// Gets the documents inside the hits, by deserializing <see cref="IHitMetadata{T}.Source" />
+		/// into <typeparamref name="TDocument" />
 		/// <para>
 		/// NOTE: if you use <see cref="ISearchRequest.StoredFields" /> on the search request,
 		/// <see cref="Documents" /> will be empty and you should use <see cref="Fields" />
@@ -143,7 +144,7 @@ namespace OpenSearch.Client
 		private IReadOnlyCollection<IHit<TDocument>> _hits;
 
 		/// <inheritdoc />
-		[DataMember(Name ="aggregations")]
+		[DataMember(Name = "aggregations")]
 		public AggregateDictionary Aggregations { get; internal set; } = AggregateDictionary.Default;
 
 		/// <inheritdoc />
@@ -170,7 +171,7 @@ namespace OpenSearch.Client
 			_hits ?? (_hits = HitsMetadata?.Hits ?? EmptyReadOnly<IHit<TDocument>>.Collection);
 
 		/// <inheritdoc />
-		[DataMember(Name ="hits")]
+		[DataMember(Name = "hits")]
 		public IHitsMetadata<TDocument> HitsMetadata { get; internal set; }
 
 		/// <inheritdoc />
@@ -178,11 +179,11 @@ namespace OpenSearch.Client
 		public double MaxScore => HitsMetadata?.MaxScore ?? 0;
 
 		/// <inheritdoc />
-		[DataMember(Name ="num_reduce_phases")]
+		[DataMember(Name = "num_reduce_phases")]
 		public long NumberOfReducePhases { get; internal set; }
 
 		/// <inheritdoc />
-		[DataMember(Name ="profile")]
+		[DataMember(Name = "profile")]
 		public Profile Profile { get; internal set; }
 
 		/// <inheritdoc />
@@ -190,27 +191,27 @@ namespace OpenSearch.Client
 		public string ScrollId { get; internal set; }
 
 		/// <inheritdoc />
-		[DataMember(Name ="_shards")]
+		[DataMember(Name = "_shards")]
 		public ShardStatistics Shards { get; internal set; }
 
 		/// <inheritdoc />
-		[DataMember(Name ="suggest")]
+		[DataMember(Name = "suggest")]
 		public ISuggestDictionary<TDocument> Suggest { get; internal set; } = SuggestDictionary<TDocument>.Default;
 
 		/// <inheritdoc />
-		[DataMember(Name ="terminated_early")]
+		[DataMember(Name = "terminated_early")]
 		public bool TerminatedEarly { get; internal set; }
 
 		/// <inheritdoc />
-		[DataMember(Name ="timed_out")]
+		[DataMember(Name = "timed_out")]
 		public bool TimedOut { get; internal set; }
 
 		/// <inheritdoc />
-		[DataMember(Name ="took")]
+		[DataMember(Name = "took")]
 		public long Took { get; internal set; }
 
 		/// <inheritdoc />
 		[IgnoreDataMember]
-		public long Total => HitsMetadata?.Total.Value ?? -1;
+		public long Total => HitsMetadata?.Total?.Value ?? -1;
 	}
 }


### PR DESCRIPTION
### Description
Fixes `NullReferenceException` when accessing `SearchResponse<TDocument>.Total` property if `TrackTotalHits` is `false`.

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
