### PR TITLE
[Backport 1.x] Bump Microsoft.TestPlatform.ObjectModel from 17.7.1 to 17.7.2 (#345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix null-ref exception when track total hits is disabled ([#341](https://github.com/opensearch-project/opensearch-net/pull/341))
 
 ### Dependencies
-- Bumps `Microsoft.TestPlatform.ObjectModel` from 17.5.0 to 17.7.1
+- Bumps `Microsoft.TestPlatform.ObjectModel` from 17.5.0 to 17.7.2
 - Bumps `JunitXml.TestLogger` from 3.0.124 to 3.0.134
 - Bumps `System.Reflection.Emit.Lightweight` from 4.3.0 to 4.7.0
 - Bumps `BenchMarkDotNet` from 0.13.5 to 0.13.7

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.1" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" />
     
     <PackageReference Include="xunit" Version="2.4.2" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Xunit\OpenSearch.OpenSearch.Xunit.csproj" />


### PR DESCRIPTION
### Description
Backports b54e353f0c92f5f316b3b6ee0947e85a4284067e from #345 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
