### PR TITLE
Support deprecation and added versions for API methods in ApiGenerator

### DIFF
--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSwag.Core.Yaml" Version="13.20.0" />
+    <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.47.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20371.2" />

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/BoundFluentMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/BoundFluentMethod.cs
@@ -30,13 +30,14 @@ using System.Collections.Generic;
 using System.Linq;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain.Specification;
+using SemanticVersioning;
 
 namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
     public class BoundFluentMethod : FluentSyntaxBase
     {
-        public BoundFluentMethod(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary, Deprecation deprecated)
-            : base(names, parts, selectorIsOptional, link, summary, deprecated) { }
+        public BoundFluentMethod(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary, Deprecation deprecated, Version versionAdded)
+            : base(names, parts, selectorIsOptional, link, summary, deprecated, versionAdded) { }
 
         private string DescriptorTypeParams => string.Join(", ", CsharpNames.DescriptorGenerics
             .Select(e => CsharpNames.DescriptorBoundDocumentGeneric));

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/BoundFluentMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/BoundFluentMethod.cs
@@ -31,16 +31,16 @@ using System.Linq;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain.Specification;
 
-namespace ApiGenerator.Domain.Code.HighLevel.Methods 
+namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
     public class BoundFluentMethod : FluentSyntaxBase
     {
-        public BoundFluentMethod(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary) 
-            : base(names, parts, selectorIsOptional, link, summary) { }
+        public BoundFluentMethod(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary, Deprecation deprecated)
+            : base(names, parts, selectorIsOptional, link, summary, deprecated) { }
 
         private string DescriptorTypeParams => string.Join(", ", CsharpNames.DescriptorGenerics
             .Select(e => CsharpNames.DescriptorBoundDocumentGeneric));
-        
+
         private string RequestTypeParams => string.Join(", ", CsharpNames.SplitGeneric(CsharpNames.GenericsDeclaredOnRequest)
             .Select(e => CsharpNames.DescriptorBoundDocumentGeneric));
 
@@ -48,17 +48,17 @@ namespace ApiGenerator.Domain.Code.HighLevel.Methods
             || !CodeConfiguration.GenericOnlyInterfaces.Contains(CsharpNames.RequestInterfaceName)
                 ? CsharpNames.RequestInterfaceName
                 : $"{CsharpNames.RequestInterfaceName}<{RequestTypeParams}>";
-        
+
         public override string DescriptorName => $"{CsharpNames.DescriptorName}<{DescriptorTypeParams}>";
         public override string GenericWhereClause => $"where {CsharpNames.DescriptorBoundDocumentGeneric} : class";
         public override string MethodGenerics => $"<{CsharpNames.DescriptorBoundDocumentGeneric}>";
-        
-        public override string RequestMethodGenerics => !string.IsNullOrWhiteSpace(RequestTypeParams) 
+
+        public override string RequestMethodGenerics => !string.IsNullOrWhiteSpace(RequestTypeParams)
             ? $"<{RequestTypeParams}>"
             : base.RequestMethodGenerics;
-        
+
         public override string Selector => $"Func<{DescriptorName}, {SelectorReturn}>";
-        
+
 
     }
 }

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentMethod.cs
@@ -30,12 +30,12 @@ using System.Collections.Generic;
 using System.Linq;
 using ApiGenerator.Domain.Specification;
 
-namespace ApiGenerator.Domain.Code.HighLevel.Methods 
+namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
     public class FluentMethod : FluentSyntaxBase
     {
-        public FluentMethod(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary) 
-            : base(names, parts, selectorIsOptional, link, summary) { }
+        public FluentMethod(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary, Deprecation deprecated)
+            : base(names, parts, selectorIsOptional, link, summary, deprecated) { }
 
         public override string GenericWhereClause =>
             string.Join(" ", CsharpNames.HighLevelDescriptorMethodGenerics

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentMethod.cs
@@ -29,13 +29,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using ApiGenerator.Domain.Specification;
+using SemanticVersioning;
 
 namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
     public class FluentMethod : FluentSyntaxBase
     {
-        public FluentMethod(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary, Deprecation deprecated)
-            : base(names, parts, selectorIsOptional, link, summary, deprecated) { }
+        public FluentMethod(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary, Deprecation deprecated, Version versionAdded)
+            : base(names, parts, selectorIsOptional, link, summary, deprecated, versionAdded) { }
 
         public override string GenericWhereClause =>
             string.Join(" ", CsharpNames.HighLevelDescriptorMethodGenerics

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentSyntaxBase.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/FluentSyntaxBase.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain.Specification;
+using SemanticVersioning;
 
 namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
@@ -37,8 +38,8 @@ namespace ApiGenerator.Domain.Code.HighLevel.Methods
     {
         private readonly bool _selectorIsOptional;
 
-        protected FluentSyntaxBase(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary, Deprecation deprecated)
-            : base(names, link, summary, deprecated) =>
+        protected FluentSyntaxBase(CsharpNames names, IReadOnlyCollection<UrlPart> parts, bool selectorIsOptional, string link, string summary, Deprecation deprecated, Version versionAdded)
+            : base(names, link, summary, deprecated, versionAdded) =>
             (UrlParts, _selectorIsOptional) = (CreateDescriptorArgs(parts), selectorIsOptional);
 
         private IReadOnlyCollection<UrlPart> UrlParts { get; }

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/InitializerMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/InitializerMethod.cs
@@ -29,12 +29,13 @@
 using System.Linq;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain.Specification;
+using SemanticVersioning;
 
 namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
     public class InitializerMethod : MethodSyntaxBase
     {
-        public InitializerMethod(CsharpNames names, string link, string summary, Deprecation deprecated) : base(names, link, summary, deprecated) { }
+        public InitializerMethod(CsharpNames names, string link, string summary, Deprecation deprecated, Version versionAdded) : base(names, link, summary, deprecated, versionAdded) { }
 
         public string MethodName => CsharpNames.MethodName;
 

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/InitializerMethod.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/InitializerMethod.cs
@@ -28,12 +28,13 @@
 
 using System.Linq;
 using ApiGenerator.Configuration;
+using ApiGenerator.Domain.Specification;
 
 namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
     public class InitializerMethod : MethodSyntaxBase
     {
-        public InitializerMethod(CsharpNames names, string link, string summary) : base(names, link, summary) { }
+        public InitializerMethod(CsharpNames names, string link, string summary, Deprecation deprecated) : base(names, link, summary, deprecated) { }
 
         public string MethodName => CsharpNames.MethodName;
 

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/MethodSyntaxBase.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/MethodSyntaxBase.cs
@@ -26,16 +26,20 @@
 *  under the License.
 */
 
+using ApiGenerator.Domain.Specification;
+
 namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
     public abstract class MethodSyntaxBase
     {
-        protected MethodSyntaxBase(CsharpNames names, string link, string summary) =>
-            (CsharpNames, DocumentationLink, XmlDocSummary) = (names, link, summary);
+        protected MethodSyntaxBase(CsharpNames names, string link, string summary, Deprecation deprecated) =>
+            (CsharpNames, DocumentationLink, XmlDocSummary, Deprecated) = (names, link, summary, deprecated);
 
         public string DocumentationLink { get;  }
 
         public string XmlDocSummary { get;  }
+
+		public Deprecation Deprecated { get; }
 
         protected CsharpNames CsharpNames { get; }
 

--- a/src/ApiGenerator/Domain/Code/HighLevel/Methods/MethodSyntaxBase.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Methods/MethodSyntaxBase.cs
@@ -27,19 +27,22 @@
 */
 
 using ApiGenerator.Domain.Specification;
+using SemanticVersioning;
 
 namespace ApiGenerator.Domain.Code.HighLevel.Methods
 {
     public abstract class MethodSyntaxBase
     {
-        protected MethodSyntaxBase(CsharpNames names, string link, string summary, Deprecation deprecated) =>
-            (CsharpNames, DocumentationLink, XmlDocSummary, Deprecated) = (names, link, summary, deprecated);
+        protected MethodSyntaxBase(CsharpNames names, string link, string summary, Deprecation deprecated, Version versionAdded) =>
+            (CsharpNames, DocumentationLink, XmlDocSummary, Deprecated, VersionAdded) = (names, link, summary, deprecated, versionAdded);
 
         public string DocumentationLink { get;  }
 
         public string XmlDocSummary { get;  }
 
 		public Deprecation Deprecated { get; }
+
+		public Version VersionAdded { get; set; }
 
         protected CsharpNames CsharpNames { get; }
 

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/Constructor.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/Constructor.cs
@@ -127,7 +127,7 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
                     Parameterless = true,
                     Generated = $"protected {typeName}() : base()",
                     Description =
-                        $"///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>{Indent}[SerializationConstructor]",
+                        $"/// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>{Indent}[SerializationConstructor]",
                 });
             return constructors;
         }

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/DescriptorPartialImplementation.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/DescriptorPartialImplementation.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ApiGenerator.Domain.Specification;
 
-namespace ApiGenerator.Domain.Code.HighLevel.Requests 
+namespace ApiGenerator.Domain.Code.HighLevel.Requests
 {
     public class DescriptorPartialImplementation
     {
@@ -41,7 +41,7 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
         public IReadOnlyCollection<UrlPath> Paths { get; set; }
         public IReadOnlyCollection<QueryParameters> Params { get; set; }
         public bool HasBody { get; set; }
-        
+
         public IEnumerable<FluentRouteSetter> GetFluentRouteSetters()
         {
             var setters = new List<FluentRouteSetter>();
@@ -67,26 +67,26 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
 
                 var code =
                     $"public {returnType} {p.InterfaceName}({p.HighLevelTypeName} {paramName}) => Assign({paramName}, (a,v)=>a.RouteValues.{routeSetter}(\"{p.Name}\", {routeValue}));";
-                var xmlDoc = $"///<summary>{p.Description}</summary>";
+                var xmlDoc = $"/// <summary>{p.Description}</summary>";
                 setters.Add(new FluentRouteSetter { Code = code, XmlDoc = xmlDoc });
                 if (paramName == "index")
                 {
                     code = $"public {returnType} {p.InterfaceName}<TOther>() where TOther : class ";
                     code += $"=> Assign(typeof(TOther), (a,v)=>a.RouteValues.{routeSetter}(\"{p.Name}\", ({p.HighLevelTypeName})v));";
-                    xmlDoc = $"///<summary>a shortcut into calling {p.InterfaceName}(typeof(TOther))</summary>";
+                    xmlDoc = $"/// <summary>a shortcut into calling {p.InterfaceName}(typeof(TOther))</summary>";
                     setters.Add(new FluentRouteSetter { Code = code, XmlDoc = xmlDoc });
                 }
                 if (paramName == "index" && p.Type == "list")
                 {
                     code = $"public {returnType} AllIndices() => Index(Indices.All);";
-                    xmlDoc = $"///<summary>A shortcut into calling Index(Indices.All)</summary>";
+                    xmlDoc = $"/// <summary>A shortcut into calling Index(Indices.All)</summary>";
                     setters.Add(new FluentRouteSetter { Code = code, XmlDoc = xmlDoc });
                 }
                 if (paramName == "fields" && p.Type == "list")
                 {
                     code = $"public {returnType} Fields<T>(params Expression<Func<T, object>>[] fields) ";
                     code += $"=> Assign(fields, (a,v)=>a.RouteValues.{routeSetter}(\"fields\", (Fields)v));";
-                    xmlDoc = $"///<summary>{p.Description}</summary>";
+                    xmlDoc = $"/// <summary>{p.Description}</summary>";
                     setters.Add(new FluentRouteSetter { Code = code, XmlDoc = xmlDoc });
                 }
             }

--- a/src/ApiGenerator/Domain/RestApiSpec.cs
+++ b/src/ApiGenerator/Domain/RestApiSpec.cs
@@ -66,7 +66,7 @@ namespace ApiGenerator.Domain
                 var urlParameterEnums = Endpoints
 					.Values
 					.SelectMany(e => e.Url.Params.Values)
-					.Where(p => p.Options != null && p.Options.Any())
+					.Where(p => !p.Skip && p.Options != null && p.Options.Any())
 					.Select(p => new EnumDescription
 					{
 						Name = p.ClsName,

--- a/src/ApiGenerator/Domain/Specification/ApiEndpoint.cs
+++ b/src/ApiGenerator/Domain/Specification/ApiEndpoint.cs
@@ -33,6 +33,7 @@ using ApiGenerator.Domain.Code;
 using ApiGenerator.Domain.Code.HighLevel.Methods;
 using ApiGenerator.Domain.Code.HighLevel.Requests;
 using ApiGenerator.Domain.Code.LowLevel;
+using SemanticVersioning;
 
 namespace ApiGenerator.Domain.Specification
 {
@@ -78,7 +79,7 @@ namespace ApiGenerator.Domain.Specification
             CsharpNames = CsharpNames,
             OfficialDocumentationLink = OfficialDocumentationLink?.Url,
             Stability = Stability,
-            Paths = Url.Paths,
+            Paths = Url.Paths.ToList(),
             Parts = Url.Parts,
             Params = ParamsToGenerate.ToList(),
             Constructors = Constructor.RequestConstructors(CsharpNames, Url, inheritsFromPlainRequestBase: true).ToList(),
@@ -91,7 +92,7 @@ namespace ApiGenerator.Domain.Specification
             CsharpNames = CsharpNames,
             OfficialDocumentationLink = OfficialDocumentationLink?.Url,
             Constructors = Constructor.DescriptorConstructors(CsharpNames, Url).ToList(),
-            Paths = Url.Paths,
+            Paths = Url.Paths.ToList(),
             Parts = Url.Parts,
             Params = ParamsToGenerate.ToList(),
             HasBody = Body != null,
@@ -120,9 +121,17 @@ namespace ApiGenerator.Domain.Specification
 		private bool BodyIsOptional => Body is not { Required: true } || HttpMethods.Contains("GET");
 
 		private Deprecation Deprecated =>
-			Url.OriginalPaths.Count == 0 && Url.DeprecatedPaths.Count > 0
-				? Url.DeprecatedPaths.Select(p => new Deprecation { Description = p.Description, Version = p.Version }).FirstOrDefault()
+			!Url.Paths.Any() && Url.AllPaths.Count > 0
+				? Url.DeprecatedPaths
+					.Select(p => p.Deprecation)
+					.MaxBy(d => d.Version)
 				: null;
+
+		private Version VersionAdded =>
+			Url.AllPaths
+				.Select(p => p.VersionAdded)
+				.Where(v => v != null)
+				.Min();
 
         public HighLevelModel HighLevelModel => new()
 		{
@@ -131,7 +140,8 @@ namespace ApiGenerator.Domain.Specification
                 selectorIsOptional: BodyIsOptional,
                 link: OfficialDocumentationLink?.Url,
                 summary: HighLevelMethodXmlDocDescription,
-				deprecated: Deprecated
+				deprecated: Deprecated,
+				versionAdded: VersionAdded
             ),
             FluentBound = !CsharpNames.DescriptorBindsOverMultipleDocuments
                 ? null
@@ -139,12 +149,14 @@ namespace ApiGenerator.Domain.Specification
                     selectorIsOptional: BodyIsOptional,
                     link: OfficialDocumentationLink?.Url,
                     summary: HighLevelMethodXmlDocDescription,
-					deprecated: Deprecated
+					deprecated: Deprecated,
+					versionAdded: VersionAdded
                 ),
             Initializer = new InitializerMethod(CsharpNames,
                 link: OfficialDocumentationLink?.Url,
                 summary: HighLevelMethodXmlDocDescription,
-				deprecated: Deprecated
+				deprecated: Deprecated,
+				versionAdded: VersionAdded
             )
         };
 
@@ -163,7 +175,7 @@ namespace ApiGenerator.Domain.Specification
                     Generator.ApiGenerator.Warnings.Add($"API '{Name}' has no documentation");
 
                 var httpMethod = PreferredHttpMethod;
-                foreach (var path in Url.PathsWithDeprecations)
+                foreach (var path in Url.AllPaths)
                 {
                     var methodName = CsharpNames.PerPathMethodName(path.Path);
                     var parts = new List<UrlPart>(path.Parts);
@@ -193,11 +205,12 @@ namespace ApiGenerator.Domain.Specification
                         HttpMethod = httpMethod,
                         OfficialDocumentationLink = OfficialDocumentationLink?.Url,
                         Stability = Stability,
-                        DeprecatedPath = path.Deprecation,
+                        Deprecation = path.Deprecation,
                         Path = path.Path,
                         Parts = parts,
                         Url = Url,
-                        HasBody = Body != null
+                        HasBody = Body != null,
+						VersionAdded = path.VersionAdded,
                     };
                     _lowLevelClientMethods.Add(apiMethod);
                 }

--- a/src/ApiGenerator/Domain/Specification/ApiEndpoint.cs
+++ b/src/ApiGenerator/Domain/Specification/ApiEndpoint.cs
@@ -117,24 +117,34 @@ namespace ApiGenerator.Domain.Specification
         public string HighLevelMethodXmlDocDescription =>
             $"<c>{PreferredHttpMethod}</c> request to the <c>{Name}</c> API, read more about this API online:";
 
-        public HighLevelModel HighLevelModel => new HighLevelModel
-        {
+		private bool BodyIsOptional => Body is not { Required: true } || HttpMethods.Contains("GET");
+
+		private Deprecation Deprecated =>
+			Url.OriginalPaths.Count == 0 && Url.DeprecatedPaths.Count > 0
+				? Url.DeprecatedPaths.Select(p => new Deprecation { Description = p.Description, Version = p.Version }).FirstOrDefault()
+				: null;
+
+        public HighLevelModel HighLevelModel => new()
+		{
             CsharpNames = CsharpNames,
             Fluent = new FluentMethod(CsharpNames, Url.Parts,
-                selectorIsOptional: Body == null || !Body.Required || HttpMethods.Contains("GET"),
+                selectorIsOptional: BodyIsOptional,
                 link: OfficialDocumentationLink?.Url,
-                summary: HighLevelMethodXmlDocDescription
+                summary: HighLevelMethodXmlDocDescription,
+				deprecated: Deprecated
             ),
             FluentBound = !CsharpNames.DescriptorBindsOverMultipleDocuments
                 ? null
                 : new BoundFluentMethod(CsharpNames, Url.Parts,
-                    selectorIsOptional: Body == null || !Body.Required || HttpMethods.Contains("GET"),
+                    selectorIsOptional: BodyIsOptional,
                     link: OfficialDocumentationLink?.Url,
-                    summary: HighLevelMethodXmlDocDescription
+                    summary: HighLevelMethodXmlDocDescription,
+					deprecated: Deprecated
                 ),
             Initializer = new InitializerMethod(CsharpNames,
                 link: OfficialDocumentationLink?.Url,
-                summary: HighLevelMethodXmlDocDescription
+                summary: HighLevelMethodXmlDocDescription,
+				deprecated: Deprecated
             )
         };
 

--- a/src/ApiGenerator/Domain/Specification/Deprecation.cs
+++ b/src/ApiGenerator/Domain/Specification/Deprecation.cs
@@ -1,0 +1,44 @@
+// /* SPDX-License-Identifier: Apache-2.0
+// *
+// * The OpenSearch Contributors require contributions made to
+// * this file be licensed under the Apache-2.0 license or a
+// * compatible open source license.
+// *
+// * Modifications Copyright OpenSearch Contributors. See
+// * GitHub history for details.
+// *
+// *  Licensed to Elasticsearch B.V. under one or more contributor
+// *  license agreements. See the NOTICE file distributed with
+// *  this work for additional information regarding copyright
+// *  ownership. Elasticsearch B.V. licenses this file to you under
+// *  the Apache License, Version 2.0 (the "License"); you may
+// *  not use this file except in compliance with the License.
+// *  You may obtain a copy of the License at
+// *
+// * 	http://www.apache.org/licenses/LICENSE-2.0
+// *
+// *  Unless required by applicable law or agreed to in writing,
+// *  software distributed under the License is distributed on an
+// *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// *  KIND, either express or implied.  See the License for the
+// *  specific language governing permissions and limitations
+// *  under the License.
+// */
+
+namespace ApiGenerator.Domain.Specification;
+
+public class Deprecation
+{
+	public string Version { get; set; }
+
+	public string Description { get; set; }
+
+	public override string ToString() =>
+		(!string.IsNullOrEmpty(Version), !string.IsNullOrEmpty(Description)) switch
+		{
+			(true, true) => $"Deprecated as of: {Version}, reason: {Description}",
+			(true, false) => $"Deprecated as of: {Version}",
+			(false, true) => $"reason: {Description}",
+			_ => "deprecated"
+		};
+}

--- a/src/ApiGenerator/Domain/Specification/Deprecation.cs
+++ b/src/ApiGenerator/Domain/Specification/Deprecation.cs
@@ -1,29 +1,30 @@
-// /* SPDX-License-Identifier: Apache-2.0
-// *
-// * The OpenSearch Contributors require contributions made to
-// * this file be licensed under the Apache-2.0 license or a
-// * compatible open source license.
-// *
-// * Modifications Copyright OpenSearch Contributors. See
-// * GitHub history for details.
-// *
-// *  Licensed to Elasticsearch B.V. under one or more contributor
-// *  license agreements. See the NOTICE file distributed with
-// *  this work for additional information regarding copyright
-// *  ownership. Elasticsearch B.V. licenses this file to you under
-// *  the Apache License, Version 2.0 (the "License"); you may
-// *  not use this file except in compliance with the License.
-// *  You may obtain a copy of the License at
-// *
-// * 	http://www.apache.org/licenses/LICENSE-2.0
-// *
-// *  Unless required by applicable law or agreed to in writing,
-// *  software distributed under the License is distributed on an
-// *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// *  KIND, either express or implied.  See the License for the
-// *  specific language governing permissions and limitations
-// *  under the License.
-// */
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ *  Licensed to Elasticsearch B.V. under one or more contributor
+ *  license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright
+ *  ownership. Elasticsearch B.V. licenses this file to you under
+ *  the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 
 namespace ApiGenerator.Domain.Specification;
 

--- a/src/ApiGenerator/Domain/Specification/Deprecation.cs
+++ b/src/ApiGenerator/Domain/Specification/Deprecation.cs
@@ -1,30 +1,30 @@
 /* SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
 /*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- *
- *  Licensed to Elasticsearch B.V. under one or more contributor
- *  license agreements. See the NOTICE file distributed with
- *  this work for additional information regarding copyright
- *  ownership. Elasticsearch B.V. licenses this file to you under
- *  the Apache License, Version 2.0 (the "License"); you may
- *  not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- */
+* Modifications Copyright OpenSearch Contributors. See
+* GitHub history for details.
+*
+*  Licensed to Elasticsearch B.V. under one or more contributor
+*  license agreements. See the NOTICE file distributed with
+*  this work for additional information regarding copyright
+*  ownership. Elasticsearch B.V. licenses this file to you under
+*  the Apache License, Version 2.0 (the "License"); you may
+*  not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
 
 namespace ApiGenerator.Domain.Specification;
 

--- a/src/ApiGenerator/Domain/Specification/QueryParameters.cs
+++ b/src/ApiGenerator/Domain/Specification/QueryParameters.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ApiGenerator.Generator;
+using Version = SemanticVersioning.Version;
 
 namespace ApiGenerator.Domain.Specification
 {
@@ -45,7 +46,7 @@ namespace ApiGenerator.Domain.Specification
 
         public string Description { get; set; }
 
-		public string VersionAdded { get; set; }
+		public Version VersionAdded { get; set; }
 
         public IEnumerable<string> DescriptionHighLevel
         {
@@ -179,7 +180,7 @@ namespace ApiGenerator.Domain.Specification
         }
 
 
-        public string InitializerGenerator(string @namespace, string type, string name, string key, string setter, string versionAdded, params string[] doc) =>
+        public string InitializerGenerator(string @namespace, string type, string name, string key, string setter, Version versionAdded, params string[] doc) =>
             CodeGenerator.Property(@namespace, type, name, key, setter, Obsolete, versionAdded, doc);
     }
 }

--- a/src/ApiGenerator/Domain/Specification/QueryParameters.cs
+++ b/src/ApiGenerator/Domain/Specification/QueryParameters.cs
@@ -97,27 +97,13 @@ namespace ApiGenerator.Domain.Specification
 
         public string Obsolete
         {
-            get
-            {
-                if (!string.IsNullOrEmpty(_obsolete)) return _obsolete;
-                if (Deprecated != null)
-                {
-                    if (!string.IsNullOrEmpty(Deprecated.Version) && !string.IsNullOrEmpty(Deprecated.Description))
-                        return $"Deprecated as of: {Deprecated.Version}, reason: {Deprecated.Description}";
-                    if (!string.IsNullOrEmpty(Deprecated.Version))
-                        return $"Deprecated as of: {Deprecated.Version}";
-                    if (!string.IsNullOrEmpty(Deprecated.Description))
-                        return $"reason: {Deprecated.Description}";
-
-                    return "deprecated";
-                }
-
-                return null;
-            }
-            set => _obsolete = value;
+            get => !string.IsNullOrEmpty(_obsolete)
+				? _obsolete
+				: Deprecated?.ToString();
+			set => _obsolete = value;
         }
 
-        public QueryParameterDeprecation Deprecated { get; set; }
+        public Deprecation Deprecated { get; set; }
 
         public IEnumerable<string> Options { get; set; }
         public string QueryStringKey { get; set; }
@@ -195,12 +181,5 @@ namespace ApiGenerator.Domain.Specification
 
         public string InitializerGenerator(string @namespace, string type, string name, string key, string setter, string versionAdded, params string[] doc) =>
             CodeGenerator.Property(@namespace, type, name, key, setter, Obsolete, versionAdded, doc);
-    }
-
-    public class QueryParameterDeprecation
-    {
-        public string Version { get; set; }
-
-        public string Description { get; set; }
     }
 }

--- a/src/ApiGenerator/Domain/Specification/UrlPart.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlPart.cs
@@ -30,16 +30,6 @@ using System.Collections.Generic;
 
 namespace ApiGenerator.Domain.Specification
 {
-
-    // Rename this type to Deprecation and remove Path duplication
-    public class DeprecatedPath
-    {
-        public string Version { get; set; }
-        public string Path { get; set; }
-        public string Description { get; set; }
-    }
-
-
     public class UrlPart
     {
         private string _description;
@@ -146,30 +136,23 @@ namespace ApiGenerator.Domain.Specification
             set => _description = CleanUpDescription(value);
         }
 
-        public string InterfaceName
-        {
-            get
-            {
-                switch (Name)
-                {
-                    case "repository": return "RepositoryName";
-                    default: return Name.ToPascalCase();
-                }
-            }
-        }
+        public string InterfaceName =>
+			Name switch
+			{
+				"repository" => "RepositoryName",
+				_ => Name.ToPascalCase()
+			};
 
-        public string Name { get; set; }
+		public string Name { get; set; }
         public string NameAsArgument => Name.ToCamelCase();
         public IEnumerable<string> Options { get; set; }
         public bool Required { get; set; }
         public bool Deprecated { get; set; }
         public string Type { get; set; }
 
-        private string CleanUpDescription(string value)
-        {
-            if (string.IsNullOrWhiteSpace(value)) return value;
-
-            return value.Replace("use `_all` or empty string", "use the special string `_all` or Indices.All");
-        }
-    }
+        private static string CleanUpDescription(string value) =>
+			string.IsNullOrWhiteSpace(value)
+				? value
+				: value.Replace("use `_all` or empty string", "use the special string `_all` or Indices.All");
+	}
 }

--- a/src/ApiGenerator/Domain/Specification/UrlPath.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlPath.cs
@@ -95,7 +95,7 @@ namespace ApiGenerator.Domain.Specification
 
         public string GetXmlDocs(string indent, bool skipResolvable = false, bool documentConstructor = false)
         {
-            var doc = $@"///<summary>{Path}</summary>";
+            var doc = $@"/// <summary>{Path}</summary>";
             var parts = Parts.Where(p => !skipResolvable || !ResolvabeFromT.Contains(p.Name)).ToList();
             if (!parts.Any()) return doc;
 
@@ -112,7 +112,7 @@ namespace ApiGenerator.Domain.Specification
             }
         }
 
-        private string P(string name, string description) => $"///<param name=\"{name}\">{description}</param>";
+        private string P(string name, string description) => $"/// <param name=\"{name}\">{description}</param>";
 
         private string LeadingBackslash(string p) => p.StartsWith("/") ? p : $"/{p}";
     }

--- a/src/ApiGenerator/Domain/Specification/UrlPath.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlPath.cs
@@ -26,50 +26,28 @@
 *  under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using SemanticVersioning;
 
-namespace ApiGenerator.Domain.Specification 
+namespace ApiGenerator.Domain.Specification
 {
     public class UrlPath
     {
-        private readonly List<UrlPart> _additionalPartsForConstructor;
+        private readonly IList<UrlPart> _additionalPartsForConstructor;
         public string Path { get; }
-        public DeprecatedPath Deprecation { get; }
+        public Deprecation Deprecation { get; }
+		public Version VersionAdded { get; }
+        public IList<UrlPart> Parts { get; }
 
-
-        public List<UrlPart> Parts { get; }
-
-        //TODO mark the parts that are deprecated
-        public UrlPath(DeprecatedPath path, IDictionary<string, UrlPart> originalParts, IReadOnlyCollection<UrlPath> allNonDeprecatedPaths) 
-            : this(path.Path, originalParts)
-        {
-            Deprecation = path;
-            foreach (var part in Parts)
-            {
-                if (!part.Deprecated && !allNonDeprecatedPaths.Any(p => p.Path.Contains($"{{{part.Name}}}")))
-                    part.Deprecated = true;
-            }
-        }
-        public UrlPath(string path, IDictionary<string, UrlPart> allParts, List<UrlPart> additionalPartsForConstructor = null)
+        public UrlPath(string path, IList<UrlPart> parts, Deprecation deprecation, Version versionAdded, IList<UrlPart> additionalPartsForConstructor = null)
         {
             _additionalPartsForConstructor = additionalPartsForConstructor ?? new List<UrlPart>();
             Path = LeadingBackslash(path);
-            if (allParts == null)
-            {
-                Parts = new List<UrlPart>();
-                return;
-            }
-            var parts =
-                from p in allParts
-                //so deliciously side effect-y but at least its more isolated then in ApiEndpoint.CsharpMethods
-                let name = p.Value.Name = p.Key
-                where path.Contains($"{{{name}}}")
-                orderby path.IndexOf($"{{{name}}}", StringComparison.Ordinal)
-                select p.Value;
-            Parts = parts.ToList();
-        }
+            Parts = parts;
+			Deprecation = deprecation;
+			VersionAdded = versionAdded;
+		}
 
         public string ConstructorArguments => string.Join(", ", Parts.Select(p => $"{p.HighLevelTypeName} {p.NameAsArgument}"));
         public string RequestBaseArguments =>

--- a/src/ApiGenerator/Extensions.cs
+++ b/src/ApiGenerator/Extensions.cs
@@ -71,5 +71,8 @@ namespace ApiGenerator
 
 		public static bool IsNullOrEmpty(this string s) =>
 			string.IsNullOrEmpty(s);
+
+		public static void SortBy<TElem, TKey>(this List<TElem> list, Func<TElem, TKey> selector) =>
+			list.Sort((a, b) => Comparer<TKey>.Default.Compare(selector(a), selector(b)));
 	}
 }

--- a/src/ApiGenerator/Generator/ApiEndpointFactory.cs
+++ b/src/ApiGenerator/Generator/ApiEndpointFactory.cs
@@ -192,11 +192,11 @@ namespace ApiGenerator.Generator
 			?? schema.ActualSchema.Enumeration?.Select(e => e.ToString())
 			?? Enumerable.Empty<string>();
 
-		private static QueryParameterDeprecation GetDeprecation(IJsonExtensionObject schema) =>
+		private static Deprecation GetDeprecation(IJsonExtensionObject schema) =>
 			(schema.XDeprecationMessage(), schema.XVersionDeprecated()) switch
 			{
 				(null, null) => null,
-				var (m, v) => new QueryParameterDeprecation { Description = m, Version = v }
+				var (m, v) => new Deprecation { Description = m, Version = v }
 			};
 
 		private static string GetDescription(OpenApiRequestBody requestBody)

--- a/src/ApiGenerator/Generator/ApiEndpointFactory.cs
+++ b/src/ApiGenerator/Generator/ApiEndpointFactory.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Mime;
+using System.Text.RegularExpressions;
 using ApiGenerator.Configuration;
 using ApiGenerator.Configuration.Overrides;
 using ApiGenerator.Domain;
@@ -39,6 +40,8 @@ using ApiGenerator.Domain.Specification;
 using NJsonSchema;
 using NJsonSchema.References;
 using NSwag;
+using SemanticVersioning;
+using Version = SemanticVersioning.Version;
 
 namespace ApiGenerator.Generator
 {
@@ -50,63 +53,103 @@ namespace ApiGenerator.Generator
 	        var methodName = tokens[^1];
 	        var ns = tokens.Length > 1 ? tokens[0] : null;
 
-	        var urlInfo = new UrlInformation();
-	        HashSet<string> requiredPathParams = null;
-	        var allPathParams = new List<OpenApiParameter>();
+	        HashSet<string> requiredPathParts = null;
+	        var allParts = new Dictionary<string, UrlPart>();
+			var canonicalPaths = new Dictionary<HashSet<string>, UrlPath>(HashSet<string>.CreateSetComparer());
+			var deprecatedPaths = new Dictionary<HashSet<string>, UrlPath>(HashSet<string>.CreateSetComparer());
+			var overloads = new List<(UrlPath Path, List<(string From, string To)> Renames)>();
 
 	        foreach (var (httpPath, path, _, operation) in variants.DistinctBy(v => v.HttpPath))
-	        {
-	            if (!operation.IsDeprecated)
-                    urlInfo.OriginalPaths.Add(httpPath);
-                else
-                {
-                    urlInfo.DeprecatedPaths.Add(new DeprecatedPath
-                    {
-                        Path = httpPath,
-                        Version = operation.GetExtension("x-version-deprecated") as string,
-                        Description = operation.GetExtension("x-deprecation-message") as string
-                    });
-                }
+			{
+				var parts = new List<UrlPart>();
+				var partNames = new HashSet<string>();
+				var overloadedParts = new List<(string From, string To)>();
 
-	            var pathParams = path.Parameters
-	                .Concat(operation.Parameters)
-	                .Where(p => p.Kind == OpenApiParameterKind.Path)
-	                .ToList();
-
-				foreach (var overloadedParam in pathParams.Where(p => p.Schema.XOverloadedParam() != null))
+				foreach (var param in path.Parameters
+							 .Concat(operation.Parameters)
+							 .Where(p => p.Kind == OpenApiParameterKind.Path))
 				{
-					urlInfo.OriginalPaths.Add(httpPath.Replace(
-						$"{{{overloadedParam.Name}}}",
-						$"{{{overloadedParam.Schema.XOverloadedParam()}}}"
-					));
+					var partName = param.Name;
+					if (!allParts.TryGetValue(partName, out var part))
+					{
+						part = allParts[partName] = new UrlPart
+						{
+							ClrTypeNameOverride = null,
+							Deprecated = param.IsDeprecated,
+							Description = param.Description,
+							Name = partName,
+							Type = GetOpenSearchType(param.Schema),
+							Options = GetEnumOptions(param.Schema)
+						};
+					}
+					partNames.Add(partName);
+					parts.Add(part);
+
+					if (param.Schema.XOverloadedParam() is {} overloadedParam) overloadedParts.Add((partName, overloadedParam));
 				}
 
-	            var paramNames = pathParams.Select(p => p.Name);
-				if (requiredPathParams != null)
-	                requiredPathParams.IntersectWith(paramNames);
-	            else
-	                requiredPathParams = new HashSet<string>(paramNames);
+				parts.SortBy(p => httpPath.IndexOf($"{{{p.Name}}}", StringComparison.Ordinal));
 
-	            allPathParams.AddRange(pathParams);
+				var urlPath = new UrlPath(httpPath, parts, GetDeprecation(operation), operation.XVersionAdded());
+				(urlPath.Deprecation == null ? canonicalPaths : deprecatedPaths).TryAdd(partNames, urlPath);
+
+				if (overloadedParts.Count > 0)
+					overloads.Add((urlPath, overloadedParts));
+
+				if (requiredPathParts != null)
+	                requiredPathParts.IntersectWith(partNames);
+	            else
+	                requiredPathParts = partNames;
 	        }
 
-	        urlInfo.OriginalParts = allPathParams.DistinctBy(p => p.Name)
-	            .Select(p => new UrlPart
-	            {
-	                ClrTypeNameOverride = null,
-	                Deprecated = p.IsDeprecated,
-	                Description = p.Description,
-	                Name = p.Name,
-	                Required = requiredPathParams?.Contains(p.Name) ?? false,
-	                Type = GetOpenSearchType(p.Schema),
-	                Options = GetEnumOptions(p.Schema)
-	            })
-	            .ToImmutableSortedDictionary(p => p.Name, p => p);
+			foreach (var (path, renames) in overloads)
+			{
+				foreach (var (from, to) in renames)
+				{
+					var newPath = path.Path.Replace($"{{{from}}}", $"{{{to}}}");
+					var newParts = path.Parts.Select(p => p.Name == from ? allParts[to] : p).ToList();
+					var newPartNames = newParts.Select(p => p.Name).ToHashSet();
+					var newUrlPath = new UrlPath(newPath, newParts, path.Deprecation, path.VersionAdded);
+					(newUrlPath.Deprecation == null ? canonicalPaths : deprecatedPaths).TryAdd(newPartNames, newUrlPath);
+				}
+			}
 
-	        urlInfo.Params = variants.SelectMany(v => v.Path.Parameters.Concat(v.Operation.Parameters))
-	            .Where(p => p.Kind == OpenApiParameterKind.Query)
-	            .DistinctBy(p => p.Name)
-	            .ToImmutableSortedDictionary(p => p.Name, BuildQueryParam);
+			//some deprecated paths describe aliases to the canonical using the same path e.g
+            // PUT /{index}/_mapping/{type}
+            // PUT /{index}/{type}/_mappings
+            //
+            //The following routine dedups these occasions and prefers either the canonical path
+            //or the first duplicate deprecated path
+
+			var paths = canonicalPaths.Values
+				.Concat(deprecatedPaths
+					.Where(p => !canonicalPaths.ContainsKey(p.Key))
+					.Select(p => p.Value))
+				.ToList();
+			paths.Sort((p1, p2) => p1.Parts
+					.Zip(p2.Parts)
+					.Select(t => string.Compare(t.First.Name, t.Second.Name, StringComparison.Ordinal))
+					.SkipWhile(c => c == 0)
+					.FirstOrDefault());
+
+                // // now, check for and prefer deprecated URLs
+                //
+                // var finalPathsWithDeprecations = new List<UrlPath>(_pathsWithDeprecation.Count);
+                //
+                // foreach (var path in _pathsWithDeprecation)
+                // {
+                //     if (path.Deprecation is null &&
+                //         DeprecatedPaths.SingleOrDefault(p => p.Path.Equals(path.Path, StringComparison.OrdinalIgnoreCase)) is { } match)
+                //     {
+                //         finalPathsWithDeprecations.Add(new UrlPath(match, OriginalParts, Paths));
+                //     }
+                //     else
+                //     {
+                //         finalPathsWithDeprecations.Add(path);
+                //     }
+                // }
+
+			foreach (var partName in requiredPathParts ?? Enumerable.Empty<string>()) allParts[partName].Required = true;
 
 	        var endpoint = new ApiEndpoint
 	        {
@@ -120,7 +163,14 @@ namespace ApiGenerator.Generator
 	                Description = variants[0].Operation.Description,
 	                Url = variants[0].Operation.ExternalDocumentation?.Url
 	            },
-	            Url = urlInfo,
+	            Url = new UrlInformation
+				{
+					AllPaths = paths,
+					Params = variants.SelectMany(v => v.Path.Parameters.Concat(v.Operation.Parameters))
+						.Where(p => p.Kind == OpenApiParameterKind.Query)
+						.DistinctBy(p => p.Name)
+						.ToImmutableSortedDictionary(p => p.Name, BuildQueryParam)
+				},
 	            Body = variants
 					.Select(v => v.Operation.RequestBody)
 					.FirstOrDefault(b => b != null) is { } reqBody
@@ -215,8 +265,15 @@ namespace ApiGenerator.Generator
 		private static string XVersionDeprecated(this IJsonExtensionObject schema) =>
 			schema.GetExtension("x-version-deprecated") as string;
 
-		private static string XVersionAdded(this IJsonExtensionObject schema) =>
-			schema.GetExtension("x-version-added") as string;
+		private static Version XVersionAdded(this IJsonExtensionObject schema) =>
+			schema.GetExtension("x-version-added") is string s
+			? s.Split('.').Length switch
+			{
+				1 => new Version($"{s}.0.0"),
+				2 => new Version($"{s}.0"),
+				_ => new Version(s),
+			}
+			: null;
 
 		private static string XDataType(this IJsonExtensionObject schema) =>
 			schema.GetExtension("x-data-type") as string;

--- a/src/ApiGenerator/Generator/CodeGenerator.cs
+++ b/src/ApiGenerator/Generator/CodeGenerator.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ApiGenerator.Domain.Code.HighLevel.Requests;
+using Version = SemanticVersioning.Version;
 
 namespace ApiGenerator.Generator
 {
@@ -45,11 +46,11 @@ namespace ApiGenerator.Generator
         public static string PropertyGenerator(string type, string name, string key, string setter) =>
             $"public {type} {name} {{ get => Q<{type}>(\"{key}\"); set => Q(\"{key}\", {setter}); }}";
 
-        public static string Property(string @namespace, string type, string name, string key, string setter, string obsolete, string versionAdded, params string[] doc)
+        public static string Property(string @namespace, string type, string name, string key, string setter, string obsolete, Version versionAdded, params string[] doc)
         {
             var components = new List<string>();
             foreach (var d in RenderDocumentation(doc)) A(d);
-			if (!string.IsNullOrWhiteSpace(versionAdded)) A($"///<remarks>Supported by OpenSearch servers of version {versionAdded} or greater.</remarks>");
+			if (versionAdded != null) A($"/// <remarks>Supported by OpenSearch servers of version {versionAdded} or greater.</remarks>");
             if (!string.IsNullOrWhiteSpace(obsolete)) A($"[Obsolete(\"{obsolete}\")]");
 
             var generated = @namespace != null && @namespace == "Cat" && name == "Format"

--- a/src/ApiGenerator/Generator/CodeGenerator.cs
+++ b/src/ApiGenerator/Generator/CodeGenerator.cs
@@ -89,15 +89,15 @@ namespace ApiGenerator.Generator
             {
                 case 0: yield break;
                 case 1:
-                    yield return $"///<summary>{doc[0]}</summary>";
+                    yield return $"/// <summary>{doc[0]}</summary>";
 
                     yield break;
                 default:
-                    yield return "///<summary>";
+                    yield return "/// <summary>";
 
                     foreach (var d in doc) yield return $"/// {d}";
 
-                    yield return "///</summary>";
+                    yield return "/// </summary>";
 
                     yield break;
             }

--- a/src/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentMethod.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentMethod.cshtml
@@ -3,10 +3,10 @@
 @inherits ApiGenerator.CodeTemplatePage<FluentSyntaxView>
 @{
 	var method = !Model.Async ? Model.Syntax.MethodName : string.Format("{0}Async", Model.Syntax.MethodName);
-    var asyncKeyword = Model.Syntax.InterfaceResponse && Model.Async ? "async " : String.Empty;
+    var asyncKeyword = Model.Syntax.InterfaceResponse && Model.Async ? "async " : string.Empty;
     var awaitKeyWord = Model.Syntax.InterfaceResponse && Model.Async ? "await ": string.Empty;
-    var configureAwait = Model.Syntax.InterfaceResponse && Model.Async ? ".ConfigureAwait(false)" : String.Empty;
-    
+    var configureAwait = Model.Syntax.InterfaceResponse && Model.Async ? ".ConfigureAwait(false)" : string.Empty;
+
     var requestMethodGenerics = Model.Syntax.RequestMethodGenerics;
     var descriptor = Model.Syntax.DescriptorName;
     var selectorArgs = Model.Syntax.SelectorArguments();

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.Namespace.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.Namespace.cshtml
@@ -18,12 +18,12 @@ using OpenSearch.Net.@(CsharpNames.ApiNamespace).@ns@(CsharpNames.ApiNamespaceSu
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client.@(CsharpNames.ApiNamespace).@ns@(CsharpNames.ApiNamespaceSuffix)
 {
-    ///<summary>
+    /// <summary>
     /// @ns.SplitPascalCase() APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.@ns"/> property
     /// on <see cref="IOpenSearchClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy
     {
         internal @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix)(OpenSearchClient client) : base(client) {}

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.cshtml
@@ -1,6 +1,6 @@
 @using System.Linq
 @using ApiGenerator.Domain
-@using ApiGenerator 
+@using ApiGenerator
 @using ApiGenerator.Domain.Code
 @inherits CodeTemplatePage<RestApiSpec>
 @{ await IncludeGeneratorNotice(); }
@@ -17,15 +17,15 @@ using OpenSearch.Client;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client
 {
-    ///<summary>
-    ///OpenSearch high level client
-    ///</summary>
+    /// <summary>
+    /// OpenSearch high level client
+    /// </summary>
     public partial class OpenSearchClient : IOpenSearchClient
     {
 </text>
     foreach (var ns in namespaces)
     {
-<text>      ///<summary>@(ns.SplitPascalCase()) APIs</summary>
+<text>      /// <summary>@(ns.SplitPascalCase()) APIs</summary>
             public @CsharpNames.HighLevelClientNamespacePrefix@(ns)@CsharpNames.ClientNamespaceSuffix @ns { get; private set; }
 </text>
     }
@@ -41,7 +41,7 @@ namespace OpenSearch.Client
 <text>
         }
 </text>
-    
+
 
     foreach (var kv in Model.EndpointsPerNamespaceHighLevel)
     {

--- a/src/ApiGenerator/Views/HighLevel/Client/Interface/IOpenSearchClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Interface/IOpenSearchClient.cshtml
@@ -15,16 +15,16 @@ using OpenSearch.Client;
 
 namespace OpenSearch.Client
 {
-    ///<summary>
-    ///OpenSearch high level client
-    ///</summary>
-    public partial interface IOpenSearchClient 
+    /// <summary>
+    /// OpenSearch high level client
+    /// </summary>
+    public partial interface IOpenSearchClient
     {
         @foreach(var (ns, endpoints) in Model.EndpointsPerNamespaceHighLevel)
         {
         if (ns != CsharpNames.RootNamespace)
         {
-<text>      ///<summary>@ns.SplitPascalCase() APIs</summary>
+<text>      /// <summary>@ns.SplitPascalCase() APIs</summary>
             @CsharpNames.HighLevelClientNamespacePrefix@(ns)@CsharpNames.ClientNamespaceSuffix @ns { get; }
 </text>
             continue;

--- a/src/ApiGenerator/Views/HighLevel/Client/MethodXmlDocs.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/MethodXmlDocs.cshtml
@@ -6,3 +6,7 @@
 /// @Raw("<para></para>")
 /// <a href="@Model.DocumentationLink">@Model.DocumentationLink</a>
 /// </summary>
+@if (Model.Deprecated is {} deprecation)
+{
+@Raw($"[Obsolete(\"{deprecation}\")]")
+}

--- a/src/ApiGenerator/Views/HighLevel/Client/MethodXmlDocs.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/MethodXmlDocs.cshtml
@@ -1,11 +1,17 @@
 @using ApiGenerator
 @using ApiGenerator.Domain.Code.HighLevel.Methods;
+@using Version = SemanticVersioning.Version;
 @inherits CodeTemplatePage<MethodSyntaxBase>
 /// <summary>
 /// @Raw(Model.XmlDocSummary)
 /// @Raw("<para></para>")
 /// <a href="@Model.DocumentationLink">@Model.DocumentationLink</a>
 /// </summary>
+@if (Model.VersionAdded is {} versionAdded && versionAdded > new Version("1.0.0"))
+{
+<text>/// <remarks>Supported by OpenSearch servers of version @(versionAdded) or greater.</remarks>
+</text>
+}
 @if (Model.Deprecated is {} deprecation)
 {
 @Raw($"[Obsolete(\"{deprecation}\")]")

--- a/src/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
@@ -10,9 +10,9 @@
     var baseInterface = names.GenericOrNonGenericInterfacePreference;
     var apiLookup = $"ApiUrlsLookups.{Model.CsharpNames.Namespace}{Model.CsharpNames.MethodName}";
 }
-    ///<summary>Descriptor for @names.MethodName@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
+    /// <summary>Descriptor for @names.MethodName@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
     public partial class @Raw(type) @(Raw(string.Format(" : RequestDescriptorBase<{0},{1}, {2}>, {2}", type,names.ParametersName, concreteInterface)))
-    { 
+    {
         internal override ApiUrls ApiUrls => @apiLookup;
 @foreach (var c in Model.Constructors)
 {
@@ -50,36 +50,27 @@
     var tSuffix = (t == "bool" || t == "bool?") ? " = true" : "";
     var typed = !string.IsNullOrEmpty(names.GenericsDeclaredOnDescriptor);
     var g = typed ? names.GenericsDeclaredOnDescriptor.Replace("<", "").Replace(">", "") : "T";
-    var desc = param.DescriptionHighLevel.ToList();
-    
-    await IncludeAsync("HighLevel/Descriptors/XmlDocs.cshtml", desc);
 
-	if (!string.IsNullOrWhiteSpace(param.VersionAdded))
-	{
-		<text>
-		///<remarks>Supported by OpenSearch servers of version @(param.VersionAdded) or greater.</remarks></text>
-	}
+    await IncludeAsync("HighLevel/Descriptors/XmlDocs.cshtml", param);
 
 	if(!string.IsNullOrWhiteSpace(param.Obsolete))
     {
-        <text>
-        [Obsolete("@Raw(param.Obsolete)")]
-        </text>
+<text>        [Obsolete("@Raw(param.Obsolete)")]
+</text>
     }
-<text>
-        public @Raw(type) @(param.ClsName)(@param.DescriptorArgumentType @param.ClsArgumentName@tSuffix) => Qs("@original", @(param.ClsArgumentName));
+<text>        public @Raw(type) @(param.ClsName)(@param.DescriptorArgumentType @param.ClsArgumentName@tSuffix) => Qs("@original", @(param.ClsArgumentName));
 </text>
     if (param.IsFieldsParam)
     {
 <text>
-        ///<summary>@param.Description</summary>
+        /// <summary>@param.Description</summary>
         public @Raw(type) @param.ClsName@(Raw(typed ? "" : "<T>"))(params @Raw("Expression<Func<" + g + ", object>>[]") fields) @Raw(typed ? "" : "where " + g + " : class") => Qs("@original", fields?@Raw(".Select(e=>(Field)e)"));
 </text>
     }
     else if (param.IsFieldParam)
     {
 <text>
-        ///<summary>@param.Description</summary>
+        /// <summary>@param.Description</summary>
         public @Raw(type) @param.ClsName@(Raw(typed ? "" : "<T>"))(@Raw("Expression<Func<"+ g +", object>>") field) @Raw(typed ? "" : "where " + g + " : class") => Qs("@original", (Field)field);
 </text>
     }
@@ -90,6 +81,6 @@
         public bool IsUnmapped => true;
         public bool UseIsUnmapped => IsUnmapped;
      </text>
-    }   
+    }
     }
 

--- a/src/ApiGenerator/Views/HighLevel/Descriptors/XmlDocs.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Descriptors/XmlDocs.cshtml
@@ -4,13 +4,14 @@
 	var description = Model.Count == 1 ? Model.First() : string.Join($"{Environment.NewLine}\t\t", Model.Select(d => "/// " + d));
     if (Model.Count == 1)
     {
-<text>      ///<summary>@Raw(description)</summary></text>
+<text>      /// <summary>@Raw(description)</summary>
+</text>
     }
     else
     {
-<text>      ///<summary>
+<text>      /// <summary>
         @Raw(description)
-        ///</summary>
+        /// </summary>
 </text>
     }
 }

--- a/src/ApiGenerator/Views/HighLevel/Descriptors/XmlDocs.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Descriptors/XmlDocs.cshtml
@@ -1,8 +1,10 @@
 @using System.Linq
-@inherits ApiGenerator.CodeTemplatePage<List<string>>
+@using Version = SemanticVersioning.Version
+@inherits ApiGenerator.CodeTemplatePage<ApiGenerator.Domain.Specification.QueryParameters>
 @{
-	var description = Model.Count == 1 ? Model.First() : string.Join($"{Environment.NewLine}\t\t", Model.Select(d => "/// " + d));
-    if (Model.Count == 1)
+	var docs = Model.DescriptionHighLevel.ToList();
+	var description = docs.Count == 1 ? docs.First() : string.Join($"{Environment.NewLine}\t\t", docs.Select(d => "/// " + d));
+    if (docs.Count == 1)
     {
 <text>      /// <summary>@Raw(description)</summary>
 </text>
@@ -14,4 +16,9 @@
         /// </summary>
 </text>
     }
+	if (Model.VersionAdded is {} versionAdded && versionAdded > new Version("1.0.0"))
+	{
+<text>		/// <remarks>Supported by OpenSearch servers of version @(versionAdded) or greater.</remarks>
+</text>
+	}
 }

--- a/src/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
@@ -15,7 +15,7 @@ namespace OpenSearch.Client
         continue;
     }
     var propertyName = $"{endpoint.CsharpNames.Namespace}{endpoint.CsharpNames.MethodName}";
-    var paths = endpoint.Url.Paths.Count == 0 ? endpoint.Url.PathsWithDeprecations : endpoint.Url.Paths;
+    var paths = !endpoint.Url.Paths.Any() ? endpoint.Url.AllPaths : endpoint.Url.Paths;
     <text>
         internal static readonly ApiUrls @(Raw(propertyName)) = new(new [] {@Raw(string.Join(", ", paths.Select(p=>$"\"{p.Path.TrimStart('/')}\"")))});
     </text>

--- a/src/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
@@ -7,7 +7,7 @@
 @{
 	var apiLookup = $"ApiUrlsLookups.{Model.CsharpNames.Namespace}{Model.CsharpNames.MethodName}";
 }
-///<summary>Request for @Model.CsharpNames.MethodName@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
+/// <summary>Request for @Model.CsharpNames.MethodName@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
 @if (Model.Stability != Stability.Stable)
 {
     string warningMessage = "";
@@ -20,8 +20,8 @@
             warningMessage = "this functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.";
             break;
     }
-            
-<text>///@Raw("<remarks>Note: " + Model.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
+
+<text>/// @Raw("<remarks>Note: " + Model.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
 
 </text>}
     public partial class @Raw(Model.Name) @Raw(string.Format(": PlainRequestBase<{0}>, {1}", Model.CsharpNames.ParametersName, Model.InterfaceName))

--- a/src/ApiGenerator/Views/LowLevel/Client/Implementation/OpenSearchLowLevelClient.Namespace.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Implementation/OpenSearchLowLevelClient.Namespace.cshtml
@@ -1,6 +1,6 @@
 @using System.Collections.ObjectModel
 @using System.Linq
-@using ApiGenerator 
+@using ApiGenerator
 @using ApiGenerator.Domain.Code
 @using ApiGenerator.Domain.Specification
 @inherits CodeTemplatePage<KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>>>
@@ -25,20 +25,20 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net.@(CsharpNames.ApiNamespace).@ns@(CsharpNames.ApiNamespaceSuffix)
 {
-    ///<summary>
+    /// <summary>
     /// @ns.SplitPascalCase() APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchLowLevelClient.@ns"/> property
     /// on <see cref="IOpenSearchLowLevelClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class @(CsharpNames.LowLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy
     {
         internal @(CsharpNames.LowLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix)(OpenSearchLowLevelClient client) : base(client) {}
 @if (ns == "Cat")
 {
-    <text>protected override string ContentType { get; } = "text/plain";</text>
+    <text>protected override string ContentType => "text/plain";</text>
 }
-    @{  
+    @{
         var methods = endpoints.SelectMany(e=>e.LowLevelClientMethods).ToList();
         foreach (var method in methods)
         {

--- a/src/ApiGenerator/Views/LowLevel/Client/Implementation/OpenSearchLowLevelClient.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Implementation/OpenSearchLowLevelClient.cshtml
@@ -1,6 +1,6 @@
 @using System.Linq
 @using ApiGenerator.Domain
-@using ApiGenerator 
+@using ApiGenerator
 @using ApiGenerator.Domain.Code
 @inherits CodeTemplatePage<RestApiSpec>
 @{ await IncludeGeneratorNotice(); }
@@ -23,15 +23,15 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net
 {
-    ///<summary>
-    ///OpenSearch low level client
-    ///</summary>
+    /// <summary>
+    /// OpenSearch low level client
+    /// </summary>
     public partial class OpenSearchLowLevelClient : IOpenSearchLowLevelClient
     {
 </text>
     foreach (var ns in namespaces)
     {
-<text>      public @(CsharpNames.LowLevelClientNamespacePrefix)@(ns)@(CsharpNames.ClientNamespaceSuffix) @ns { get; private set; } 
+<text>      public @(CsharpNames.LowLevelClientNamespacePrefix)@(ns)@(CsharpNames.ClientNamespaceSuffix) @ns { get; private set; }
 </text>
     }
 <text>
@@ -46,7 +46,7 @@ namespace OpenSearch.Net
 <text>
         }
 </text>
-    
+
 
     foreach (var (ns, endpoints) in Model.EndpointsPerNamespaceLowLevel)
     {

--- a/src/ApiGenerator/Views/LowLevel/Client/Interface/IOpenSearchLowLevelClient.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Interface/IOpenSearchLowLevelClient.cshtml
@@ -17,17 +17,17 @@ using OpenSearch.Net;
 
 namespace OpenSearch.Net
 {
-    ///<summary>
-    ///OpenSearch low level client
-    ///</summary>
-    public partial interface IOpenSearchLowLevelClient 
+    /// <summary>
+    /// OpenSearch low level client
+    /// </summary>
+    public partial interface IOpenSearchLowLevelClient
     {
         @foreach(var (ns, endpoints) in Model.EndpointsPerNamespaceLowLevel)
         {
         if (ns != CsharpNames.RootNamespace)
         {
 <text>
-            ///<summary>@ns.SplitPascalCase() APIs</summary>
+            /// <summary>@ns.SplitPascalCase() APIs</summary>
             @CsharpNames.LowLevelClientNamespacePrefix@(ns)@CsharpNames.ClientNamespaceSuffix @ns { get; }
 </text>
             continue;

--- a/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodDocs.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodDocs.cshtml
@@ -2,13 +2,13 @@
 @using ApiGenerator.Domain.Code.LowLevel
 @using ApiGenerator.Domain.Specification
 @inherits ApiGenerator.CodeTemplatePage<LowLevelClientMethod>
-///<summary>@Model.HttpMethod on @Model.Path@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
+/// <summary>@Model.HttpMethod on @Model.Path@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
 @foreach (var part in Model.Parts)
 {
-<text>      ///@Raw("<param name=\""+part.NameAsArgument+"\">")@part.Description@Raw("</param>")
+<text>      /// @Raw("<param name=\""+part.NameAsArgument+"\">")@part.Description@Raw("</param>")
 </text>
 }
-        ///@Raw(@"<param name=""requestParameters"">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>")
+        /// @Raw(@"<param name=""requestParameters"">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>")
         @if (Model.Stability != Stability.Stable)
         {
             string warningMessage = "";
@@ -23,9 +23,10 @@
             }
 
             warningMessage += " This functionality is subject to potential breaking changes within a minor version, meaning that your referencing code may break when this library is upgraded.";
-            
-<text>      ///@Raw("<remarks>Note: " + Model.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
 
+<text>      /// @Raw("<remarks>Note: " + Model.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
+
+</text>}
 </text>}
         @if (Model.DeprecatedPath != null)
         {

--- a/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodDocs.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodDocs.cshtml
@@ -1,6 +1,8 @@
 @using ApiGenerator
 @using ApiGenerator.Domain.Code.LowLevel
 @using ApiGenerator.Domain.Specification
+@using SemanticVersioning
+@using Version = SemanticVersioning.Version
 @inherits ApiGenerator.CodeTemplatePage<LowLevelClientMethod>
 /// <summary>@Model.HttpMethod on @Model.Path@(Raw(Model.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + Model.OfficialDocumentationLink + "</para>"))</summary>
 @foreach (var part in Model.Parts)
@@ -27,8 +29,11 @@
 <text>      /// @Raw("<remarks>Note: " + Model.Stability + " within the OpenSearch server, " + warningMessage + "</remarks>")
 
 </text>}
+		@if (Model.VersionAdded is {} versionAdded && versionAdded > new Version("1.0.0"))
+		{
+<text>      /// @Raw("<remarks>Supported by OpenSearch servers of version " + versionAdded + " or greater.</remarks>")
 </text>}
-        @if (Model.DeprecatedPath != null)
+        @if (Model.Deprecation is {} deprecation)
         {
-<text>      [Obsolete("Deprecated in version @Model.DeprecatedPath.Version: @Raw(Model.DeprecatedPath.Description)")]
+<text>      [Obsolete("Deprecated in version @deprecation.Version: @Raw(deprecation.Description)")]
 </text>}

--- a/src/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
@@ -25,8 +25,8 @@ namespace OpenSearch.Net@(ns)
         var supportsBody = endpoint.Body != null;
         var names = r.CsharpNames;
 <text>
-    ///<summary>Request options for @names.MethodName@Raw(r.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + r.OfficialDocumentationLink + "</para>")</summary>
-    public partial class @names.ParametersName : RequestParameters<@names.ParametersName> 
+    /// <summary>Request options for @names.MethodName@Raw(r.OfficialDocumentationLink.IsNullOrEmpty() ? "" : " <para>" + r.OfficialDocumentationLink + "</para>")</summary>
+    public partial class @names.ParametersName : RequestParameters<@names.ParametersName>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.@r.HttpMethod;
         public override bool SupportsBody => @(supportsBody ? "true" : "false");

--- a/src/OpenSearch.Client/_Generated/ApiUrlsLookup.cs
+++ b/src/OpenSearch.Client/_Generated/ApiUrlsLookup.cs
@@ -89,8 +89,8 @@ namespace OpenSearch.Client
                 new[]
                 {
                     "_nodes",
-                    "_nodes/{node_id}",
                     "_nodes/{metric}",
+                    "_nodes/{node_id}",
                     "_nodes/{node_id}/{metric}"
                 }
             );

--- a/src/OpenSearch.Client/_Generated/Descriptors.Cluster.cs
+++ b/src/OpenSearch.Client/_Generated/Descriptors.Cluster.cs
@@ -58,7 +58,7 @@ using OpenSearch.Net.Specification.ClusterApi;
 // ReSharper disable RedundantNameQualifier
 namespace OpenSearch.Client.Specification.ClusterApi
 {
-    ///<summary>Descriptor for AllocationExplain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
+    /// <summary>Descriptor for AllocationExplain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
     public partial class ClusterAllocationExplainDescriptor
         : RequestDescriptorBase<
             ClusterAllocationExplainDescriptor,
@@ -71,17 +71,17 @@ namespace OpenSearch.Client.Specification.ClusterApi
 
         // values part of the url path
         // Request parameters
-        ///<summary>Return information about disk usage and shard sizes.</summary>
+        /// <summary>Return information about disk usage and shard sizes.</summary>
         public ClusterAllocationExplainDescriptor IncludeDiskInfo(bool? includediskinfo = true) =>
             Qs("include_disk_info", includediskinfo);
 
-        ///<summary>Return 'YES' decisions in explanation.</summary>
+        /// <summary>Return 'YES' decisions in explanation.</summary>
         public ClusterAllocationExplainDescriptor IncludeYesDecisions(
             bool? includeyesdecisions = true
         ) => Qs("include_yes_decisions", includeyesdecisions);
     }
 
-    ///<summary>Descriptor for DeleteVotingConfigExclusions <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Descriptor for DeleteVotingConfigExclusions <para>https://opensearch.org/docs/latest</para></summary>
     public partial class DeleteVotingConfigExclusionsDescriptor
         : RequestDescriptorBase<
             DeleteVotingConfigExclusionsDescriptor,
@@ -94,12 +94,12 @@ namespace OpenSearch.Client.Specification.ClusterApi
 
         // values part of the url path
         // Request parameters
-        ///<summary>Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list.</summary>
+        /// <summary>Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list.</summary>
         public DeleteVotingConfigExclusionsDescriptor WaitForRemoval(bool? waitforremoval = true) =>
             Qs("wait_for_removal", waitforremoval);
     }
 
-    ///<summary>Descriptor for GetSettings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
+    /// <summary>Descriptor for GetSettings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
     public partial class ClusterGetSettingsDescriptor
         : RequestDescriptorBase<
             ClusterGetSettingsDescriptor,
@@ -112,31 +112,31 @@ namespace OpenSearch.Client.Specification.ClusterApi
 
         // values part of the url path
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public ClusterGetSettingsDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Return settings in flat format.</summary>
+        /// <summary>Return settings in flat format.</summary>
         public ClusterGetSettingsDescriptor FlatSettings(bool? flatsettings = true) =>
             Qs("flat_settings", flatsettings);
 
-        ///<summary>Whether to return all default clusters setting.</summary>
+        /// <summary>Whether to return all default clusters setting.</summary>
         public ClusterGetSettingsDescriptor IncludeDefaults(bool? includedefaults = true) =>
             Qs("include_defaults", includedefaults);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public ClusterGetSettingsDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public ClusterGetSettingsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for Health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
+    /// <summary>Descriptor for Health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
     public partial class ClusterHealthDescriptor
         : RequestDescriptorBase<
             ClusterHealthDescriptor,
@@ -147,94 +147,94 @@ namespace OpenSearch.Client.Specification.ClusterApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterHealth;
 
-        ///<summary>/_cluster/health</summary>
+        /// <summary>/_cluster/health</summary>
         public ClusterHealthDescriptor()
             : base() { }
 
-        ///<summary>/_cluster/health/{index}</summary>
-        ///<param name="index">Optional, accepts null</param>
+        /// <summary>/_cluster/health/{index}</summary>
+        /// <param name="index">Optional, accepts null</param>
         public ClusterHealthDescriptor(Indices index)
             : base(r => r.Optional("index", index)) { }
 
         // values part of the url path
         Indices IClusterHealthRequest.Index => Self.RouteValues.Get<Indices>("index");
 
-        ///<summary>Limit the information returned to specific indicies.</summary>
+        /// <summary>Limit the information returned to specific indicies.</summary>
         public ClusterHealthDescriptor Index(Indices index) =>
             Assign(index, (a, v) => a.RouteValues.Optional("index", v));
 
-        ///<summary>a shortcut into calling Index(typeof(TOther))</summary>
+        /// <summary>a shortcut into calling Index(typeof(TOther))</summary>
         public ClusterHealthDescriptor Index<TOther>()
             where TOther : class =>
             Assign(typeof(TOther), (a, v) => a.RouteValues.Optional("index", (Indices)v));
 
-        ///<summary>A shortcut into calling Index(Indices.All)</summary>
+        /// <summary>A shortcut into calling Index(Indices.All)</summary>
         public ClusterHealthDescriptor AllIndices() => Index(Indices.All);
 
         // Request parameters
-        ///<summary>The awareness attribute for which the health is required.</summary>
+        /// <summary>The awareness attribute for which the health is required.</summary>
         public ClusterHealthDescriptor AwarenessAttribute(string awarenessattribute) =>
             Qs("awareness_attribute", awarenessattribute);
 
-        ///<summary>Specify the level of detail for returned information.</summary>
+        /// <summary>Specify the level of detail for returned information.</summary>
         public ClusterHealthDescriptor ClusterHealthLevel(ClusterHealthLevel? clusterhealthlevel) =>
             Qs("level", clusterhealthlevel);
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public ClusterHealthDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Checks whether local node is commissioned or not. If set to true on a local call it will throw exception if node is decommissioned.</summary>
+        /// <summary>Checks whether local node is commissioned or not. If set to true on a local call it will throw exception if node is decommissioned.</summary>
         public ClusterHealthDescriptor EnsureNodeCommissioned(
             bool? ensurenodecommissioned = true
         ) => Qs("ensure_node_commissioned", ensurenodecommissioned);
 
-        ///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+        /// <summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
         public ClusterHealthDescriptor ExpandWildcards(ExpandWildcards? expandwildcards) =>
             Qs("expand_wildcards", expandwildcards);
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public ClusterHealthDescriptor Local(bool? local = true) => Qs("local", local);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public ClusterHealthDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public ClusterHealthDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 
-        ///<summary>Wait until the specified number of shards is active.</summary>
+        /// <summary>Wait until the specified number of shards is active.</summary>
         public ClusterHealthDescriptor WaitForActiveShards(string waitforactiveshards) =>
             Qs("wait_for_active_shards", waitforactiveshards);
 
-        ///<summary>Wait until all currently queued events with the given priority are processed.</summary>
+        /// <summary>Wait until all currently queued events with the given priority are processed.</summary>
         public ClusterHealthDescriptor WaitForEvents(WaitForEvents? waitforevents) =>
             Qs("wait_for_events", waitforevents);
 
-        ///<summary>Wait until the specified number of nodes is available.</summary>
+        /// <summary>Wait until the specified number of nodes is available.</summary>
         public ClusterHealthDescriptor WaitForNodes(string waitfornodes) =>
             Qs("wait_for_nodes", waitfornodes);
 
-        ///<summary>Whether to wait until there are no initializing shards in the cluster.</summary>
+        /// <summary>Whether to wait until there are no initializing shards in the cluster.</summary>
         public ClusterHealthDescriptor WaitForNoInitializingShards(
             bool? waitfornoinitializingshards = true
         ) => Qs("wait_for_no_initializing_shards", waitfornoinitializingshards);
 
-        ///<summary>Whether to wait until there are no relocating shards in the cluster.</summary>
+        /// <summary>Whether to wait until there are no relocating shards in the cluster.</summary>
         public ClusterHealthDescriptor WaitForNoRelocatingShards(
             bool? waitfornorelocatingshards = true
         ) => Qs("wait_for_no_relocating_shards", waitfornorelocatingshards);
 
-        ///<summary>Wait until cluster is in a specific state.</summary>
+        /// <summary>Wait until cluster is in a specific state.</summary>
         public ClusterHealthDescriptor WaitForStatus(WaitForStatus? waitforstatus) =>
             Qs("wait_for_status", waitforstatus);
     }
 
-    ///<summary>Descriptor for PendingTasks <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Descriptor for PendingTasks <para>https://opensearch.org/docs/latest</para></summary>
     public partial class ClusterPendingTasksDescriptor
         : RequestDescriptorBase<
             ClusterPendingTasksDescriptor,
@@ -247,15 +247,15 @@ namespace OpenSearch.Client.Specification.ClusterApi
 
         // values part of the url path
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public ClusterPendingTasksDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public ClusterPendingTasksDescriptor Local(bool? local = true) => Qs("local", local);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]

--- a/src/OpenSearch.Client/_Generated/Descriptors.DanglingIndices.cs
+++ b/src/OpenSearch.Client/_Generated/Descriptors.DanglingIndices.cs
@@ -58,7 +58,7 @@ using OpenSearch.Net.Specification.DanglingIndicesApi;
 // ReSharper disable RedundantNameQualifier
 namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
-    ///<summary>Descriptor for DeleteDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Descriptor for DeleteDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class DeleteDanglingIndexDescriptor
         : RequestDescriptorBase<
             DeleteDanglingIndexDescriptor,
@@ -69,12 +69,12 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.DanglingIndicesDeleteDanglingIndex;
 
-        ///<summary>/_dangling/{index_uuid}</summary>
-        ///<param name="indexUuid">this parameter is required</param>
+        /// <summary>/_dangling/{index_uuid}</summary>
+        /// <param name="indexUuid">this parameter is required</param>
         public DeleteDanglingIndexDescriptor(IndexUuid indexUuid)
             : base(r => r.Required("index_uuid", indexUuid)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected DeleteDanglingIndexDescriptor()
             : base() { }
@@ -84,27 +84,27 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
             Self.RouteValues.Get<IndexUuid>("index_uuid");
 
         // Request parameters
-        ///<summary>Must be set to true in order to delete the dangling index.</summary>
+        /// <summary>Must be set to true in order to delete the dangling index.</summary>
         public DeleteDanglingIndexDescriptor AcceptDataLoss(bool? acceptdataloss = true) =>
             Qs("accept_data_loss", acceptdataloss);
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public DeleteDanglingIndexDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public DeleteDanglingIndexDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public DeleteDanglingIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for ImportDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Descriptor for ImportDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class ImportDanglingIndexDescriptor
         : RequestDescriptorBase<
             ImportDanglingIndexDescriptor,
@@ -115,12 +115,12 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.DanglingIndicesImportDanglingIndex;
 
-        ///<summary>/_dangling/{index_uuid}</summary>
-        ///<param name="indexUuid">this parameter is required</param>
+        /// <summary>/_dangling/{index_uuid}</summary>
+        /// <param name="indexUuid">this parameter is required</param>
         public ImportDanglingIndexDescriptor(IndexUuid indexUuid)
             : base(r => r.Required("index_uuid", indexUuid)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected ImportDanglingIndexDescriptor()
             : base() { }
@@ -130,27 +130,27 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
             Self.RouteValues.Get<IndexUuid>("index_uuid");
 
         // Request parameters
-        ///<summary>Must be set to true in order to import the dangling index.</summary>
+        /// <summary>Must be set to true in order to import the dangling index.</summary>
         public ImportDanglingIndexDescriptor AcceptDataLoss(bool? acceptdataloss = true) =>
             Qs("accept_data_loss", acceptdataloss);
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public ImportDanglingIndexDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public ImportDanglingIndexDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public ImportDanglingIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for List <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Descriptor for List <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class ListDanglingIndicesDescriptor
         : RequestDescriptorBase<
             ListDanglingIndicesDescriptor,

--- a/src/OpenSearch.Client/_Generated/Descriptors.Ingest.cs
+++ b/src/OpenSearch.Client/_Generated/Descriptors.Ingest.cs
@@ -58,7 +58,7 @@ using OpenSearch.Net.Specification.IngestApi;
 // ReSharper disable RedundantNameQualifier
 namespace OpenSearch.Client.Specification.IngestApi
 {
-    ///<summary>Descriptor for DeletePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
+    /// <summary>Descriptor for DeletePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
     public partial class DeletePipelineDescriptor
         : RequestDescriptorBase<
             DeletePipelineDescriptor,
@@ -69,12 +69,12 @@ namespace OpenSearch.Client.Specification.IngestApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestDeletePipeline;
 
-        ///<summary>/_ingest/pipeline/{id}</summary>
-        ///<param name="id">this parameter is required</param>
+        /// <summary>/_ingest/pipeline/{id}</summary>
+        /// <param name="id">this parameter is required</param>
         public DeletePipelineDescriptor(Id id)
             : base(r => r.Required("id", id)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected DeletePipelineDescriptor()
             : base() { }
@@ -83,23 +83,23 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id IDeletePipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public DeletePipelineDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public DeletePipelineDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public DeletePipelineDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for GetPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
+    /// <summary>Descriptor for GetPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
     public partial class GetPipelineDescriptor
         : RequestDescriptorBase<
             GetPipelineDescriptor,
@@ -110,29 +110,29 @@ namespace OpenSearch.Client.Specification.IngestApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestGetPipeline;
 
-        ///<summary>/_ingest/pipeline</summary>
+        /// <summary>/_ingest/pipeline</summary>
         public GetPipelineDescriptor()
             : base() { }
 
-        ///<summary>/_ingest/pipeline/{id}</summary>
-        ///<param name="id">Optional, accepts null</param>
+        /// <summary>/_ingest/pipeline/{id}</summary>
+        /// <param name="id">Optional, accepts null</param>
         public GetPipelineDescriptor(Id id)
             : base(r => r.Optional("id", id)) { }
 
         // values part of the url path
         Id IGetPipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 
-        ///<summary>Comma-separated list of pipeline ids. Wildcards supported.</summary>
+        /// <summary>Comma-separated list of pipeline ids. Wildcards supported.</summary>
         public GetPipelineDescriptor Id(Id id) =>
             Assign(id, (a, v) => a.RouteValues.Optional("id", v));
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public GetPipelineDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -140,7 +140,7 @@ namespace OpenSearch.Client.Specification.IngestApi
             Qs("master_timeout", mastertimeout);
     }
 
-    ///<summary>Descriptor for GrokProcessorPatterns <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Descriptor for GrokProcessorPatterns <para>https://opensearch.org/docs/latest</para></summary>
     public partial class GrokProcessorPatternsDescriptor
         : RequestDescriptorBase<
             GrokProcessorPatternsDescriptor,
@@ -154,7 +154,7 @@ namespace OpenSearch.Client.Specification.IngestApi
         // Request parameters
     }
 
-    ///<summary>Descriptor for PutPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
+    /// <summary>Descriptor for PutPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
     public partial class PutPipelineDescriptor
         : RequestDescriptorBase<
             PutPipelineDescriptor,
@@ -165,12 +165,12 @@ namespace OpenSearch.Client.Specification.IngestApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestPutPipeline;
 
-        ///<summary>/_ingest/pipeline/{id}</summary>
-        ///<param name="id">this parameter is required</param>
+        /// <summary>/_ingest/pipeline/{id}</summary>
+        /// <param name="id">this parameter is required</param>
         public PutPipelineDescriptor(Id id)
             : base(r => r.Required("id", id)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected PutPipelineDescriptor()
             : base() { }
@@ -179,23 +179,23 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id IPutPipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public PutPipelineDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public PutPipelineDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public PutPipelineDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for SimulatePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
+    /// <summary>Descriptor for SimulatePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
     public partial class SimulatePipelineDescriptor
         : RequestDescriptorBase<
             SimulatePipelineDescriptor,
@@ -206,24 +206,24 @@ namespace OpenSearch.Client.Specification.IngestApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestSimulatePipeline;
 
-        ///<summary>/_ingest/pipeline/_simulate</summary>
+        /// <summary>/_ingest/pipeline/_simulate</summary>
         public SimulatePipelineDescriptor()
             : base() { }
 
-        ///<summary>/_ingest/pipeline/{id}/_simulate</summary>
-        ///<param name="id">Optional, accepts null</param>
+        /// <summary>/_ingest/pipeline/{id}/_simulate</summary>
+        /// <param name="id">Optional, accepts null</param>
         public SimulatePipelineDescriptor(Id id)
             : base(r => r.Optional("id", id)) { }
 
         // values part of the url path
         Id ISimulatePipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 
-        ///<summary>Pipeline ID.</summary>
+        /// <summary>Pipeline ID.</summary>
         public SimulatePipelineDescriptor Id(Id id) =>
             Assign(id, (a, v) => a.RouteValues.Optional("id", v));
 
         // Request parameters
-        ///<summary>Verbose mode. Display data output for each processor in executed pipeline.</summary>
+        /// <summary>Verbose mode. Display data output for each processor in executed pipeline.</summary>
         public SimulatePipelineDescriptor Verbose(bool? verbose = true) => Qs("verbose", verbose);
     }
 }

--- a/src/OpenSearch.Client/_Generated/Descriptors.Nodes.cs
+++ b/src/OpenSearch.Client/_Generated/Descriptors.Nodes.cs
@@ -58,7 +58,7 @@ using OpenSearch.Net.Specification.NodesApi;
 // ReSharper disable RedundantNameQualifier
 namespace OpenSearch.Client.Specification.NodesApi
 {
-    ///<summary>Descriptor for HotThreads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
+    /// <summary>Descriptor for HotThreads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
     public partial class NodesHotThreadsDescriptor
         : RequestDescriptorBase<
             NodesHotThreadsDescriptor,
@@ -69,68 +69,68 @@ namespace OpenSearch.Client.Specification.NodesApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesHotThreads;
 
-        ///<summary>/_nodes/hot_threads</summary>
+        /// <summary>/_nodes/hot_threads</summary>
         public NodesHotThreadsDescriptor()
             : base() { }
 
-        ///<summary>/_nodes/{node_id}/hot_threads</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/hot_threads</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
         public NodesHotThreadsDescriptor(NodeIds nodeId)
             : base(r => r.Optional("node_id", nodeId)) { }
 
         // values part of the url path
         NodeIds INodesHotThreadsRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
-        ///<summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
+        /// <summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
         public NodesHotThreadsDescriptor NodeId(NodeIds nodeId) =>
             Assign(nodeId, (a, v) => a.RouteValues.Optional("node_id", v));
 
         // Request parameters
-        ///<summary>Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue.</summary>
+        /// <summary>Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue.</summary>
         public NodesHotThreadsDescriptor IgnoreIdleThreads(bool? ignoreidlethreads = true) =>
             Qs("ignore_idle_threads", ignoreidlethreads);
 
-        ///<summary>The interval for the second sampling of threads.</summary>
+        /// <summary>The interval for the second sampling of threads.</summary>
         public NodesHotThreadsDescriptor Interval(Time interval) => Qs("interval", interval);
 
-        ///<summary>The type to sample.</summary>
+        /// <summary>The type to sample.</summary>
         public NodesHotThreadsDescriptor SampleType(SampleType? sampletype) =>
             Qs("type", sampletype);
 
-        ///<summary>Number of samples of thread stacktrace.</summary>
+        /// <summary>Number of samples of thread stacktrace.</summary>
         public NodesHotThreadsDescriptor Snapshots(long? snapshots) => Qs("snapshots", snapshots);
 
-        ///<summary>Specify the number of threads to provide information for.</summary>
+        /// <summary>Specify the number of threads to provide information for.</summary>
         public NodesHotThreadsDescriptor Threads(long? threads) => Qs("threads", threads);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public NodesHotThreadsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for Info <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+    /// <summary>Descriptor for Info <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
     public partial class NodesInfoDescriptor
         : RequestDescriptorBase<NodesInfoDescriptor, NodesInfoRequestParameters, INodesInfoRequest>,
             INodesInfoRequest
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesInfo;
 
-        ///<summary>/_nodes</summary>
+        /// <summary>/_nodes</summary>
         public NodesInfoDescriptor()
             : base() { }
 
-        ///<summary>/_nodes/{node_id}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        public NodesInfoDescriptor(NodeIds nodeId)
-            : base(r => r.Optional("node_id", nodeId)) { }
-
-        ///<summary>/_nodes/{metric}</summary>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/{metric}</summary>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesInfoDescriptor(Metrics metric)
             : base(r => r.Optional("metric", metric)) { }
 
-        ///<summary>/_nodes/{node_id}/{metric}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        public NodesInfoDescriptor(NodeIds nodeId)
+            : base(r => r.Optional("node_id", nodeId)) { }
+
+        /// <summary>/_nodes/{node_id}/{metric}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesInfoDescriptor(NodeIds nodeId, Metrics metric)
             : base(r => r.Optional("node_id", nodeId).Optional("metric", metric)) { }
 
@@ -138,24 +138,24 @@ namespace OpenSearch.Client.Specification.NodesApi
         Metrics INodesInfoRequest.Metric => Self.RouteValues.Get<Metrics>("metric");
         NodeIds INodesInfoRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
-        ///<summary>Comma-separated list of metrics you wish returned. Leave empty to return all.</summary>
+        /// <summary>Comma-separated list of metrics you wish returned. Leave empty to return all.</summary>
         public NodesInfoDescriptor Metric(Metrics metric) =>
             Assign(metric, (a, v) => a.RouteValues.Optional("metric", v));
 
-        ///<summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
+        /// <summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
         public NodesInfoDescriptor NodeId(NodeIds nodeId) =>
             Assign(nodeId, (a, v) => a.RouteValues.Optional("node_id", v));
 
         // Request parameters
-        ///<summary>Return settings in flat format.</summary>
+        /// <summary>Return settings in flat format.</summary>
         public NodesInfoDescriptor FlatSettings(bool? flatsettings = true) =>
             Qs("flat_settings", flatsettings);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public NodesInfoDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for ReloadSecureSettings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
+    /// <summary>Descriptor for ReloadSecureSettings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
     public partial class ReloadSecureSettingsDescriptor
         : RequestDescriptorBase<
             ReloadSecureSettingsDescriptor,
@@ -166,28 +166,28 @@ namespace OpenSearch.Client.Specification.NodesApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesReloadSecureSettings;
 
-        ///<summary>/_nodes/reload_secure_settings</summary>
+        /// <summary>/_nodes/reload_secure_settings</summary>
         public ReloadSecureSettingsDescriptor()
             : base() { }
 
-        ///<summary>/_nodes/{node_id}/reload_secure_settings</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/reload_secure_settings</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
         public ReloadSecureSettingsDescriptor(NodeIds nodeId)
             : base(r => r.Optional("node_id", nodeId)) { }
 
         // values part of the url path
         NodeIds IReloadSecureSettingsRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
-        ///<summary>Comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.</summary>
+        /// <summary>Comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.</summary>
         public ReloadSecureSettingsDescriptor NodeId(NodeIds nodeId) =>
             Assign(nodeId, (a, v) => a.RouteValues.Optional("node_id", v));
 
         // Request parameters
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public ReloadSecureSettingsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for Stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+    /// <summary>Descriptor for Stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
     public partial class NodesStatsDescriptor
         : RequestDescriptorBase<
             NodesStatsDescriptor,
@@ -198,36 +198,36 @@ namespace OpenSearch.Client.Specification.NodesApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesStats;
 
-        ///<summary>/_nodes/stats</summary>
+        /// <summary>/_nodes/stats</summary>
         public NodesStatsDescriptor()
             : base() { }
 
-        ///<summary>/_nodes/stats/{metric}</summary>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/stats/{metric}</summary>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesStatsDescriptor(Metrics metric)
             : base(r => r.Optional("metric", metric)) { }
 
-        ///<summary>/_nodes/stats/{metric}/{index_metric}</summary>
-        ///<param name="metric">Optional, accepts null</param>
-        ///<param name="indexMetric">Optional, accepts null</param>
+        /// <summary>/_nodes/stats/{metric}/{index_metric}</summary>
+        /// <param name="metric">Optional, accepts null</param>
+        /// <param name="indexMetric">Optional, accepts null</param>
         public NodesStatsDescriptor(Metrics metric, IndexMetrics indexMetric)
             : base(r => r.Optional("metric", metric).Optional("index_metric", indexMetric)) { }
 
-        ///<summary>/_nodes/{node_id}/stats</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/stats</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
         public NodesStatsDescriptor(NodeIds nodeId)
             : base(r => r.Optional("node_id", nodeId)) { }
 
-        ///<summary>/_nodes/{node_id}/stats/{metric}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/stats/{metric}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesStatsDescriptor(NodeIds nodeId, Metrics metric)
             : base(r => r.Optional("node_id", nodeId).Optional("metric", metric)) { }
 
-        ///<summary>/_nodes/{node_id}/stats/{metric}/{index_metric}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        ///<param name="metric">Optional, accepts null</param>
-        ///<param name="indexMetric">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/stats/{metric}/{index_metric}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        /// <param name="metric">Optional, accepts null</param>
+        /// <param name="indexMetric">Optional, accepts null</param>
         public NodesStatsDescriptor(NodeIds nodeId, Metrics metric, IndexMetrics indexMetric)
             : base(
                 r =>
@@ -242,61 +242,61 @@ namespace OpenSearch.Client.Specification.NodesApi
         Metrics INodesStatsRequest.Metric => Self.RouteValues.Get<Metrics>("metric");
         NodeIds INodesStatsRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
-        ///<summary>Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified.</summary>
+        /// <summary>Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified.</summary>
         public NodesStatsDescriptor IndexMetric(IndexMetrics indexMetric) =>
             Assign(indexMetric, (a, v) => a.RouteValues.Optional("index_metric", v));
 
-        ///<summary>Limit the information returned to the specified metrics.</summary>
+        /// <summary>Limit the information returned to the specified metrics.</summary>
         public NodesStatsDescriptor Metric(Metrics metric) =>
             Assign(metric, (a, v) => a.RouteValues.Optional("metric", v));
 
-        ///<summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
+        /// <summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
         public NodesStatsDescriptor NodeId(NodeIds nodeId) =>
             Assign(nodeId, (a, v) => a.RouteValues.Optional("node_id", v));
 
         // Request parameters
-        ///<summary>Comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards).</summary>
         public NodesStatsDescriptor CompletionFields(Fields completionfields) =>
             Qs("completion_fields", completionfields);
 
-        ///<summary>Comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards).</summary>
         public NodesStatsDescriptor CompletionFields<T>(params Expression<Func<T, object>>[] fields)
             where T : class => Qs("completion_fields", fields?.Select(e => (Field)e));
 
-        ///<summary>Comma-separated list of fields for `fielddata` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` index metric (supports wildcards).</summary>
         public NodesStatsDescriptor FielddataFields(Fields fielddatafields) =>
             Qs("fielddata_fields", fielddatafields);
 
-        ///<summary>Comma-separated list of fields for `fielddata` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` index metric (supports wildcards).</summary>
         public NodesStatsDescriptor FielddataFields<T>(params Expression<Func<T, object>>[] fields)
             where T : class => Qs("fielddata_fields", fields?.Select(e => (Field)e));
 
-        ///<summary>Comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards).</summary>
         public NodesStatsDescriptor Fields(Fields fields) => Qs("fields", fields);
 
-        ///<summary>Comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards).</summary>
         public NodesStatsDescriptor Fields<T>(params Expression<Func<T, object>>[] fields)
             where T : class => Qs("fields", fields?.Select(e => (Field)e));
 
-        ///<summary>Comma-separated list of search groups for `search` index metric.</summary>
+        /// <summary>Comma-separated list of search groups for `search` index metric.</summary>
         public NodesStatsDescriptor Groups(params string[] groups) => Qs("groups", groups);
 
-        ///<summary>Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).</summary>
+        /// <summary>Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).</summary>
         public NodesStatsDescriptor IncludeSegmentFileSizes(bool? includesegmentfilesizes = true) =>
             Qs("include_segment_file_sizes", includesegmentfilesizes);
 
-        ///<summary>Return indices stats aggregated at index, node or shard level.</summary>
+        /// <summary>Return indices stats aggregated at index, node or shard level.</summary>
         public NodesStatsDescriptor NodesStatLevel(NodesStatLevel? nodesstatlevel) =>
             Qs("level", nodesstatlevel);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public NodesStatsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 
-        ///<summary>Comma-separated list of document types for the `indexing` index metric.</summary>
+        /// <summary>Comma-separated list of document types for the `indexing` index metric.</summary>
         public NodesStatsDescriptor Types(params string[] types) => Qs("types", types);
     }
 
-    ///<summary>Descriptor for Usage <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Descriptor for Usage <para>https://opensearch.org/docs/latest</para></summary>
     public partial class NodesUsageDescriptor
         : RequestDescriptorBase<
             NodesUsageDescriptor,
@@ -307,23 +307,23 @@ namespace OpenSearch.Client.Specification.NodesApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesUsage;
 
-        ///<summary>/_nodes/usage</summary>
+        /// <summary>/_nodes/usage</summary>
         public NodesUsageDescriptor()
             : base() { }
 
-        ///<summary>/_nodes/usage/{metric}</summary>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/usage/{metric}</summary>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesUsageDescriptor(Metrics metric)
             : base(r => r.Optional("metric", metric)) { }
 
-        ///<summary>/_nodes/{node_id}/usage</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/usage</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
         public NodesUsageDescriptor(NodeIds nodeId)
             : base(r => r.Optional("node_id", nodeId)) { }
 
-        ///<summary>/_nodes/{node_id}/usage/{metric}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/usage/{metric}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesUsageDescriptor(NodeIds nodeId, Metrics metric)
             : base(r => r.Optional("node_id", nodeId).Optional("metric", metric)) { }
 
@@ -331,16 +331,16 @@ namespace OpenSearch.Client.Specification.NodesApi
         Metrics INodesUsageRequest.Metric => Self.RouteValues.Get<Metrics>("metric");
         NodeIds INodesUsageRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
-        ///<summary>Limit the information returned to the specified metrics.</summary>
+        /// <summary>Limit the information returned to the specified metrics.</summary>
         public NodesUsageDescriptor Metric(Metrics metric) =>
             Assign(metric, (a, v) => a.RouteValues.Optional("metric", v));
 
-        ///<summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
+        /// <summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
         public NodesUsageDescriptor NodeId(NodeIds nodeId) =>
             Assign(nodeId, (a, v) => a.RouteValues.Optional("node_id", v));
 
         // Request parameters
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public NodesUsageDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 }

--- a/src/OpenSearch.Client/_Generated/Descriptors.Snapshot.cs
+++ b/src/OpenSearch.Client/_Generated/Descriptors.Snapshot.cs
@@ -58,7 +58,7 @@ using OpenSearch.Net.Specification.SnapshotApi;
 // ReSharper disable RedundantNameQualifier
 namespace OpenSearch.Client.Specification.SnapshotApi
 {
-    ///<summary>Descriptor for CleanupRepository <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Descriptor for CleanupRepository <para>https://opensearch.org/docs/latest</para></summary>
     public partial class CleanupRepositoryDescriptor
         : RequestDescriptorBase<
             CleanupRepositoryDescriptor,
@@ -69,12 +69,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotCleanupRepository;
 
-        ///<summary>/_snapshot/{repository}/_cleanup</summary>
-        ///<param name="repository">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/_cleanup</summary>
+        /// <param name="repository">this parameter is required</param>
         public CleanupRepositoryDescriptor(Name repository)
             : base(r => r.Required("repository", repository)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected CleanupRepositoryDescriptor()
             : base() { }
@@ -83,23 +83,23 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ICleanupRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public CleanupRepositoryDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public CleanupRepositoryDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public CleanupRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for Clone <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Descriptor for Clone <para>https://opensearch.org/docs/latest</para></summary>
     public partial class CloneSnapshotDescriptor
         : RequestDescriptorBase<
             CloneSnapshotDescriptor,
@@ -110,10 +110,10 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotClone;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}/_clone/{target_snapshot}</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
-        ///<param name="targetSnapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}/_clone/{target_snapshot}</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
+        /// <param name="targetSnapshot">this parameter is required</param>
         public CloneSnapshotDescriptor(Name repository, Name snapshot, Name targetSnapshot)
             : base(
                 r =>
@@ -122,7 +122,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
                         .Required("target_snapshot", targetSnapshot)
             ) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected CloneSnapshotDescriptor()
             : base() { }
@@ -133,12 +133,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ICloneSnapshotRequest.TargetSnapshot => Self.RouteValues.Get<Name>("target_snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public CloneSnapshotDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -146,20 +146,20 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             Qs("master_timeout", mastertimeout);
     }
 
-    ///<summary>Descriptor for Snapshot</summary>
+    /// <summary>Descriptor for Snapshot</summary>
     public partial class SnapshotDescriptor
         : RequestDescriptorBase<SnapshotDescriptor, SnapshotRequestParameters, ISnapshotRequest>,
             ISnapshotRequest
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotSnapshot;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
         public SnapshotDescriptor(Name repository, Name snapshot)
             : base(r => r.Required("repository", repository).Required("snapshot", snapshot)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected SnapshotDescriptor()
             : base() { }
@@ -169,24 +169,24 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ISnapshotRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public SnapshotDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public SnapshotDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public SnapshotDescriptor WaitForCompletion(bool? waitforcompletion = true) =>
             Qs("wait_for_completion", waitforcompletion);
     }
 
-    ///<summary>Descriptor for CreateRepository</summary>
+    /// <summary>Descriptor for CreateRepository</summary>
     public partial class CreateRepositoryDescriptor
         : RequestDescriptorBase<
             CreateRepositoryDescriptor,
@@ -197,12 +197,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotCreateRepository;
 
-        ///<summary>/_snapshot/{repository}</summary>
-        ///<param name="repository">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}</summary>
+        /// <param name="repository">this parameter is required</param>
         public CreateRepositoryDescriptor(Name repository)
             : base(r => r.Required("repository", repository)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected CreateRepositoryDescriptor()
             : base() { }
@@ -211,26 +211,26 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ICreateRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public CreateRepositoryDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public CreateRepositoryDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public CreateRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 
-        ///<summary>Whether to verify the repository after creation.</summary>
+        /// <summary>Whether to verify the repository after creation.</summary>
         public CreateRepositoryDescriptor Verify(bool? verify = true) => Qs("verify", verify);
     }
 
-    ///<summary>Descriptor for Delete <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
+    /// <summary>Descriptor for Delete <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
     public partial class DeleteSnapshotDescriptor
         : RequestDescriptorBase<
             DeleteSnapshotDescriptor,
@@ -241,13 +241,13 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotDelete;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
         public DeleteSnapshotDescriptor(Name repository, Name snapshot)
             : base(r => r.Required("repository", repository).Required("snapshot", snapshot)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected DeleteSnapshotDescriptor()
             : base() { }
@@ -257,12 +257,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name IDeleteSnapshotRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public DeleteSnapshotDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -270,7 +270,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             Qs("master_timeout", mastertimeout);
     }
 
-    ///<summary>Descriptor for DeleteRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
+    /// <summary>Descriptor for DeleteRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
     public partial class DeleteRepositoryDescriptor
         : RequestDescriptorBase<
             DeleteRepositoryDescriptor,
@@ -281,12 +281,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotDeleteRepository;
 
-        ///<summary>/_snapshot/{repository}</summary>
-        ///<param name="repository">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}</summary>
+        /// <param name="repository">this parameter is required</param>
         public DeleteRepositoryDescriptor(Names repository)
             : base(r => r.Required("repository", repository)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected DeleteRepositoryDescriptor()
             : base() { }
@@ -295,23 +295,23 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names IDeleteRepositoryRequest.RepositoryName => Self.RouteValues.Get<Names>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public DeleteRepositoryDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public DeleteRepositoryDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public DeleteRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 
-    ///<summary>Descriptor for Get <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Descriptor for Get <para>https://opensearch.org/docs/latest</para></summary>
     public partial class GetSnapshotDescriptor
         : RequestDescriptorBase<
             GetSnapshotDescriptor,
@@ -322,13 +322,13 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotGet;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
         public GetSnapshotDescriptor(Name repository, Names snapshot)
             : base(r => r.Required("repository", repository).Required("snapshot", snapshot)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected GetSnapshotDescriptor()
             : base() { }
@@ -338,27 +338,27 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names IGetSnapshotRequest.Snapshot => Self.RouteValues.Get<Names>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public GetSnapshotDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
+        /// <summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
         public GetSnapshotDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) =>
             Qs("ignore_unavailable", ignoreunavailable);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public GetSnapshotDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob.</summary>
+        /// <summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob.</summary>
         public GetSnapshotDescriptor Verbose(bool? verbose = true) => Qs("verbose", verbose);
     }
 
-    ///<summary>Descriptor for GetRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
+    /// <summary>Descriptor for GetRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
     public partial class GetRepositoryDescriptor
         : RequestDescriptorBase<
             GetRepositoryDescriptor,
@@ -369,32 +369,32 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotGetRepository;
 
-        ///<summary>/_snapshot</summary>
+        /// <summary>/_snapshot</summary>
         public GetRepositoryDescriptor()
             : base() { }
 
-        ///<summary>/_snapshot/{repository}</summary>
-        ///<param name="repository">Optional, accepts null</param>
+        /// <summary>/_snapshot/{repository}</summary>
+        /// <param name="repository">Optional, accepts null</param>
         public GetRepositoryDescriptor(Names repository)
             : base(r => r.Optional("repository", repository)) { }
 
         // values part of the url path
         Names IGetRepositoryRequest.RepositoryName => Self.RouteValues.Get<Names>("repository");
 
-        ///<summary>Comma-separated list of repository names.</summary>
+        /// <summary>Comma-separated list of repository names.</summary>
         public GetRepositoryDescriptor RepositoryName(Names repository) =>
             Assign(repository, (a, v) => a.RouteValues.Optional("repository", v));
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public GetRepositoryDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public GetRepositoryDescriptor Local(bool? local = true) => Qs("local", local);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -402,20 +402,20 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             Qs("master_timeout", mastertimeout);
     }
 
-    ///<summary>Descriptor for Restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
+    /// <summary>Descriptor for Restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
     public partial class RestoreDescriptor
         : RequestDescriptorBase<RestoreDescriptor, RestoreRequestParameters, IRestoreRequest>,
             IRestoreRequest
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotRestore;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}/_restore</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}/_restore</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
         public RestoreDescriptor(Name repository, Name snapshot)
             : base(r => r.Required("repository", repository).Required("snapshot", snapshot)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected RestoreDescriptor()
             : base() { }
@@ -425,24 +425,24 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name IRestoreRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public RestoreDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public RestoreDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public RestoreDescriptor WaitForCompletion(bool? waitforcompletion = true) =>
             Qs("wait_for_completion", waitforcompletion);
     }
 
-    ///<summary>Descriptor for Status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+    /// <summary>Descriptor for Status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
     public partial class SnapshotStatusDescriptor
         : RequestDescriptorBase<
             SnapshotStatusDescriptor,
@@ -453,18 +453,18 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotStatus;
 
-        ///<summary>/_snapshot/_status</summary>
+        /// <summary>/_snapshot/_status</summary>
         public SnapshotStatusDescriptor()
             : base() { }
 
-        ///<summary>/_snapshot/{repository}/_status</summary>
-        ///<param name="repository">Optional, accepts null</param>
+        /// <summary>/_snapshot/{repository}/_status</summary>
+        /// <param name="repository">Optional, accepts null</param>
         public SnapshotStatusDescriptor(Name repository)
             : base(r => r.Optional("repository", repository)) { }
 
-        ///<summary>/_snapshot/{repository}/{snapshot}/_status</summary>
-        ///<param name="repository">Optional, accepts null</param>
-        ///<param name="snapshot">Optional, accepts null</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}/_status</summary>
+        /// <param name="repository">Optional, accepts null</param>
+        /// <param name="snapshot">Optional, accepts null</param>
         public SnapshotStatusDescriptor(Name repository, Names snapshot)
             : base(r => r.Optional("repository", repository).Optional("snapshot", snapshot)) { }
 
@@ -472,25 +472,25 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ISnapshotStatusRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
         Names ISnapshotStatusRequest.Snapshot => Self.RouteValues.Get<Names>("snapshot");
 
-        ///<summary>Repository name.</summary>
+        /// <summary>Repository name.</summary>
         public SnapshotStatusDescriptor RepositoryName(Name repository) =>
             Assign(repository, (a, v) => a.RouteValues.Optional("repository", v));
 
-        ///<summary>Comma-separated list of snapshot names.</summary>
+        /// <summary>Comma-separated list of snapshot names.</summary>
         public SnapshotStatusDescriptor Snapshot(Names snapshot) =>
             Assign(snapshot, (a, v) => a.RouteValues.Optional("snapshot", v));
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public SnapshotStatusDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
+        /// <summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
         public SnapshotStatusDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) =>
             Qs("ignore_unavailable", ignoreunavailable);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -498,7 +498,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             Qs("master_timeout", mastertimeout);
     }
 
-    ///<summary>Descriptor for VerifyRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
+    /// <summary>Descriptor for VerifyRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
     public partial class VerifyRepositoryDescriptor
         : RequestDescriptorBase<
             VerifyRepositoryDescriptor,
@@ -509,12 +509,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotVerifyRepository;
 
-        ///<summary>/_snapshot/{repository}/_verify</summary>
-        ///<param name="repository">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/_verify</summary>
+        /// <param name="repository">this parameter is required</param>
         public VerifyRepositoryDescriptor(Name repository)
             : base(r => r.Required("repository", repository)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected VerifyRepositoryDescriptor()
             : base() { }
@@ -523,19 +523,19 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name IVerifyRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public VerifyRepositoryDescriptor ClusterManagerTimeout(Time clustermanagertimeout) =>
             Qs("cluster_manager_timeout", clustermanagertimeout);
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
         public VerifyRepositoryDescriptor MasterTimeout(Time mastertimeout) =>
             Qs("master_timeout", mastertimeout);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public VerifyRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
     }
 }

--- a/src/OpenSearch.Client/_Generated/Descriptors.Tasks.cs
+++ b/src/OpenSearch.Client/_Generated/Descriptors.Tasks.cs
@@ -58,7 +58,7 @@ using OpenSearch.Net.Specification.TasksApi;
 // ReSharper disable RedundantNameQualifier
 namespace OpenSearch.Client.Specification.TasksApi
 {
-    ///<summary>Descriptor for Cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
+    /// <summary>Descriptor for Cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
     public partial class CancelTasksDescriptor
         : RequestDescriptorBase<
             CancelTasksDescriptor,
@@ -69,51 +69,51 @@ namespace OpenSearch.Client.Specification.TasksApi
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.TasksCancel;
 
-        ///<summary>/_tasks/_cancel</summary>
+        /// <summary>/_tasks/_cancel</summary>
         public CancelTasksDescriptor()
             : base() { }
 
-        ///<summary>/_tasks/{task_id}/_cancel</summary>
-        ///<param name="taskId">Optional, accepts null</param>
+        /// <summary>/_tasks/{task_id}/_cancel</summary>
+        /// <param name="taskId">Optional, accepts null</param>
         public CancelTasksDescriptor(TaskId taskId)
             : base(r => r.Optional("task_id", taskId)) { }
 
         // values part of the url path
         TaskId ICancelTasksRequest.TaskId => Self.RouteValues.Get<TaskId>("task_id");
 
-        ///<summary>Cancel the task with specified task id (node_id:task_number).</summary>
+        /// <summary>Cancel the task with specified task id (node_id:task_number).</summary>
         public CancelTasksDescriptor TaskId(TaskId taskId) =>
             Assign(taskId, (a, v) => a.RouteValues.Optional("task_id", v));
 
         // Request parameters
-        ///<summary>Comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
+        /// <summary>Comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
         public CancelTasksDescriptor Actions(params string[] actions) => Qs("actions", actions);
 
-        ///<summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
+        /// <summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
         public CancelTasksDescriptor Nodes(params string[] nodes) => Qs("nodes", nodes);
 
-        ///<summary>Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.</summary>
+        /// <summary>Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.</summary>
         public CancelTasksDescriptor ParentTaskId(string parenttaskid) =>
             Qs("parent_task_id", parenttaskid);
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public CancelTasksDescriptor WaitForCompletion(bool? waitforcompletion = true) =>
             Qs("wait_for_completion", waitforcompletion);
     }
 
-    ///<summary>Descriptor for GetTask <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+    /// <summary>Descriptor for GetTask <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
     public partial class GetTaskDescriptor
         : RequestDescriptorBase<GetTaskDescriptor, GetTaskRequestParameters, IGetTaskRequest>,
             IGetTaskRequest
     {
         internal override ApiUrls ApiUrls => ApiUrlsLookups.TasksGetTask;
 
-        ///<summary>/_tasks/{task_id}</summary>
-        ///<param name="taskId">this parameter is required</param>
+        /// <summary>/_tasks/{task_id}</summary>
+        /// <param name="taskId">this parameter is required</param>
         public GetTaskDescriptor(TaskId taskId)
             : base(r => r.Required("task_id", taskId)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected GetTaskDescriptor()
             : base() { }
@@ -122,15 +122,15 @@ namespace OpenSearch.Client.Specification.TasksApi
         TaskId IGetTaskRequest.TaskId => Self.RouteValues.Get<TaskId>("task_id");
 
         // Request parameters
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public GetTaskDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public GetTaskDescriptor WaitForCompletion(bool? waitforcompletion = true) =>
             Qs("wait_for_completion", waitforcompletion);
     }
 
-    ///<summary>Descriptor for List <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+    /// <summary>Descriptor for List <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
     public partial class ListTasksDescriptor
         : RequestDescriptorBase<ListTasksDescriptor, ListTasksRequestParameters, IListTasksRequest>,
             IListTasksRequest
@@ -139,26 +139,26 @@ namespace OpenSearch.Client.Specification.TasksApi
 
         // values part of the url path
         // Request parameters
-        ///<summary>Comma-separated list of actions that should be returned. Leave empty to return all.</summary>
+        /// <summary>Comma-separated list of actions that should be returned. Leave empty to return all.</summary>
         public ListTasksDescriptor Actions(params string[] actions) => Qs("actions", actions);
 
-        ///<summary>Return detailed task information.</summary>
+        /// <summary>Return detailed task information.</summary>
         public ListTasksDescriptor Detailed(bool? detailed = true) => Qs("detailed", detailed);
 
-        ///<summary>Group tasks by nodes or parent/child relationships.</summary>
+        /// <summary>Group tasks by nodes or parent/child relationships.</summary>
         public ListTasksDescriptor GroupBy(GroupBy? groupby) => Qs("group_by", groupby);
 
-        ///<summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
+        /// <summary>Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.</summary>
         public ListTasksDescriptor Nodes(params string[] nodes) => Qs("nodes", nodes);
 
-        ///<summary>Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.</summary>
+        /// <summary>Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.</summary>
         public ListTasksDescriptor ParentTaskId(string parenttaskid) =>
             Qs("parent_task_id", parenttaskid);
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public ListTasksDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public ListTasksDescriptor WaitForCompletion(bool? waitforcompletion = true) =>
             Qs("wait_for_completion", waitforcompletion);
     }

--- a/src/OpenSearch.Client/_Generated/IOpenSearchClient.cs
+++ b/src/OpenSearch.Client/_Generated/IOpenSearchClient.cs
@@ -57,27 +57,27 @@ using OpenSearch.Client.Specification.TasksApi;
 
 namespace OpenSearch.Client
 {
-    ///<summary>
-    ///OpenSearch high level client
-    ///</summary>
+    /// <summary>
+    /// OpenSearch high level client
+    /// </summary>
     public partial interface IOpenSearchClient
     {
-        ///<summary>Cluster APIs</summary>
+        /// <summary>Cluster APIs</summary>
         ClusterNamespace Cluster { get; }
 
-        ///<summary>Dangling Indices APIs</summary>
+        /// <summary>Dangling Indices APIs</summary>
         DanglingIndicesNamespace DanglingIndices { get; }
 
-        ///<summary>Ingest APIs</summary>
+        /// <summary>Ingest APIs</summary>
         IngestNamespace Ingest { get; }
 
-        ///<summary>Nodes APIs</summary>
+        /// <summary>Nodes APIs</summary>
         NodesNamespace Nodes { get; }
 
-        ///<summary>Snapshot APIs</summary>
+        /// <summary>Snapshot APIs</summary>
         SnapshotNamespace Snapshot { get; }
 
-        ///<summary>Tasks APIs</summary>
+        /// <summary>Tasks APIs</summary>
         TasksNamespace Tasks { get; }
     }
 }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Cluster.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Cluster.cs
@@ -51,12 +51,12 @@ using OpenSearch.Net.Specification.ClusterApi;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client.Specification.ClusterApi
 {
-    ///<summary>
+    /// <summary>
     /// Cluster APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Cluster"/> property
     /// on <see cref="IOpenSearchClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class ClusterNamespace : NamespacedClientProxy
     {
         internal ClusterNamespace(OpenSearchClient client)

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.DanglingIndices.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.DanglingIndices.cs
@@ -51,12 +51,12 @@ using OpenSearch.Net.Specification.DanglingIndicesApi;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
-    ///<summary>
+    /// <summary>
     /// Dangling Indices APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.DanglingIndices"/> property
     /// on <see cref="IOpenSearchClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class DanglingIndicesNamespace : NamespacedClientProxy
     {
         internal DanglingIndicesNamespace(OpenSearchClient client)

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Ingest.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Ingest.cs
@@ -51,12 +51,12 @@ using OpenSearch.Net.Specification.IngestApi;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client.Specification.IngestApi
 {
-    ///<summary>
+    /// <summary>
     /// Ingest APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Ingest"/> property
     /// on <see cref="IOpenSearchClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class IngestNamespace : NamespacedClientProxy
     {
         internal IngestNamespace(OpenSearchClient client)

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Nodes.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Nodes.cs
@@ -51,12 +51,12 @@ using OpenSearch.Net.Specification.NodesApi;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client.Specification.NodesApi
 {
-    ///<summary>
+    /// <summary>
     /// Nodes APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Nodes"/> property
     /// on <see cref="IOpenSearchClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class NodesNamespace : NamespacedClientProxy
     {
         internal NodesNamespace(OpenSearchClient client)

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Snapshot.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Snapshot.cs
@@ -51,12 +51,12 @@ using OpenSearch.Net.Specification.SnapshotApi;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client.Specification.SnapshotApi
 {
-    ///<summary>
+    /// <summary>
     /// Snapshot APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Snapshot"/> property
     /// on <see cref="IOpenSearchClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class SnapshotNamespace : NamespacedClientProxy
     {
         internal SnapshotNamespace(OpenSearchClient client)

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Tasks.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Tasks.cs
@@ -51,12 +51,12 @@ using OpenSearch.Net.Specification.TasksApi;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client.Specification.TasksApi
 {
-    ///<summary>
+    /// <summary>
     /// Tasks APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Tasks"/> property
     /// on <see cref="IOpenSearchClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class TasksNamespace : NamespacedClientProxy
     {
         internal TasksNamespace(OpenSearchClient client)

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.cs
@@ -56,27 +56,27 @@ using OpenSearch.Client.Specification.TasksApi;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client
 {
-    ///<summary>
-    ///OpenSearch high level client
-    ///</summary>
+    /// <summary>
+    /// OpenSearch high level client
+    /// </summary>
     public partial class OpenSearchClient : IOpenSearchClient
     {
-        ///<summary>Cluster APIs</summary>
+        /// <summary>Cluster APIs</summary>
         public ClusterNamespace Cluster { get; private set; }
 
-        ///<summary>Dangling Indices APIs</summary>
+        /// <summary>Dangling Indices APIs</summary>
         public DanglingIndicesNamespace DanglingIndices { get; private set; }
 
-        ///<summary>Ingest APIs</summary>
+        /// <summary>Ingest APIs</summary>
         public IngestNamespace Ingest { get; private set; }
 
-        ///<summary>Nodes APIs</summary>
+        /// <summary>Nodes APIs</summary>
         public NodesNamespace Nodes { get; private set; }
 
-        ///<summary>Snapshot APIs</summary>
+        /// <summary>Snapshot APIs</summary>
         public SnapshotNamespace Snapshot { get; private set; }
 
-        ///<summary>Tasks APIs</summary>
+        /// <summary>Tasks APIs</summary>
         public TasksNamespace Tasks { get; private set; }
 
         partial void SetupGeneratedNamespaces()

--- a/src/OpenSearch.Client/_Generated/Requests.Cluster.cs
+++ b/src/OpenSearch.Client/_Generated/Requests.Cluster.cs
@@ -62,7 +62,7 @@ namespace OpenSearch.Client.Specification.ClusterApi
     public partial interface IClusterAllocationExplainRequest
         : IRequest<ClusterAllocationExplainRequestParameters> { }
 
-    ///<summary>Request for AllocationExplain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
+    /// <summary>Request for AllocationExplain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
     public partial class ClusterAllocationExplainRequest
         : PlainRequestBase<ClusterAllocationExplainRequestParameters>,
             IClusterAllocationExplainRequest
@@ -73,14 +73,14 @@ namespace OpenSearch.Client.Specification.ClusterApi
         // values part of the url path
 
         // Request parameters
-        ///<summary>Return information about disk usage and shard sizes.</summary>
+        /// <summary>Return information about disk usage and shard sizes.</summary>
         public bool? IncludeDiskInfo
         {
             get => Q<bool?>("include_disk_info");
             set => Q("include_disk_info", value);
         }
 
-        ///<summary>Return 'YES' decisions in explanation.</summary>
+        /// <summary>Return 'YES' decisions in explanation.</summary>
         public bool? IncludeYesDecisions
         {
             get => Q<bool?>("include_yes_decisions");
@@ -92,7 +92,7 @@ namespace OpenSearch.Client.Specification.ClusterApi
     public partial interface IDeleteVotingConfigExclusionsRequest
         : IRequest<DeleteVotingConfigExclusionsRequestParameters> { }
 
-    ///<summary>Request for DeleteVotingConfigExclusions <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request for DeleteVotingConfigExclusions <para>https://opensearch.org/docs/latest</para></summary>
     public partial class DeleteVotingConfigExclusionsRequest
         : PlainRequestBase<DeleteVotingConfigExclusionsRequestParameters>,
             IDeleteVotingConfigExclusionsRequest
@@ -103,7 +103,7 @@ namespace OpenSearch.Client.Specification.ClusterApi
         // values part of the url path
 
         // Request parameters
-        ///<summary>Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list.</summary>
+        /// <summary>Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list.</summary>
         public bool? WaitForRemoval
         {
             get => Q<bool?>("wait_for_removal");
@@ -115,7 +115,7 @@ namespace OpenSearch.Client.Specification.ClusterApi
     public partial interface IClusterGetSettingsRequest
         : IRequest<ClusterGetSettingsRequestParameters> { }
 
-    ///<summary>Request for GetSettings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
+    /// <summary>Request for GetSettings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
     public partial class ClusterGetSettingsRequest
         : PlainRequestBase<ClusterGetSettingsRequestParameters>,
             IClusterGetSettingsRequest
@@ -126,29 +126,29 @@ namespace OpenSearch.Client.Specification.ClusterApi
         // values part of the url path
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Return settings in flat format.</summary>
+        /// <summary>Return settings in flat format.</summary>
         public bool? FlatSettings
         {
             get => Q<bool?>("flat_settings");
             set => Q("flat_settings", value);
         }
 
-        ///<summary>Whether to return all default clusters setting.</summary>
+        /// <summary>Whether to return all default clusters setting.</summary>
         public bool? IncludeDefaults
         {
             get => Q<bool?>("include_defaults");
             set => Q("include_defaults", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -158,7 +158,7 @@ namespace OpenSearch.Client.Specification.ClusterApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -173,7 +173,7 @@ namespace OpenSearch.Client.Specification.ClusterApi
         Indices Index { get; }
     }
 
-    ///<summary>Request for Health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
+    /// <summary>Request for Health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
     public partial class ClusterHealthRequest
         : PlainRequestBase<ClusterHealthRequestParameters>,
             IClusterHealthRequest
@@ -181,12 +181,12 @@ namespace OpenSearch.Client.Specification.ClusterApi
         protected IClusterHealthRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterHealth;
 
-        ///<summary>/_cluster/health</summary>
+        /// <summary>/_cluster/health</summary>
         public ClusterHealthRequest()
             : base() { }
 
-        ///<summary>/_cluster/health/{index}</summary>
-        ///<param name="index">Optional, accepts null</param>
+        /// <summary>/_cluster/health/{index}</summary>
+        /// <param name="index">Optional, accepts null</param>
         public ClusterHealthRequest(Indices index)
             : base(r => r.Optional("index", index)) { }
 
@@ -195,50 +195,50 @@ namespace OpenSearch.Client.Specification.ClusterApi
         Indices IClusterHealthRequest.Index => Self.RouteValues.Get<Indices>("index");
 
         // Request parameters
-        ///<summary>The awareness attribute for which the health is required.</summary>
+        /// <summary>The awareness attribute for which the health is required.</summary>
         public string AwarenessAttribute
         {
             get => Q<string>("awareness_attribute");
             set => Q("awareness_attribute", value);
         }
 
-        ///<summary>Specify the level of detail for returned information.</summary>
+        /// <summary>Specify the level of detail for returned information.</summary>
         public ClusterHealthLevel? ClusterHealthLevel
         {
             get => Q<ClusterHealthLevel?>("level");
             set => Q("level", value);
         }
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Checks whether local node is commissioned or not. If set to true on a local call it will throw exception if node is decommissioned.</summary>
+        /// <summary>Checks whether local node is commissioned or not. If set to true on a local call it will throw exception if node is decommissioned.</summary>
         public bool? EnsureNodeCommissioned
         {
             get => Q<bool?>("ensure_node_commissioned");
             set => Q("ensure_node_commissioned", value);
         }
 
-        ///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+        /// <summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
         public ExpandWildcards? ExpandWildcards
         {
             get => Q<ExpandWildcards?>("expand_wildcards");
             set => Q("expand_wildcards", value);
         }
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public bool? Local
         {
             get => Q<bool?>("local");
             set => Q("local", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -248,49 +248,49 @@ namespace OpenSearch.Client.Specification.ClusterApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Wait until the specified number of shards is active.</summary>
+        /// <summary>Wait until the specified number of shards is active.</summary>
         public string WaitForActiveShards
         {
             get => Q<string>("wait_for_active_shards");
             set => Q("wait_for_active_shards", value);
         }
 
-        ///<summary>Wait until all currently queued events with the given priority are processed.</summary>
+        /// <summary>Wait until all currently queued events with the given priority are processed.</summary>
         public WaitForEvents? WaitForEvents
         {
             get => Q<WaitForEvents?>("wait_for_events");
             set => Q("wait_for_events", value);
         }
 
-        ///<summary>Wait until the specified number of nodes is available.</summary>
+        /// <summary>Wait until the specified number of nodes is available.</summary>
         public string WaitForNodes
         {
             get => Q<string>("wait_for_nodes");
             set => Q("wait_for_nodes", value);
         }
 
-        ///<summary>Whether to wait until there are no initializing shards in the cluster.</summary>
+        /// <summary>Whether to wait until there are no initializing shards in the cluster.</summary>
         public bool? WaitForNoInitializingShards
         {
             get => Q<bool?>("wait_for_no_initializing_shards");
             set => Q("wait_for_no_initializing_shards", value);
         }
 
-        ///<summary>Whether to wait until there are no relocating shards in the cluster.</summary>
+        /// <summary>Whether to wait until there are no relocating shards in the cluster.</summary>
         public bool? WaitForNoRelocatingShards
         {
             get => Q<bool?>("wait_for_no_relocating_shards");
             set => Q("wait_for_no_relocating_shards", value);
         }
 
-        ///<summary>Wait until cluster is in a specific state.</summary>
+        /// <summary>Wait until cluster is in a specific state.</summary>
         public WaitForStatus? WaitForStatus
         {
             get => Q<WaitForStatus?>("wait_for_status");
@@ -302,7 +302,7 @@ namespace OpenSearch.Client.Specification.ClusterApi
     public partial interface IClusterPendingTasksRequest
         : IRequest<ClusterPendingTasksRequestParameters> { }
 
-    ///<summary>Request for PendingTasks <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request for PendingTasks <para>https://opensearch.org/docs/latest</para></summary>
     public partial class ClusterPendingTasksRequest
         : PlainRequestBase<ClusterPendingTasksRequestParameters>,
             IClusterPendingTasksRequest
@@ -313,22 +313,22 @@ namespace OpenSearch.Client.Specification.ClusterApi
         // values part of the url path
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public bool? Local
         {
             get => Q<bool?>("local");
             set => Q("local", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]

--- a/src/OpenSearch.Client/_Generated/Requests.DanglingIndices.cs
+++ b/src/OpenSearch.Client/_Generated/Requests.DanglingIndices.cs
@@ -66,7 +66,7 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
         IndexUuid IndexUuid { get; }
     }
 
-    ///<summary>Request for DeleteDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Request for DeleteDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class DeleteDanglingIndexRequest
         : PlainRequestBase<DeleteDanglingIndexRequestParameters>,
             IDeleteDanglingIndexRequest
@@ -74,12 +74,12 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
         protected IDeleteDanglingIndexRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.DanglingIndicesDeleteDanglingIndex;
 
-        ///<summary>/_dangling/{index_uuid}</summary>
-        ///<param name="indexUuid">this parameter is required</param>
+        /// <summary>/_dangling/{index_uuid}</summary>
+        /// <param name="indexUuid">this parameter is required</param>
         public DeleteDanglingIndexRequest(IndexUuid indexUuid)
             : base(r => r.Required("index_uuid", indexUuid)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected DeleteDanglingIndexRequest()
             : base() { }
@@ -90,22 +90,22 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
             Self.RouteValues.Get<IndexUuid>("index_uuid");
 
         // Request parameters
-        ///<summary>Must be set to true in order to delete the dangling index.</summary>
+        /// <summary>Must be set to true in order to delete the dangling index.</summary>
         public bool? AcceptDataLoss
         {
             get => Q<bool?>("accept_data_loss");
             set => Q("accept_data_loss", value);
         }
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -115,7 +115,7 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -131,7 +131,7 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
         IndexUuid IndexUuid { get; }
     }
 
-    ///<summary>Request for ImportDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Request for ImportDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class ImportDanglingIndexRequest
         : PlainRequestBase<ImportDanglingIndexRequestParameters>,
             IImportDanglingIndexRequest
@@ -139,12 +139,12 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
         protected IImportDanglingIndexRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.DanglingIndicesImportDanglingIndex;
 
-        ///<summary>/_dangling/{index_uuid}</summary>
-        ///<param name="indexUuid">this parameter is required</param>
+        /// <summary>/_dangling/{index_uuid}</summary>
+        /// <param name="indexUuid">this parameter is required</param>
         public ImportDanglingIndexRequest(IndexUuid indexUuid)
             : base(r => r.Required("index_uuid", indexUuid)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected ImportDanglingIndexRequest()
             : base() { }
@@ -155,22 +155,22 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
             Self.RouteValues.Get<IndexUuid>("index_uuid");
 
         // Request parameters
-        ///<summary>Must be set to true in order to import the dangling index.</summary>
+        /// <summary>Must be set to true in order to import the dangling index.</summary>
         public bool? AcceptDataLoss
         {
             get => Q<bool?>("accept_data_loss");
             set => Q("accept_data_loss", value);
         }
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -180,7 +180,7 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -192,7 +192,7 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
     public partial interface IListDanglingIndicesRequest
         : IRequest<ListDanglingIndicesRequestParameters> { }
 
-    ///<summary>Request for List <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Request for List <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class ListDanglingIndicesRequest
         : PlainRequestBase<ListDanglingIndicesRequestParameters>,
             IListDanglingIndicesRequest

--- a/src/OpenSearch.Client/_Generated/Requests.Ingest.cs
+++ b/src/OpenSearch.Client/_Generated/Requests.Ingest.cs
@@ -65,7 +65,7 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id Id { get; }
     }
 
-    ///<summary>Request for DeletePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
+    /// <summary>Request for DeletePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
     public partial class DeletePipelineRequest
         : PlainRequestBase<DeletePipelineRequestParameters>,
             IDeletePipelineRequest
@@ -73,12 +73,12 @@ namespace OpenSearch.Client.Specification.IngestApi
         protected IDeletePipelineRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestDeletePipeline;
 
-        ///<summary>/_ingest/pipeline/{id}</summary>
-        ///<param name="id">this parameter is required</param>
+        /// <summary>/_ingest/pipeline/{id}</summary>
+        /// <param name="id">this parameter is required</param>
         public DeletePipelineRequest(Id id)
             : base(r => r.Required("id", id)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected DeletePipelineRequest()
             : base() { }
@@ -88,15 +88,15 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id IDeletePipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -106,7 +106,7 @@ namespace OpenSearch.Client.Specification.IngestApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -121,7 +121,7 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id Id { get; }
     }
 
-    ///<summary>Request for GetPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
+    /// <summary>Request for GetPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
     public partial class GetPipelineRequest
         : PlainRequestBase<GetPipelineRequestParameters>,
             IGetPipelineRequest
@@ -129,12 +129,12 @@ namespace OpenSearch.Client.Specification.IngestApi
         protected IGetPipelineRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestGetPipeline;
 
-        ///<summary>/_ingest/pipeline</summary>
+        /// <summary>/_ingest/pipeline</summary>
         public GetPipelineRequest()
             : base() { }
 
-        ///<summary>/_ingest/pipeline/{id}</summary>
-        ///<param name="id">Optional, accepts null</param>
+        /// <summary>/_ingest/pipeline/{id}</summary>
+        /// <param name="id">Optional, accepts null</param>
         public GetPipelineRequest(Id id)
             : base(r => r.Optional("id", id)) { }
 
@@ -143,15 +143,15 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id IGetPipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -166,7 +166,7 @@ namespace OpenSearch.Client.Specification.IngestApi
     public partial interface IGrokProcessorPatternsRequest
         : IRequest<GrokProcessorPatternsRequestParameters> { }
 
-    ///<summary>Request for GrokProcessorPatterns <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request for GrokProcessorPatterns <para>https://opensearch.org/docs/latest</para></summary>
     public partial class GrokProcessorPatternsRequest
         : PlainRequestBase<GrokProcessorPatternsRequestParameters>,
             IGrokProcessorPatternsRequest
@@ -185,7 +185,7 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id Id { get; }
     }
 
-    ///<summary>Request for PutPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
+    /// <summary>Request for PutPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
     public partial class PutPipelineRequest
         : PlainRequestBase<PutPipelineRequestParameters>,
             IPutPipelineRequest
@@ -193,12 +193,12 @@ namespace OpenSearch.Client.Specification.IngestApi
         protected IPutPipelineRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestPutPipeline;
 
-        ///<summary>/_ingest/pipeline/{id}</summary>
-        ///<param name="id">this parameter is required</param>
+        /// <summary>/_ingest/pipeline/{id}</summary>
+        /// <param name="id">this parameter is required</param>
         public PutPipelineRequest(Id id)
             : base(r => r.Required("id", id)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected PutPipelineRequest()
             : base() { }
@@ -208,15 +208,15 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id IPutPipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -226,7 +226,7 @@ namespace OpenSearch.Client.Specification.IngestApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -241,7 +241,7 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id Id { get; }
     }
 
-    ///<summary>Request for SimulatePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
+    /// <summary>Request for SimulatePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
     public partial class SimulatePipelineRequest
         : PlainRequestBase<SimulatePipelineRequestParameters>,
             ISimulatePipelineRequest
@@ -249,12 +249,12 @@ namespace OpenSearch.Client.Specification.IngestApi
         protected ISimulatePipelineRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestSimulatePipeline;
 
-        ///<summary>/_ingest/pipeline/_simulate</summary>
+        /// <summary>/_ingest/pipeline/_simulate</summary>
         public SimulatePipelineRequest()
             : base() { }
 
-        ///<summary>/_ingest/pipeline/{id}/_simulate</summary>
-        ///<param name="id">Optional, accepts null</param>
+        /// <summary>/_ingest/pipeline/{id}/_simulate</summary>
+        /// <param name="id">Optional, accepts null</param>
         public SimulatePipelineRequest(Id id)
             : base(r => r.Optional("id", id)) { }
 
@@ -263,7 +263,7 @@ namespace OpenSearch.Client.Specification.IngestApi
         Id ISimulatePipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 
         // Request parameters
-        ///<summary>Verbose mode. Display data output for each processor in executed pipeline.</summary>
+        /// <summary>Verbose mode. Display data output for each processor in executed pipeline.</summary>
         public bool? Verbose
         {
             get => Q<bool?>("verbose");

--- a/src/OpenSearch.Client/_Generated/Requests.Nodes.cs
+++ b/src/OpenSearch.Client/_Generated/Requests.Nodes.cs
@@ -65,7 +65,7 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds NodeId { get; }
     }
 
-    ///<summary>Request for HotThreads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
+    /// <summary>Request for HotThreads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
     public partial class NodesHotThreadsRequest
         : PlainRequestBase<NodesHotThreadsRequestParameters>,
             INodesHotThreadsRequest
@@ -73,12 +73,12 @@ namespace OpenSearch.Client.Specification.NodesApi
         protected INodesHotThreadsRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesHotThreads;
 
-        ///<summary>/_nodes/hot_threads</summary>
+        /// <summary>/_nodes/hot_threads</summary>
         public NodesHotThreadsRequest()
             : base() { }
 
-        ///<summary>/_nodes/{node_id}/hot_threads</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/hot_threads</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
         public NodesHotThreadsRequest(NodeIds nodeId)
             : base(r => r.Optional("node_id", nodeId)) { }
 
@@ -87,42 +87,42 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds INodesHotThreadsRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
         // Request parameters
-        ///<summary>Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue.</summary>
+        /// <summary>Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue.</summary>
         public bool? IgnoreIdleThreads
         {
             get => Q<bool?>("ignore_idle_threads");
             set => Q("ignore_idle_threads", value);
         }
 
-        ///<summary>The interval for the second sampling of threads.</summary>
+        /// <summary>The interval for the second sampling of threads.</summary>
         public Time Interval
         {
             get => Q<Time>("interval");
             set => Q("interval", value);
         }
 
-        ///<summary>The type to sample.</summary>
+        /// <summary>The type to sample.</summary>
         public SampleType? SampleType
         {
             get => Q<SampleType?>("type");
             set => Q("type", value);
         }
 
-        ///<summary>Number of samples of thread stacktrace.</summary>
+        /// <summary>Number of samples of thread stacktrace.</summary>
         public long? Snapshots
         {
             get => Q<long?>("snapshots");
             set => Q("snapshots", value);
         }
 
-        ///<summary>Specify the number of threads to provide information for.</summary>
+        /// <summary>Specify the number of threads to provide information for.</summary>
         public long? Threads
         {
             get => Q<long?>("threads");
             set => Q("threads", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -140,7 +140,7 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds NodeId { get; }
     }
 
-    ///<summary>Request for Info <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+    /// <summary>Request for Info <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
     public partial class NodesInfoRequest
         : PlainRequestBase<NodesInfoRequestParameters>,
             INodesInfoRequest
@@ -148,23 +148,23 @@ namespace OpenSearch.Client.Specification.NodesApi
         protected INodesInfoRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesInfo;
 
-        ///<summary>/_nodes</summary>
+        /// <summary>/_nodes</summary>
         public NodesInfoRequest()
             : base() { }
 
-        ///<summary>/_nodes/{node_id}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        public NodesInfoRequest(NodeIds nodeId)
-            : base(r => r.Optional("node_id", nodeId)) { }
-
-        ///<summary>/_nodes/{metric}</summary>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/{metric}</summary>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesInfoRequest(Metrics metric)
             : base(r => r.Optional("metric", metric)) { }
 
-        ///<summary>/_nodes/{node_id}/{metric}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        public NodesInfoRequest(NodeIds nodeId)
+            : base(r => r.Optional("node_id", nodeId)) { }
+
+        /// <summary>/_nodes/{node_id}/{metric}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesInfoRequest(NodeIds nodeId, Metrics metric)
             : base(r => r.Optional("node_id", nodeId).Optional("metric", metric)) { }
 
@@ -176,14 +176,14 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds INodesInfoRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
         // Request parameters
-        ///<summary>Return settings in flat format.</summary>
+        /// <summary>Return settings in flat format.</summary>
         public bool? FlatSettings
         {
             get => Q<bool?>("flat_settings");
             set => Q("flat_settings", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -199,7 +199,7 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds NodeId { get; }
     }
 
-    ///<summary>Request for ReloadSecureSettings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
+    /// <summary>Request for ReloadSecureSettings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
     public partial class ReloadSecureSettingsRequest
         : PlainRequestBase<ReloadSecureSettingsRequestParameters>,
             IReloadSecureSettingsRequest
@@ -207,12 +207,12 @@ namespace OpenSearch.Client.Specification.NodesApi
         protected IReloadSecureSettingsRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesReloadSecureSettings;
 
-        ///<summary>/_nodes/reload_secure_settings</summary>
+        /// <summary>/_nodes/reload_secure_settings</summary>
         public ReloadSecureSettingsRequest()
             : base() { }
 
-        ///<summary>/_nodes/{node_id}/reload_secure_settings</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/reload_secure_settings</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
         public ReloadSecureSettingsRequest(NodeIds nodeId)
             : base(r => r.Optional("node_id", nodeId)) { }
 
@@ -221,7 +221,7 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds IReloadSecureSettingsRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
         // Request parameters
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -242,7 +242,7 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds NodeId { get; }
     }
 
-    ///<summary>Request for Stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+    /// <summary>Request for Stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
     public partial class NodesStatsRequest
         : PlainRequestBase<NodesStatsRequestParameters>,
             INodesStatsRequest
@@ -250,36 +250,36 @@ namespace OpenSearch.Client.Specification.NodesApi
         protected INodesStatsRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesStats;
 
-        ///<summary>/_nodes/stats</summary>
+        /// <summary>/_nodes/stats</summary>
         public NodesStatsRequest()
             : base() { }
 
-        ///<summary>/_nodes/stats/{metric}</summary>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/stats/{metric}</summary>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesStatsRequest(Metrics metric)
             : base(r => r.Optional("metric", metric)) { }
 
-        ///<summary>/_nodes/stats/{metric}/{index_metric}</summary>
-        ///<param name="metric">Optional, accepts null</param>
-        ///<param name="indexMetric">Optional, accepts null</param>
+        /// <summary>/_nodes/stats/{metric}/{index_metric}</summary>
+        /// <param name="metric">Optional, accepts null</param>
+        /// <param name="indexMetric">Optional, accepts null</param>
         public NodesStatsRequest(Metrics metric, IndexMetrics indexMetric)
             : base(r => r.Optional("metric", metric).Optional("index_metric", indexMetric)) { }
 
-        ///<summary>/_nodes/{node_id}/stats</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/stats</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
         public NodesStatsRequest(NodeIds nodeId)
             : base(r => r.Optional("node_id", nodeId)) { }
 
-        ///<summary>/_nodes/{node_id}/stats/{metric}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/stats/{metric}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesStatsRequest(NodeIds nodeId, Metrics metric)
             : base(r => r.Optional("node_id", nodeId).Optional("metric", metric)) { }
 
-        ///<summary>/_nodes/{node_id}/stats/{metric}/{index_metric}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        ///<param name="metric">Optional, accepts null</param>
-        ///<param name="indexMetric">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/stats/{metric}/{index_metric}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        /// <param name="metric">Optional, accepts null</param>
+        /// <param name="indexMetric">Optional, accepts null</param>
         public NodesStatsRequest(NodeIds nodeId, Metrics metric, IndexMetrics indexMetric)
             : base(
                 r =>
@@ -300,56 +300,56 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds INodesStatsRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
         // Request parameters
-        ///<summary>Comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards).</summary>
         public Fields CompletionFields
         {
             get => Q<Fields>("completion_fields");
             set => Q("completion_fields", value);
         }
 
-        ///<summary>Comma-separated list of fields for `fielddata` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` index metric (supports wildcards).</summary>
         public Fields FielddataFields
         {
             get => Q<Fields>("fielddata_fields");
             set => Q("fielddata_fields", value);
         }
 
-        ///<summary>Comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards).</summary>
         public Fields Fields
         {
             get => Q<Fields>("fields");
             set => Q("fields", value);
         }
 
-        ///<summary>Comma-separated list of search groups for `search` index metric.</summary>
+        /// <summary>Comma-separated list of search groups for `search` index metric.</summary>
         public string[] Groups
         {
             get => Q<string[]>("groups");
             set => Q("groups", value);
         }
 
-        ///<summary>Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).</summary>
+        /// <summary>Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).</summary>
         public bool? IncludeSegmentFileSizes
         {
             get => Q<bool?>("include_segment_file_sizes");
             set => Q("include_segment_file_sizes", value);
         }
 
-        ///<summary>Return indices stats aggregated at index, node or shard level.</summary>
+        /// <summary>Return indices stats aggregated at index, node or shard level.</summary>
         public NodesStatLevel? NodesStatLevel
         {
             get => Q<NodesStatLevel?>("level");
             set => Q("level", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Comma-separated list of document types for the `indexing` index metric.</summary>
+        /// <summary>Comma-separated list of document types for the `indexing` index metric.</summary>
         public string[] Types
         {
             get => Q<string[]>("types");
@@ -367,7 +367,7 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds NodeId { get; }
     }
 
-    ///<summary>Request for Usage <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request for Usage <para>https://opensearch.org/docs/latest</para></summary>
     public partial class NodesUsageRequest
         : PlainRequestBase<NodesUsageRequestParameters>,
             INodesUsageRequest
@@ -375,23 +375,23 @@ namespace OpenSearch.Client.Specification.NodesApi
         protected INodesUsageRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesUsage;
 
-        ///<summary>/_nodes/usage</summary>
+        /// <summary>/_nodes/usage</summary>
         public NodesUsageRequest()
             : base() { }
 
-        ///<summary>/_nodes/usage/{metric}</summary>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/usage/{metric}</summary>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesUsageRequest(Metrics metric)
             : base(r => r.Optional("metric", metric)) { }
 
-        ///<summary>/_nodes/{node_id}/usage</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/usage</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
         public NodesUsageRequest(NodeIds nodeId)
             : base(r => r.Optional("node_id", nodeId)) { }
 
-        ///<summary>/_nodes/{node_id}/usage/{metric}</summary>
-        ///<param name="nodeId">Optional, accepts null</param>
-        ///<param name="metric">Optional, accepts null</param>
+        /// <summary>/_nodes/{node_id}/usage/{metric}</summary>
+        /// <param name="nodeId">Optional, accepts null</param>
+        /// <param name="metric">Optional, accepts null</param>
         public NodesUsageRequest(NodeIds nodeId, Metrics metric)
             : base(r => r.Optional("node_id", nodeId).Optional("metric", metric)) { }
 
@@ -403,7 +403,7 @@ namespace OpenSearch.Client.Specification.NodesApi
         NodeIds INodesUsageRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
         // Request parameters
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");

--- a/src/OpenSearch.Client/_Generated/Requests.Snapshot.cs
+++ b/src/OpenSearch.Client/_Generated/Requests.Snapshot.cs
@@ -66,7 +66,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name RepositoryName { get; }
     }
 
-    ///<summary>Request for CleanupRepository <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request for CleanupRepository <para>https://opensearch.org/docs/latest</para></summary>
     public partial class CleanupRepositoryRequest
         : PlainRequestBase<CleanupRepositoryRequestParameters>,
             ICleanupRepositoryRequest
@@ -74,12 +74,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected ICleanupRepositoryRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotCleanupRepository;
 
-        ///<summary>/_snapshot/{repository}/_cleanup</summary>
-        ///<param name="repository">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/_cleanup</summary>
+        /// <param name="repository">this parameter is required</param>
         public CleanupRepositoryRequest(Name repository)
             : base(r => r.Required("repository", repository)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected CleanupRepositoryRequest()
             : base() { }
@@ -89,15 +89,15 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ICleanupRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -107,7 +107,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -128,7 +128,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name TargetSnapshot { get; }
     }
 
-    ///<summary>Request for Clone <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request for Clone <para>https://opensearch.org/docs/latest</para></summary>
     public partial class CloneSnapshotRequest
         : PlainRequestBase<CloneSnapshotRequestParameters>,
             ICloneSnapshotRequest
@@ -136,10 +136,10 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected ICloneSnapshotRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotClone;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}/_clone/{target_snapshot}</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
-        ///<param name="targetSnapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}/_clone/{target_snapshot}</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
+        /// <param name="targetSnapshot">this parameter is required</param>
         public CloneSnapshotRequest(Name repository, Name snapshot, Name targetSnapshot)
             : base(
                 r =>
@@ -148,7 +148,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
                         .Required("target_snapshot", targetSnapshot)
             ) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected CloneSnapshotRequest()
             : base() { }
@@ -164,15 +164,15 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ICloneSnapshotRequest.TargetSnapshot => Self.RouteValues.Get<Name>("target_snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -193,7 +193,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name Snapshot { get; }
     }
 
-    ///<summary>Request for Snapshot</summary>
+    /// <summary>Request for Snapshot</summary>
     public partial class SnapshotRequest
         : PlainRequestBase<SnapshotRequestParameters>,
             ISnapshotRequest
@@ -201,13 +201,13 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected ISnapshotRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotSnapshot;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
         public SnapshotRequest(Name repository, Name snapshot)
             : base(r => r.Required("repository", repository).Required("snapshot", snapshot)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected SnapshotRequest()
             : base() { }
@@ -220,15 +220,15 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ISnapshotRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -238,7 +238,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");
@@ -253,7 +253,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name RepositoryName { get; }
     }
 
-    ///<summary>Request for CreateRepository</summary>
+    /// <summary>Request for CreateRepository</summary>
     public partial class CreateRepositoryRequest
         : PlainRequestBase<CreateRepositoryRequestParameters>,
             ICreateRepositoryRequest
@@ -261,12 +261,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected ICreateRepositoryRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotCreateRepository;
 
-        ///<summary>/_snapshot/{repository}</summary>
-        ///<param name="repository">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}</summary>
+        /// <param name="repository">this parameter is required</param>
         public CreateRepositoryRequest(Name repository)
             : base(r => r.Required("repository", repository)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected CreateRepositoryRequest()
             : base() { }
@@ -276,15 +276,15 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name ICreateRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -294,14 +294,14 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Whether to verify the repository after creation.</summary>
+        /// <summary>Whether to verify the repository after creation.</summary>
         public bool? Verify
         {
             get => Q<bool?>("verify");
@@ -319,7 +319,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name Snapshot { get; }
     }
 
-    ///<summary>Request for Delete <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
+    /// <summary>Request for Delete <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
     public partial class DeleteSnapshotRequest
         : PlainRequestBase<DeleteSnapshotRequestParameters>,
             IDeleteSnapshotRequest
@@ -327,13 +327,13 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected IDeleteSnapshotRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotDelete;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
         public DeleteSnapshotRequest(Name repository, Name snapshot)
             : base(r => r.Required("repository", repository).Required("snapshot", snapshot)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected DeleteSnapshotRequest()
             : base() { }
@@ -346,15 +346,15 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name IDeleteSnapshotRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -372,7 +372,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names RepositoryName { get; }
     }
 
-    ///<summary>Request for DeleteRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
+    /// <summary>Request for DeleteRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
     public partial class DeleteRepositoryRequest
         : PlainRequestBase<DeleteRepositoryRequestParameters>,
             IDeleteRepositoryRequest
@@ -380,12 +380,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected IDeleteRepositoryRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotDeleteRepository;
 
-        ///<summary>/_snapshot/{repository}</summary>
-        ///<param name="repository">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}</summary>
+        /// <param name="repository">this parameter is required</param>
         public DeleteRepositoryRequest(Names repository)
             : base(r => r.Required("repository", repository)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected DeleteRepositoryRequest()
             : base() { }
@@ -395,15 +395,15 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names IDeleteRepositoryRequest.RepositoryName => Self.RouteValues.Get<Names>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -413,7 +413,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
@@ -431,7 +431,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names Snapshot { get; }
     }
 
-    ///<summary>Request for Get <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request for Get <para>https://opensearch.org/docs/latest</para></summary>
     public partial class GetSnapshotRequest
         : PlainRequestBase<GetSnapshotRequestParameters>,
             IGetSnapshotRequest
@@ -439,13 +439,13 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected IGetSnapshotRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotGet;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
         public GetSnapshotRequest(Name repository, Names snapshot)
             : base(r => r.Required("repository", repository).Required("snapshot", snapshot)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected GetSnapshotRequest()
             : base() { }
@@ -458,22 +458,22 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names IGetSnapshotRequest.Snapshot => Self.RouteValues.Get<Names>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
+        /// <summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
         public bool? IgnoreUnavailable
         {
             get => Q<bool?>("ignore_unavailable");
             set => Q("ignore_unavailable", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -483,7 +483,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob.</summary>
+        /// <summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob.</summary>
         public bool? Verbose
         {
             get => Q<bool?>("verbose");
@@ -498,7 +498,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names RepositoryName { get; }
     }
 
-    ///<summary>Request for GetRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
+    /// <summary>Request for GetRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
     public partial class GetRepositoryRequest
         : PlainRequestBase<GetRepositoryRequestParameters>,
             IGetRepositoryRequest
@@ -506,12 +506,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected IGetRepositoryRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotGetRepository;
 
-        ///<summary>/_snapshot</summary>
+        /// <summary>/_snapshot</summary>
         public GetRepositoryRequest()
             : base() { }
 
-        ///<summary>/_snapshot/{repository}</summary>
-        ///<param name="repository">Optional, accepts null</param>
+        /// <summary>/_snapshot/{repository}</summary>
+        /// <param name="repository">Optional, accepts null</param>
         public GetRepositoryRequest(Names repository)
             : base(r => r.Optional("repository", repository)) { }
 
@@ -520,22 +520,22 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names IGetRepositoryRequest.RepositoryName => Self.RouteValues.Get<Names>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public bool? Local
         {
             get => Q<bool?>("local");
             set => Q("local", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -556,7 +556,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name Snapshot { get; }
     }
 
-    ///<summary>Request for Restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
+    /// <summary>Request for Restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
     public partial class RestoreRequest
         : PlainRequestBase<RestoreRequestParameters>,
             IRestoreRequest
@@ -564,13 +564,13 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected IRestoreRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotRestore;
 
-        ///<summary>/_snapshot/{repository}/{snapshot}/_restore</summary>
-        ///<param name="repository">this parameter is required</param>
-        ///<param name="snapshot">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}/_restore</summary>
+        /// <param name="repository">this parameter is required</param>
+        /// <param name="snapshot">this parameter is required</param>
         public RestoreRequest(Name repository, Name snapshot)
             : base(r => r.Required("repository", repository).Required("snapshot", snapshot)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected RestoreRequest()
             : base() { }
@@ -583,15 +583,15 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name IRestoreRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -601,7 +601,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");
@@ -619,7 +619,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names Snapshot { get; }
     }
 
-    ///<summary>Request for Status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+    /// <summary>Request for Status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
     public partial class SnapshotStatusRequest
         : PlainRequestBase<SnapshotStatusRequestParameters>,
             ISnapshotStatusRequest
@@ -627,18 +627,18 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected ISnapshotStatusRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotStatus;
 
-        ///<summary>/_snapshot/_status</summary>
+        /// <summary>/_snapshot/_status</summary>
         public SnapshotStatusRequest()
             : base() { }
 
-        ///<summary>/_snapshot/{repository}/_status</summary>
-        ///<param name="repository">Optional, accepts null</param>
+        /// <summary>/_snapshot/{repository}/_status</summary>
+        /// <param name="repository">Optional, accepts null</param>
         public SnapshotStatusRequest(Name repository)
             : base(r => r.Optional("repository", repository)) { }
 
-        ///<summary>/_snapshot/{repository}/{snapshot}/_status</summary>
-        ///<param name="repository">Optional, accepts null</param>
-        ///<param name="snapshot">Optional, accepts null</param>
+        /// <summary>/_snapshot/{repository}/{snapshot}/_status</summary>
+        /// <param name="repository">Optional, accepts null</param>
+        /// <param name="snapshot">Optional, accepts null</param>
         public SnapshotStatusRequest(Name repository, Names snapshot)
             : base(r => r.Optional("repository", repository).Optional("snapshot", snapshot)) { }
 
@@ -650,22 +650,22 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Names ISnapshotStatusRequest.Snapshot => Self.RouteValues.Get<Names>("snapshot");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
+        /// <summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
         public bool? IgnoreUnavailable
         {
             get => Q<bool?>("ignore_unavailable");
             set => Q("ignore_unavailable", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -683,7 +683,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name RepositoryName { get; }
     }
 
-    ///<summary>Request for VerifyRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
+    /// <summary>Request for VerifyRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
     public partial class VerifyRepositoryRequest
         : PlainRequestBase<VerifyRepositoryRequestParameters>,
             IVerifyRepositoryRequest
@@ -691,12 +691,12 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         protected IVerifyRepositoryRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotVerifyRepository;
 
-        ///<summary>/_snapshot/{repository}/_verify</summary>
-        ///<param name="repository">this parameter is required</param>
+        /// <summary>/_snapshot/{repository}/_verify</summary>
+        /// <param name="repository">this parameter is required</param>
         public VerifyRepositoryRequest(Name repository)
             : base(r => r.Required("repository", repository)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected VerifyRepositoryRequest()
             : base() { }
@@ -706,15 +706,15 @@ namespace OpenSearch.Client.Specification.SnapshotApi
         Name IVerifyRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 
         // Request parameters
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public Time ClusterManagerTimeout
         {
             get => Q<Time>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -724,7 +724,7 @@ namespace OpenSearch.Client.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");

--- a/src/OpenSearch.Client/_Generated/Requests.Tasks.cs
+++ b/src/OpenSearch.Client/_Generated/Requests.Tasks.cs
@@ -65,7 +65,7 @@ namespace OpenSearch.Client.Specification.TasksApi
         TaskId TaskId { get; }
     }
 
-    ///<summary>Request for Cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
+    /// <summary>Request for Cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
     public partial class CancelTasksRequest
         : PlainRequestBase<CancelTasksRequestParameters>,
             ICancelTasksRequest
@@ -73,12 +73,12 @@ namespace OpenSearch.Client.Specification.TasksApi
         protected ICancelTasksRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.TasksCancel;
 
-        ///<summary>/_tasks/_cancel</summary>
+        /// <summary>/_tasks/_cancel</summary>
         public CancelTasksRequest()
             : base() { }
 
-        ///<summary>/_tasks/{task_id}/_cancel</summary>
-        ///<param name="taskId">Optional, accepts null</param>
+        /// <summary>/_tasks/{task_id}/_cancel</summary>
+        /// <param name="taskId">Optional, accepts null</param>
         public CancelTasksRequest(TaskId taskId)
             : base(r => r.Optional("task_id", taskId)) { }
 
@@ -87,31 +87,31 @@ namespace OpenSearch.Client.Specification.TasksApi
         TaskId ICancelTasksRequest.TaskId => Self.RouteValues.Get<TaskId>("task_id");
 
         // Request parameters
-        ///<summary>Comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
+        /// <summary>Comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
         public string[] Actions
         {
             get => Q<string[]>("actions");
             set => Q("actions", value);
         }
 
-        ///<summary>
+        /// <summary>
         /// Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're
         /// connecting to, leave empty to get information from all nodes.
-        ///</summary>
+        /// </summary>
         public string[] Nodes
         {
             get => Q<string[]>("nodes");
             set => Q("nodes", value);
         }
 
-        ///<summary>Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.</summary>
+        /// <summary>Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.</summary>
         public string ParentTaskId
         {
             get => Q<string>("parent_task_id");
             set => Q("parent_task_id", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");
@@ -126,7 +126,7 @@ namespace OpenSearch.Client.Specification.TasksApi
         TaskId TaskId { get; }
     }
 
-    ///<summary>Request for GetTask <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+    /// <summary>Request for GetTask <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
     public partial class GetTaskRequest
         : PlainRequestBase<GetTaskRequestParameters>,
             IGetTaskRequest
@@ -134,12 +134,12 @@ namespace OpenSearch.Client.Specification.TasksApi
         protected IGetTaskRequest Self => this;
         internal override ApiUrls ApiUrls => ApiUrlsLookups.TasksGetTask;
 
-        ///<summary>/_tasks/{task_id}</summary>
-        ///<param name="taskId">this parameter is required</param>
+        /// <summary>/_tasks/{task_id}</summary>
+        /// <param name="taskId">this parameter is required</param>
         public GetTaskRequest(TaskId taskId)
             : base(r => r.Required("task_id", taskId)) { }
 
-        ///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+        /// <summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
         [SerializationConstructor]
         protected GetTaskRequest()
             : base() { }
@@ -149,14 +149,14 @@ namespace OpenSearch.Client.Specification.TasksApi
         TaskId IGetTaskRequest.TaskId => Self.RouteValues.Get<TaskId>("task_id");
 
         // Request parameters
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");
@@ -167,7 +167,7 @@ namespace OpenSearch.Client.Specification.TasksApi
     [InterfaceDataContract]
     public partial interface IListTasksRequest : IRequest<ListTasksRequestParameters> { }
 
-    ///<summary>Request for List <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+    /// <summary>Request for List <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
     public partial class ListTasksRequest
         : PlainRequestBase<ListTasksRequestParameters>,
             IListTasksRequest
@@ -178,52 +178,52 @@ namespace OpenSearch.Client.Specification.TasksApi
         // values part of the url path
 
         // Request parameters
-        ///<summary>Comma-separated list of actions that should be returned. Leave empty to return all.</summary>
+        /// <summary>Comma-separated list of actions that should be returned. Leave empty to return all.</summary>
         public string[] Actions
         {
             get => Q<string[]>("actions");
             set => Q("actions", value);
         }
 
-        ///<summary>Return detailed task information.</summary>
+        /// <summary>Return detailed task information.</summary>
         public bool? Detailed
         {
             get => Q<bool?>("detailed");
             set => Q("detailed", value);
         }
 
-        ///<summary>Group tasks by nodes or parent/child relationships.</summary>
+        /// <summary>Group tasks by nodes or parent/child relationships.</summary>
         public GroupBy? GroupBy
         {
             get => Q<GroupBy?>("group_by");
             set => Q("group_by", value);
         }
 
-        ///<summary>
+        /// <summary>
         /// Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're
         /// connecting to, leave empty to get information from all nodes.
-        ///</summary>
+        /// </summary>
         public string[] Nodes
         {
             get => Q<string[]>("nodes");
             set => Q("nodes", value);
         }
 
-        ///<summary>Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.</summary>
+        /// <summary>Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.</summary>
         public string ParentTaskId
         {
             get => Q<string>("parent_task_id");
             set => Q("parent_task_id", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public Time Timeout
         {
             get => Q<Time>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");

--- a/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Cluster.cs
+++ b/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Cluster.cs
@@ -52,21 +52,21 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace OpenSearch.Net.Specification.ClusterApi
 {
-    ///<summary>Request options for AllocationExplain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
+    /// <summary>Request options for AllocationExplain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
     public partial class ClusterAllocationExplainRequestParameters
         : RequestParameters<ClusterAllocationExplainRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
         public override bool SupportsBody => true;
 
-        ///<summary>Return information about disk usage and shard sizes.</summary>
+        /// <summary>Return information about disk usage and shard sizes.</summary>
         public bool? IncludeDiskInfo
         {
             get => Q<bool?>("include_disk_info");
             set => Q("include_disk_info", value);
         }
 
-        ///<summary>Return 'YES' decisions in explanation.</summary>
+        /// <summary>Return 'YES' decisions in explanation.</summary>
         public bool? IncludeYesDecisions
         {
             get => Q<bool?>("include_yes_decisions");
@@ -74,22 +74,22 @@ namespace OpenSearch.Net.Specification.ClusterApi
         }
     }
 
-    ///<summary>Request options for DeleteComponentTemplate <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for DeleteComponentTemplate <para>https://opensearch.org/docs/latest</para></summary>
     public partial class DeleteComponentTemplateRequestParameters
         : RequestParameters<DeleteComponentTemplateRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -99,7 +99,7 @@ namespace OpenSearch.Net.Specification.ClusterApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -107,14 +107,14 @@ namespace OpenSearch.Net.Specification.ClusterApi
         }
     }
 
-    ///<summary>Request options for DeleteVotingConfigExclusions <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for DeleteVotingConfigExclusions <para>https://opensearch.org/docs/latest</para></summary>
     public partial class DeleteVotingConfigExclusionsRequestParameters
         : RequestParameters<DeleteVotingConfigExclusionsRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
         public override bool SupportsBody => false;
 
-        ///<summary>Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list.</summary>
+        /// <summary>Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list.</summary>
         public bool? WaitForRemoval
         {
             get => Q<bool?>("wait_for_removal");
@@ -122,21 +122,21 @@ namespace OpenSearch.Net.Specification.ClusterApi
         }
     }
 
-    ///<summary>Request options for ExistsComponentTemplate <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for ExistsComponentTemplate <para>https://opensearch.org/docs/latest</para></summary>
     public partial class ExistsComponentTemplateRequestParameters
         : RequestParameters<ExistsComponentTemplateRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
         public override bool SupportsBody => false;
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public bool? Local
         {
             get => Q<bool?>("local");
             set => Q("local", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -147,29 +147,29 @@ namespace OpenSearch.Net.Specification.ClusterApi
         }
     }
 
-    ///<summary>Request options for GetComponentTemplate <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for GetComponentTemplate <para>https://opensearch.org/docs/latest</para></summary>
     public partial class GetComponentTemplateRequestParameters
         : RequestParameters<GetComponentTemplateRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public bool? Local
         {
             get => Q<bool?>("local");
             set => Q("local", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -180,36 +180,36 @@ namespace OpenSearch.Net.Specification.ClusterApi
         }
     }
 
-    ///<summary>Request options for GetSettings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
+    /// <summary>Request options for GetSettings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
     public partial class ClusterGetSettingsRequestParameters
         : RequestParameters<ClusterGetSettingsRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Return settings in flat format.</summary>
+        /// <summary>Return settings in flat format.</summary>
         public bool? FlatSettings
         {
             get => Q<bool?>("flat_settings");
             set => Q("flat_settings", value);
         }
 
-        ///<summary>Whether to return all default clusters setting.</summary>
+        /// <summary>Whether to return all default clusters setting.</summary>
         public bool? IncludeDefaults
         {
             get => Q<bool?>("include_defaults");
             set => Q("include_defaults", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -219,7 +219,7 @@ namespace OpenSearch.Net.Specification.ClusterApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -227,57 +227,57 @@ namespace OpenSearch.Net.Specification.ClusterApi
         }
     }
 
-    ///<summary>Request options for Health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
+    /// <summary>Request options for Health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
     public partial class ClusterHealthRequestParameters
         : RequestParameters<ClusterHealthRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>The awareness attribute for which the health is required.</summary>
+        /// <summary>The awareness attribute for which the health is required.</summary>
         public string AwarenessAttribute
         {
             get => Q<string>("awareness_attribute");
             set => Q("awareness_attribute", value);
         }
 
-        ///<summary>Specify the level of detail for returned information.</summary>
+        /// <summary>Specify the level of detail for returned information.</summary>
         public ClusterHealthLevel? ClusterHealthLevel
         {
             get => Q<ClusterHealthLevel?>("level");
             set => Q("level", value);
         }
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Checks whether local node is commissioned or not. If set to true on a local call it will throw exception if node is decommissioned.</summary>
+        /// <summary>Checks whether local node is commissioned or not. If set to true on a local call it will throw exception if node is decommissioned.</summary>
         public bool? EnsureNodeCommissioned
         {
             get => Q<bool?>("ensure_node_commissioned");
             set => Q("ensure_node_commissioned", value);
         }
 
-        ///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+        /// <summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
         public ExpandWildcards? ExpandWildcards
         {
             get => Q<ExpandWildcards?>("expand_wildcards");
             set => Q("expand_wildcards", value);
         }
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public bool? Local
         {
             get => Q<bool?>("local");
             set => Q("local", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -287,49 +287,49 @@ namespace OpenSearch.Net.Specification.ClusterApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Wait until the specified number of shards is active.</summary>
+        /// <summary>Wait until the specified number of shards is active.</summary>
         public string WaitForActiveShards
         {
             get => Q<string>("wait_for_active_shards");
             set => Q("wait_for_active_shards", value);
         }
 
-        ///<summary>Wait until all currently queued events with the given priority are processed.</summary>
+        /// <summary>Wait until all currently queued events with the given priority are processed.</summary>
         public WaitForEvents? WaitForEvents
         {
             get => Q<WaitForEvents?>("wait_for_events");
             set => Q("wait_for_events", value);
         }
 
-        ///<summary>Wait until the specified number of nodes is available.</summary>
+        /// <summary>Wait until the specified number of nodes is available.</summary>
         public string WaitForNodes
         {
             get => Q<string>("wait_for_nodes");
             set => Q("wait_for_nodes", value);
         }
 
-        ///<summary>Whether to wait until there are no initializing shards in the cluster.</summary>
+        /// <summary>Whether to wait until there are no initializing shards in the cluster.</summary>
         public bool? WaitForNoInitializingShards
         {
             get => Q<bool?>("wait_for_no_initializing_shards");
             set => Q("wait_for_no_initializing_shards", value);
         }
 
-        ///<summary>Whether to wait until there are no relocating shards in the cluster.</summary>
+        /// <summary>Whether to wait until there are no relocating shards in the cluster.</summary>
         public bool? WaitForNoRelocatingShards
         {
             get => Q<bool?>("wait_for_no_relocating_shards");
             set => Q("wait_for_no_relocating_shards", value);
         }
 
-        ///<summary>Wait until cluster is in a specific state.</summary>
+        /// <summary>Wait until cluster is in a specific state.</summary>
         public WaitForStatus? WaitForStatus
         {
             get => Q<WaitForStatus?>("wait_for_status");
@@ -337,29 +337,29 @@ namespace OpenSearch.Net.Specification.ClusterApi
         }
     }
 
-    ///<summary>Request options for PendingTasks <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for PendingTasks <para>https://opensearch.org/docs/latest</para></summary>
     public partial class ClusterPendingTasksRequestParameters
         : RequestParameters<ClusterPendingTasksRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public bool? Local
         {
             get => Q<bool?>("local");
             set => Q("local", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]

--- a/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.DanglingIndices.cs
+++ b/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.DanglingIndices.cs
@@ -52,29 +52,29 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace OpenSearch.Net.Specification.DanglingIndicesApi
 {
-    ///<summary>Request options for DeleteDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Request options for DeleteDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class DeleteDanglingIndexRequestParameters
         : RequestParameters<DeleteDanglingIndexRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
         public override bool SupportsBody => false;
 
-        ///<summary>Must be set to true in order to delete the dangling index.</summary>
+        /// <summary>Must be set to true in order to delete the dangling index.</summary>
         public bool? AcceptDataLoss
         {
             get => Q<bool?>("accept_data_loss");
             set => Q("accept_data_loss", value);
         }
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -84,7 +84,7 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -92,29 +92,29 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
         }
     }
 
-    ///<summary>Request options for ImportDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Request options for ImportDanglingIndex <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class ImportDanglingIndexRequestParameters
         : RequestParameters<ImportDanglingIndexRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
         public override bool SupportsBody => false;
 
-        ///<summary>Must be set to true in order to import the dangling index.</summary>
+        /// <summary>Must be set to true in order to import the dangling index.</summary>
         public bool? AcceptDataLoss
         {
             get => Q<bool?>("accept_data_loss");
             set => Q("accept_data_loss", value);
         }
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -124,7 +124,7 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -132,7 +132,7 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
         }
     }
 
-    ///<summary>Request options for List <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+    /// <summary>Request options for List <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
     public partial class ListDanglingIndicesRequestParameters
         : RequestParameters<ListDanglingIndicesRequestParameters>
     {

--- a/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Ingest.cs
+++ b/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Ingest.cs
@@ -52,22 +52,22 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace OpenSearch.Net.Specification.IngestApi
 {
-    ///<summary>Request options for DeletePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
+    /// <summary>Request options for DeletePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
     public partial class DeletePipelineRequestParameters
         : RequestParameters<DeletePipelineRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -77,7 +77,7 @@ namespace OpenSearch.Net.Specification.IngestApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -85,22 +85,22 @@ namespace OpenSearch.Net.Specification.IngestApi
         }
     }
 
-    ///<summary>Request options for GetPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
+    /// <summary>Request options for GetPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
     public partial class GetPipelineRequestParameters
         : RequestParameters<GetPipelineRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -111,7 +111,7 @@ namespace OpenSearch.Net.Specification.IngestApi
         }
     }
 
-    ///<summary>Request options for GrokProcessorPatterns <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for GrokProcessorPatterns <para>https://opensearch.org/docs/latest</para></summary>
     public partial class GrokProcessorPatternsRequestParameters
         : RequestParameters<GrokProcessorPatternsRequestParameters>
     {
@@ -119,22 +119,22 @@ namespace OpenSearch.Net.Specification.IngestApi
         public override bool SupportsBody => false;
     }
 
-    ///<summary>Request options for PutPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
+    /// <summary>Request options for PutPipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
     public partial class PutPipelineRequestParameters
         : RequestParameters<PutPipelineRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
         public override bool SupportsBody => true;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -144,7 +144,7 @@ namespace OpenSearch.Net.Specification.IngestApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -152,14 +152,14 @@ namespace OpenSearch.Net.Specification.IngestApi
         }
     }
 
-    ///<summary>Request options for SimulatePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
+    /// <summary>Request options for SimulatePipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
     public partial class SimulatePipelineRequestParameters
         : RequestParameters<SimulatePipelineRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
         public override bool SupportsBody => true;
 
-        ///<summary>Verbose mode. Display data output for each processor in executed pipeline.</summary>
+        /// <summary>Verbose mode. Display data output for each processor in executed pipeline.</summary>
         public bool? Verbose
         {
             get => Q<bool?>("verbose");

--- a/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Nodes.cs
+++ b/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Nodes.cs
@@ -52,49 +52,49 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace OpenSearch.Net.Specification.NodesApi
 {
-    ///<summary>Request options for HotThreads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
+    /// <summary>Request options for HotThreads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
     public partial class NodesHotThreadsRequestParameters
         : RequestParameters<NodesHotThreadsRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue.</summary>
+        /// <summary>Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue.</summary>
         public bool? IgnoreIdleThreads
         {
             get => Q<bool?>("ignore_idle_threads");
             set => Q("ignore_idle_threads", value);
         }
 
-        ///<summary>The interval for the second sampling of threads.</summary>
+        /// <summary>The interval for the second sampling of threads.</summary>
         public TimeSpan Interval
         {
             get => Q<TimeSpan>("interval");
             set => Q("interval", value);
         }
 
-        ///<summary>The type to sample.</summary>
+        /// <summary>The type to sample.</summary>
         public SampleType? SampleType
         {
             get => Q<SampleType?>("type");
             set => Q("type", value);
         }
 
-        ///<summary>Number of samples of thread stacktrace.</summary>
+        /// <summary>Number of samples of thread stacktrace.</summary>
         public long? Snapshots
         {
             get => Q<long?>("snapshots");
             set => Q("snapshots", value);
         }
 
-        ///<summary>Specify the number of threads to provide information for.</summary>
+        /// <summary>Specify the number of threads to provide information for.</summary>
         public long? Threads
         {
             get => Q<long?>("threads");
             set => Q("threads", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -102,20 +102,20 @@ namespace OpenSearch.Net.Specification.NodesApi
         }
     }
 
-    ///<summary>Request options for Info <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+    /// <summary>Request options for Info <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
     public partial class NodesInfoRequestParameters : RequestParameters<NodesInfoRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Return settings in flat format.</summary>
+        /// <summary>Return settings in flat format.</summary>
         public bool? FlatSettings
         {
             get => Q<bool?>("flat_settings");
             set => Q("flat_settings", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -123,14 +123,14 @@ namespace OpenSearch.Net.Specification.NodesApi
         }
     }
 
-    ///<summary>Request options for ReloadSecureSettings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
+    /// <summary>Request options for ReloadSecureSettings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
     public partial class ReloadSecureSettingsRequestParameters
         : RequestParameters<ReloadSecureSettingsRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
         public override bool SupportsBody => true;
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -138,63 +138,63 @@ namespace OpenSearch.Net.Specification.NodesApi
         }
     }
 
-    ///<summary>Request options for Stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+    /// <summary>Request options for Stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
     public partial class NodesStatsRequestParameters
         : RequestParameters<NodesStatsRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards).</summary>
         public string[] CompletionFields
         {
             get => Q<string[]>("completion_fields");
             set => Q("completion_fields", value);
         }
 
-        ///<summary>Comma-separated list of fields for `fielddata` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` index metric (supports wildcards).</summary>
         public string[] FielddataFields
         {
             get => Q<string[]>("fielddata_fields");
             set => Q("fielddata_fields", value);
         }
 
-        ///<summary>Comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards).</summary>
+        /// <summary>Comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards).</summary>
         public string[] Fields
         {
             get => Q<string[]>("fields");
             set => Q("fields", value);
         }
 
-        ///<summary>Comma-separated list of search groups for `search` index metric.</summary>
+        /// <summary>Comma-separated list of search groups for `search` index metric.</summary>
         public string[] Groups
         {
             get => Q<string[]>("groups");
             set => Q("groups", value);
         }
 
-        ///<summary>Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).</summary>
+        /// <summary>Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).</summary>
         public bool? IncludeSegmentFileSizes
         {
             get => Q<bool?>("include_segment_file_sizes");
             set => Q("include_segment_file_sizes", value);
         }
 
-        ///<summary>Return indices stats aggregated at index, node or shard level.</summary>
+        /// <summary>Return indices stats aggregated at index, node or shard level.</summary>
         public NodesStatLevel? NodesStatLevel
         {
             get => Q<NodesStatLevel?>("level");
             set => Q("level", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Comma-separated list of document types for the `indexing` index metric.</summary>
+        /// <summary>Comma-separated list of document types for the `indexing` index metric.</summary>
         public string[] Types
         {
             get => Q<string[]>("types");
@@ -202,14 +202,14 @@ namespace OpenSearch.Net.Specification.NodesApi
         }
     }
 
-    ///<summary>Request options for Usage <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for Usage <para>https://opensearch.org/docs/latest</para></summary>
     public partial class NodesUsageRequestParameters
         : RequestParameters<NodesUsageRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");

--- a/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Snapshot.cs
+++ b/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Snapshot.cs
@@ -52,22 +52,22 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace OpenSearch.Net.Specification.SnapshotApi
 {
-    ///<summary>Request options for CleanupRepository <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for CleanupRepository <para>https://opensearch.org/docs/latest</para></summary>
     public partial class CleanupRepositoryRequestParameters
         : RequestParameters<CleanupRepositoryRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -77,7 +77,7 @@ namespace OpenSearch.Net.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -85,22 +85,22 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for Clone <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for Clone <para>https://opensearch.org/docs/latest</para></summary>
     public partial class CloneSnapshotRequestParameters
         : RequestParameters<CloneSnapshotRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
         public override bool SupportsBody => true;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -111,21 +111,21 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for Snapshot</summary>
+    /// <summary>Request options for Snapshot</summary>
     public partial class SnapshotRequestParameters : RequestParameters<SnapshotRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
         public override bool SupportsBody => true;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -135,7 +135,7 @@ namespace OpenSearch.Net.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");
@@ -143,22 +143,22 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for CreateRepository</summary>
+    /// <summary>Request options for CreateRepository</summary>
     public partial class CreateRepositoryRequestParameters
         : RequestParameters<CreateRepositoryRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
         public override bool SupportsBody => true;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -168,14 +168,14 @@ namespace OpenSearch.Net.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Whether to verify the repository after creation.</summary>
+        /// <summary>Whether to verify the repository after creation.</summary>
         public bool? Verify
         {
             get => Q<bool?>("verify");
@@ -183,22 +183,22 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for Delete <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
+    /// <summary>Request options for Delete <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
     public partial class DeleteSnapshotRequestParameters
         : RequestParameters<DeleteSnapshotRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -209,22 +209,22 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for DeleteRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
+    /// <summary>Request options for DeleteRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
     public partial class DeleteRepositoryRequestParameters
         : RequestParameters<DeleteRepositoryRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -234,7 +234,7 @@ namespace OpenSearch.Net.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
@@ -242,29 +242,29 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for Get <para>https://opensearch.org/docs/latest</para></summary>
+    /// <summary>Request options for Get <para>https://opensearch.org/docs/latest</para></summary>
     public partial class GetSnapshotRequestParameters
         : RequestParameters<GetSnapshotRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
+        /// <summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
         public bool? IgnoreUnavailable
         {
             get => Q<bool?>("ignore_unavailable");
             set => Q("ignore_unavailable", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -274,7 +274,7 @@ namespace OpenSearch.Net.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob.</summary>
+        /// <summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob.</summary>
         public bool? Verbose
         {
             get => Q<bool?>("verbose");
@@ -282,29 +282,29 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for GetRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
+    /// <summary>Request options for GetRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
     public partial class GetRepositoryRequestParameters
         : RequestParameters<GetRepositoryRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
+        /// <summary>Return local information, do not retrieve the state from cluster-manager node.</summary>
         public bool? Local
         {
             get => Q<bool?>("local");
             set => Q("local", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -315,21 +315,21 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for Restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
+    /// <summary>Request options for Restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
     public partial class RestoreRequestParameters : RequestParameters<RestoreRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
         public override bool SupportsBody => true;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -339,7 +339,7 @@ namespace OpenSearch.Net.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");
@@ -347,29 +347,29 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for Status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+    /// <summary>Request options for Status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
     public partial class SnapshotStatusRequestParameters
         : RequestParameters<SnapshotStatusRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
+        /// <summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown.</summary>
         public bool? IgnoreUnavailable
         {
             get => Q<bool?>("ignore_unavailable");
             set => Q("ignore_unavailable", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -380,22 +380,22 @@ namespace OpenSearch.Net.Specification.SnapshotApi
         }
     }
 
-    ///<summary>Request options for VerifyRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
+    /// <summary>Request options for VerifyRepository <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
     public partial class VerifyRepositoryRequestParameters
         : RequestParameters<VerifyRepositoryRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout for connection to cluster-manager node.</summary>
-        ///<remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        /// <summary>Operation timeout for connection to cluster-manager node.</summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
         public TimeSpan ClusterManagerTimeout
         {
             get => Q<TimeSpan>("cluster_manager_timeout");
             set => Q("cluster_manager_timeout", value);
         }
 
-        ///<summary>Operation timeout for connection to master node.</summary>
+        /// <summary>Operation timeout for connection to master node.</summary>
         [Obsolete(
             "Deprecated as of: 2.0.0, reason: To promote inclusive language, use 'cluster_manager_timeout' instead."
         )]
@@ -405,7 +405,7 @@ namespace OpenSearch.Net.Specification.SnapshotApi
             set => Q("master_timeout", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");

--- a/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Tasks.cs
+++ b/src/OpenSearch.Net/_Generated/Api/RequestParameters/RequestParameters.Tasks.cs
@@ -52,38 +52,38 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace OpenSearch.Net.Specification.TasksApi
 {
-    ///<summary>Request options for Cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
+    /// <summary>Request options for Cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
     public partial class CancelTasksRequestParameters
         : RequestParameters<CancelTasksRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
         public override bool SupportsBody => false;
 
-        ///<summary>Comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
+        /// <summary>Comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
         public string[] Actions
         {
             get => Q<string[]>("actions");
             set => Q("actions", value);
         }
 
-        ///<summary>
+        /// <summary>
         /// Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're
         /// connecting to, leave empty to get information from all nodes.
-        ///</summary>
+        /// </summary>
         public string[] Nodes
         {
             get => Q<string[]>("nodes");
             set => Q("nodes", value);
         }
 
-        ///<summary>Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.</summary>
+        /// <summary>Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.</summary>
         public string ParentTaskId
         {
             get => Q<string>("parent_task_id");
             set => Q("parent_task_id", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");
@@ -91,20 +91,20 @@ namespace OpenSearch.Net.Specification.TasksApi
         }
     }
 
-    ///<summary>Request options for GetTask <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+    /// <summary>Request options for GetTask <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
     public partial class GetTaskRequestParameters : RequestParameters<GetTaskRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");
@@ -112,58 +112,58 @@ namespace OpenSearch.Net.Specification.TasksApi
         }
     }
 
-    ///<summary>Request options for List <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+    /// <summary>Request options for List <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
     public partial class ListTasksRequestParameters : RequestParameters<ListTasksRequestParameters>
     {
         public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
         public override bool SupportsBody => false;
 
-        ///<summary>Comma-separated list of actions that should be returned. Leave empty to return all.</summary>
+        /// <summary>Comma-separated list of actions that should be returned. Leave empty to return all.</summary>
         public string[] Actions
         {
             get => Q<string[]>("actions");
             set => Q("actions", value);
         }
 
-        ///<summary>Return detailed task information.</summary>
+        /// <summary>Return detailed task information.</summary>
         public bool? Detailed
         {
             get => Q<bool?>("detailed");
             set => Q("detailed", value);
         }
 
-        ///<summary>Group tasks by nodes or parent/child relationships.</summary>
+        /// <summary>Group tasks by nodes or parent/child relationships.</summary>
         public GroupBy? GroupBy
         {
             get => Q<GroupBy?>("group_by");
             set => Q("group_by", value);
         }
 
-        ///<summary>
+        /// <summary>
         /// Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're
         /// connecting to, leave empty to get information from all nodes.
-        ///</summary>
+        /// </summary>
         public string[] Nodes
         {
             get => Q<string[]>("nodes");
             set => Q("nodes", value);
         }
 
-        ///<summary>Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.</summary>
+        /// <summary>Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.</summary>
         public string ParentTaskId
         {
             get => Q<string>("parent_task_id");
             set => Q("parent_task_id", value);
         }
 
-        ///<summary>Operation timeout.</summary>
+        /// <summary>Operation timeout.</summary>
         public TimeSpan Timeout
         {
             get => Q<TimeSpan>("timeout");
             set => Q("timeout", value);
         }
 
-        ///<summary>Should this request wait until the operation has completed before returning.</summary>
+        /// <summary>Should this request wait until the operation has completed before returning.</summary>
         public bool? WaitForCompletion
         {
             get => Q<bool?>("wait_for_completion");

--- a/src/OpenSearch.Net/_Generated/IOpenSearchLowLevelClient.cs
+++ b/src/OpenSearch.Net/_Generated/IOpenSearchLowLevelClient.cs
@@ -59,27 +59,27 @@ using OpenSearch.Net.Specification.TasksApi;
 
 namespace OpenSearch.Net
 {
-    ///<summary>
-    ///OpenSearch low level client
-    ///</summary>
+    /// <summary>
+    /// OpenSearch low level client
+    /// </summary>
     public partial interface IOpenSearchLowLevelClient
     {
-        ///<summary>Cluster APIs</summary>
+        /// <summary>Cluster APIs</summary>
         LowLevelClusterNamespace Cluster { get; }
 
-        ///<summary>Dangling Indices APIs</summary>
+        /// <summary>Dangling Indices APIs</summary>
         LowLevelDanglingIndicesNamespace DanglingIndices { get; }
 
-        ///<summary>Ingest APIs</summary>
+        /// <summary>Ingest APIs</summary>
         LowLevelIngestNamespace Ingest { get; }
 
-        ///<summary>Nodes APIs</summary>
+        /// <summary>Nodes APIs</summary>
         LowLevelNodesNamespace Nodes { get; }
 
-        ///<summary>Snapshot APIs</summary>
+        /// <summary>Snapshot APIs</summary>
         LowLevelSnapshotNamespace Snapshot { get; }
 
-        ///<summary>Tasks APIs</summary>
+        /// <summary>Tasks APIs</summary>
         LowLevelTasksNamespace Tasks { get; }
     }
 }

--- a/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Cluster.cs
+++ b/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Cluster.cs
@@ -58,20 +58,20 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net.Specification.ClusterApi
 {
-    ///<summary>
+    /// <summary>
     /// Cluster APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchLowLevelClient.Cluster"/> property
     /// on <see cref="IOpenSearchLowLevelClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class LowLevelClusterNamespace : NamespacedClientProxy
     {
         internal LowLevelClusterNamespace(OpenSearchLowLevelClient client)
             : base(client) { }
 
-        ///<summary>POST on /_cluster/allocation/explain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
-        ///<param name="body">The index, shard, and primary flag to explain. Empty means &#x27;explain the first unassigned shard&#x27;</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_cluster/allocation/explain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
+        /// <param name="body">The index, shard, and primary flag to explain. Empty means &#x27;explain the first unassigned shard&#x27;</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse AllocationExplain<TResponse>(
             PostData body,
             ClusterAllocationExplainRequestParameters requestParameters = null
@@ -84,9 +84,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_cluster/allocation/explain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
-        ///<param name="body">The index, shard, and primary flag to explain. Empty means &#x27;explain the first unassigned shard&#x27;</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_cluster/allocation/explain <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</para></summary>
+        /// <param name="body">The index, shard, and primary flag to explain. Empty means &#x27;explain the first unassigned shard&#x27;</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.allocation_explain", "body")]
         public Task<TResponse> AllocationExplainAsync<TResponse>(
             PostData body,
@@ -102,9 +102,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="name">The name of the template.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="name">The name of the template.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse DeleteComponentTemplate<TResponse>(
             string name,
             DeleteComponentTemplateRequestParameters requestParameters = null
@@ -117,9 +117,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="name">The name of the template.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="name">The name of the template.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.delete_component_template", "name")]
         public Task<TResponse> DeleteComponentTemplateAsync<TResponse>(
             string name,
@@ -135,8 +135,8 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_cluster/voting_config_exclusions <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_cluster/voting_config_exclusions <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse DeleteVotingConfigExclusions<TResponse>(
             DeleteVotingConfigExclusionsRequestParameters requestParameters = null
         )
@@ -148,8 +148,8 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_cluster/voting_config_exclusions <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_cluster/voting_config_exclusions <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.delete_voting_config_exclusions", "")]
         public Task<TResponse> DeleteVotingConfigExclusionsAsync<TResponse>(
             DeleteVotingConfigExclusionsRequestParameters requestParameters = null,
@@ -164,9 +164,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>HEAD on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="name">The name of the template.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>HEAD on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="name">The name of the template.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse ExistsComponentTemplate<TResponse>(
             string name,
             ExistsComponentTemplateRequestParameters requestParameters = null
@@ -179,9 +179,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>HEAD on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="name">The name of the template.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>HEAD on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="name">The name of the template.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.exists_component_template", "name")]
         public Task<TResponse> ExistsComponentTemplateAsync<TResponse>(
             string name,
@@ -197,8 +197,8 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_component_template <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_component_template <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GetComponentTemplate<TResponse>(
             GetComponentTemplateRequestParameters requestParameters = null
         )
@@ -210,8 +210,8 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_component_template <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_component_template <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.get_component_template", "")]
         public Task<TResponse> GetComponentTemplateAsync<TResponse>(
             GetComponentTemplateRequestParameters requestParameters = null,
@@ -226,9 +226,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="name">The Comma-separated names of the component templates.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="name">The Comma-separated names of the component templates.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GetComponentTemplate<TResponse>(
             string name,
             GetComponentTemplateRequestParameters requestParameters = null
@@ -241,9 +241,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="name">The Comma-separated names of the component templates.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_component_template/{name} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="name">The Comma-separated names of the component templates.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.get_component_template", "name")]
         public Task<TResponse> GetComponentTemplateAsync<TResponse>(
             string name,
@@ -259,16 +259,16 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_cluster/settings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_cluster/settings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GetSettings<TResponse>(
             ClusterGetSettingsRequestParameters requestParameters = null
         )
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_cluster/settings", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_cluster/settings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_cluster/settings <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.get_settings", "")]
         public Task<TResponse> GetSettingsAsync<TResponse>(
             ClusterGetSettingsRequestParameters requestParameters = null,
@@ -283,14 +283,14 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_cluster/health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_cluster/health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Health<TResponse>(ClusterHealthRequestParameters requestParameters = null)
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_cluster/health", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_cluster/health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_cluster/health <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.health", "")]
         public Task<TResponse> HealthAsync<TResponse>(
             ClusterHealthRequestParameters requestParameters = null,
@@ -305,9 +305,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_cluster/health/{index} <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
-        ///<param name="index">Limit the information returned to specific indicies.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_cluster/health/{index} <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
+        /// <param name="index">Limit the information returned to specific indicies.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Health<TResponse>(
             string index,
             ClusterHealthRequestParameters requestParameters = null
@@ -320,9 +320,9 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_cluster/health/{index} <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
-        ///<param name="index">Limit the information returned to specific indicies.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_cluster/health/{index} <para>https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</para></summary>
+        /// <param name="index">Limit the information returned to specific indicies.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.health", "index")]
         public Task<TResponse> HealthAsync<TResponse>(
             string index,
@@ -338,8 +338,8 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_cluster/pending_tasks <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_cluster/pending_tasks <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse PendingTasks<TResponse>(
             ClusterPendingTasksRequestParameters requestParameters = null
         )
@@ -351,8 +351,8 @@ namespace OpenSearch.Net.Specification.ClusterApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_cluster/pending_tasks <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_cluster/pending_tasks <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("cluster.pending_tasks", "")]
         public Task<TResponse> PendingTasksAsync<TResponse>(
             ClusterPendingTasksRequestParameters requestParameters = null,

--- a/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.DanglingIndices.cs
+++ b/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.DanglingIndices.cs
@@ -58,20 +58,20 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net.Specification.DanglingIndicesApi
 {
-    ///<summary>
+    /// <summary>
     /// Dangling Indices APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchLowLevelClient.DanglingIndices"/> property
     /// on <see cref="IOpenSearchLowLevelClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class LowLevelDanglingIndicesNamespace : NamespacedClientProxy
     {
         internal LowLevelDanglingIndicesNamespace(OpenSearchLowLevelClient client)
             : base(client) { }
 
-        ///<summary>DELETE on /_dangling/{index_uuid} <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
-        ///<param name="indexUuid">The UUID of the dangling index.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_dangling/{index_uuid} <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+        /// <param name="indexUuid">The UUID of the dangling index.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse DeleteDanglingIndex<TResponse>(
             string indexUuid,
             DeleteDanglingIndexRequestParameters requestParameters = null
@@ -84,9 +84,9 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_dangling/{index_uuid} <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
-        ///<param name="indexUuid">The UUID of the dangling index.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_dangling/{index_uuid} <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+        /// <param name="indexUuid">The UUID of the dangling index.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("dangling_indices.delete_dangling_index", "index_uuid")]
         public Task<TResponse> DeleteDanglingIndexAsync<TResponse>(
             string indexUuid,
@@ -102,9 +102,9 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_dangling/{index_uuid} <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
-        ///<param name="indexUuid">The UUID of the dangling index.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_dangling/{index_uuid} <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+        /// <param name="indexUuid">The UUID of the dangling index.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse ImportDanglingIndex<TResponse>(
             string indexUuid,
             ImportDanglingIndexRequestParameters requestParameters = null
@@ -117,9 +117,9 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_dangling/{index_uuid} <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
-        ///<param name="indexUuid">The UUID of the dangling index.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_dangling/{index_uuid} <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+        /// <param name="indexUuid">The UUID of the dangling index.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("dangling_indices.import_dangling_index", "index_uuid")]
         public Task<TResponse> ImportDanglingIndexAsync<TResponse>(
             string indexUuid,
@@ -135,16 +135,16 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_dangling <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_dangling <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse List<TResponse>(
             ListDanglingIndicesRequestParameters requestParameters = null
         )
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_dangling", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_dangling <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_dangling <para>https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("dangling_indices.list_dangling_indices", "")]
         public Task<TResponse> ListAsync<TResponse>(
             ListDanglingIndicesRequestParameters requestParameters = null,

--- a/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Ingest.cs
+++ b/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Ingest.cs
@@ -58,20 +58,20 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net.Specification.IngestApi
 {
-    ///<summary>
+    /// <summary>
     /// Ingest APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchLowLevelClient.Ingest"/> property
     /// on <see cref="IOpenSearchLowLevelClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class LowLevelIngestNamespace : NamespacedClientProxy
     {
         internal LowLevelIngestNamespace(OpenSearchLowLevelClient client)
             : base(client) { }
 
-        ///<summary>DELETE on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
-        ///<param name="id">Pipeline ID.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
+        /// <param name="id">Pipeline ID.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse DeletePipeline<TResponse>(
             string id,
             DeletePipelineRequestParameters requestParameters = null
@@ -84,9 +84,9 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
-        ///<param name="id">Pipeline ID.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</para></summary>
+        /// <param name="id">Pipeline ID.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("ingest.delete_pipeline", "id")]
         public Task<TResponse> DeletePipelineAsync<TResponse>(
             string id,
@@ -102,16 +102,16 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_ingest/pipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_ingest/pipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GetPipeline<TResponse>(
             GetPipelineRequestParameters requestParameters = null
         )
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_ingest/pipeline", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_ingest/pipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_ingest/pipeline <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("ingest.get_pipeline", "")]
         public Task<TResponse> GetPipelineAsync<TResponse>(
             GetPipelineRequestParameters requestParameters = null,
@@ -126,9 +126,9 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
-        ///<param name="id">Comma-separated list of pipeline ids. Wildcards supported.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
+        /// <param name="id">Comma-separated list of pipeline ids. Wildcards supported.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GetPipeline<TResponse>(
             string id,
             GetPipelineRequestParameters requestParameters = null
@@ -141,9 +141,9 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
-        ///<param name="id">Comma-separated list of pipeline ids. Wildcards supported.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</para></summary>
+        /// <param name="id">Comma-separated list of pipeline ids. Wildcards supported.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("ingest.get_pipeline", "id")]
         public Task<TResponse> GetPipelineAsync<TResponse>(
             string id,
@@ -159,8 +159,8 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_ingest/processor/grok <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_ingest/processor/grok <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GrokProcessorPatterns<TResponse>(
             GrokProcessorPatternsRequestParameters requestParameters = null
         )
@@ -172,8 +172,8 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_ingest/processor/grok <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_ingest/processor/grok <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("ingest.processor_grok", "")]
         public Task<TResponse> GrokProcessorPatternsAsync<TResponse>(
             GrokProcessorPatternsRequestParameters requestParameters = null,
@@ -188,10 +188,10 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>PUT on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
-        ///<param name="id">Pipeline ID.</param>
-        ///<param name="body">The ingest definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>PUT on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
+        /// <param name="id">Pipeline ID.</param>
+        /// <param name="body">The ingest definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse PutPipeline<TResponse>(
             string id,
             PostData body,
@@ -205,10 +205,10 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>PUT on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
-        ///<param name="id">Pipeline ID.</param>
-        ///<param name="body">The ingest definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>PUT on /_ingest/pipeline/{id} <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</para></summary>
+        /// <param name="id">Pipeline ID.</param>
+        /// <param name="body">The ingest definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("ingest.put_pipeline", "id, body")]
         public Task<TResponse> PutPipelineAsync<TResponse>(
             string id,
@@ -225,9 +225,9 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_ingest/pipeline/_simulate <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
-        ///<param name="body">The simulate definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_ingest/pipeline/_simulate <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
+        /// <param name="body">The simulate definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse SimulatePipeline<TResponse>(
             PostData body,
             SimulatePipelineRequestParameters requestParameters = null
@@ -240,9 +240,9 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_ingest/pipeline/_simulate <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
-        ///<param name="body">The simulate definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_ingest/pipeline/_simulate <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
+        /// <param name="body">The simulate definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("ingest.simulate", "body")]
         public Task<TResponse> SimulatePipelineAsync<TResponse>(
             PostData body,
@@ -258,10 +258,10 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_ingest/pipeline/{id}/_simulate <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
-        ///<param name="id">Pipeline ID.</param>
-        ///<param name="body">The simulate definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_ingest/pipeline/{id}/_simulate <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
+        /// <param name="id">Pipeline ID.</param>
+        /// <param name="body">The simulate definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse SimulatePipeline<TResponse>(
             string id,
             PostData body,
@@ -275,10 +275,10 @@ namespace OpenSearch.Net.Specification.IngestApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_ingest/pipeline/{id}/_simulate <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
-        ///<param name="id">Pipeline ID.</param>
-        ///<param name="body">The simulate definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_ingest/pipeline/{id}/_simulate <para>https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</para></summary>
+        /// <param name="id">Pipeline ID.</param>
+        /// <param name="body">The simulate definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("ingest.simulate", "id, body")]
         public Task<TResponse> SimulatePipelineAsync<TResponse>(
             string id,

--- a/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Nodes.cs
+++ b/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Nodes.cs
@@ -58,27 +58,27 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net.Specification.NodesApi
 {
-    ///<summary>
+    /// <summary>
     /// Nodes APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchLowLevelClient.Nodes"/> property
     /// on <see cref="IOpenSearchLowLevelClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class LowLevelNodesNamespace : NamespacedClientProxy
     {
         internal LowLevelNodesNamespace(OpenSearchLowLevelClient client)
             : base(client) { }
 
-        ///<summary>GET on /_nodes/hot_threads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/hot_threads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse HotThreadsForAll<TResponse>(
             NodesHotThreadsRequestParameters requestParameters = null
         )
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_nodes/hot_threads", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_nodes/hot_threads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/hot_threads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.hot_threads", "")]
         public Task<TResponse> HotThreadsForAllAsync<TResponse>(
             NodesHotThreadsRequestParameters requestParameters = null,
@@ -93,9 +93,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/hot_threads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/hot_threads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse HotThreads<TResponse>(
             string nodeId,
             NodesHotThreadsRequestParameters requestParameters = null
@@ -108,9 +108,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/hot_threads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/hot_threads <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.hot_threads", "node_id")]
         public Task<TResponse> HotThreadsAsync<TResponse>(
             string nodeId,
@@ -126,14 +126,14 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse InfoForAll<TResponse>(NodesInfoRequestParameters requestParameters = null)
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_nodes", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_nodes <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.info", "")]
         public Task<TResponse> InfoForAllAsync<TResponse>(
             NodesInfoRequestParameters requestParameters = null,
@@ -142,42 +142,9 @@ namespace OpenSearch.Net.Specification.NodesApi
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequestAsync<TResponse>(GET, "_nodes", ctx, null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_nodes/{node_id} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
-        public TResponse Info<TResponse>(
-            string nodeId,
-            NodesInfoRequestParameters requestParameters = null
-        )
-            where TResponse : class, IOpenSearchResponse, new() =>
-            DoRequest<TResponse>(
-                GET,
-                Url($"_nodes/{nodeId:nodeId}"),
-                null,
-                RequestParams(requestParameters)
-            );
-
-        ///<summary>GET on /_nodes/{node_id} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
-        [MapsApi("nodes.info", "node_id")]
-        public Task<TResponse> InfoAsync<TResponse>(
-            string nodeId,
-            NodesInfoRequestParameters requestParameters = null,
-            CancellationToken ctx = default
-        )
-            where TResponse : class, IOpenSearchResponse, new() =>
-            DoRequestAsync<TResponse>(
-                GET,
-                Url($"_nodes/{nodeId:nodeId}"),
-                ctx,
-                null,
-                RequestParams(requestParameters)
-            );
-
-        ///<summary>GET on /_nodes/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
-        ///<param name="metric">Comma-separated list of metrics you wish returned. Leave empty to return all.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+        /// <param name="metric">Comma-separated list of metrics you wish returned. Leave empty to return all.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse InfoForAll<TResponse>(
             string metric,
             NodesInfoRequestParameters requestParameters = null
@@ -190,9 +157,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
-        ///<param name="metric">Comma-separated list of metrics you wish returned. Leave empty to return all.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+        /// <param name="metric">Comma-separated list of metrics you wish returned. Leave empty to return all.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.info", "metric")]
         public Task<TResponse> InfoForAllAsync<TResponse>(
             string metric,
@@ -208,10 +175,43 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="metric">Comma-separated list of metrics you wish returned. Leave empty to return all.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        public TResponse Info<TResponse>(
+            string nodeId,
+            NodesInfoRequestParameters requestParameters = null
+        )
+            where TResponse : class, IOpenSearchResponse, new() =>
+            DoRequest<TResponse>(
+                GET,
+                Url($"_nodes/{nodeId:nodeId}"),
+                null,
+                RequestParams(requestParameters)
+            );
+
+        /// <summary>GET on /_nodes/{node_id} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        [MapsApi("nodes.info", "node_id")]
+        public Task<TResponse> InfoAsync<TResponse>(
+            string nodeId,
+            NodesInfoRequestParameters requestParameters = null,
+            CancellationToken ctx = default
+        )
+            where TResponse : class, IOpenSearchResponse, new() =>
+            DoRequestAsync<TResponse>(
+                GET,
+                Url($"_nodes/{nodeId:nodeId}"),
+                ctx,
+                null,
+                RequestParams(requestParameters)
+            );
+
+        /// <summary>GET on /_nodes/{node_id}/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="metric">Comma-separated list of metrics you wish returned. Leave empty to return all.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Info<TResponse>(
             string nodeId,
             string metric,
@@ -225,10 +225,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="metric">Comma-separated list of metrics you wish returned. Leave empty to return all.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="metric">Comma-separated list of metrics you wish returned. Leave empty to return all.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.info", "node_id, metric")]
         public Task<TResponse> InfoAsync<TResponse>(
             string nodeId,
@@ -245,9 +245,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_nodes/reload_secure_settings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
-        ///<param name="body">An object containing the password for the opensearch keystore</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_nodes/reload_secure_settings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
+        /// <param name="body">An object containing the password for the opensearch keystore</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse ReloadSecureSettingsForAll<TResponse>(
             PostData body,
             ReloadSecureSettingsRequestParameters requestParameters = null
@@ -260,9 +260,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_nodes/reload_secure_settings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
-        ///<param name="body">An object containing the password for the opensearch keystore</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_nodes/reload_secure_settings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
+        /// <param name="body">An object containing the password for the opensearch keystore</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.reload_secure_settings", "body")]
         public Task<TResponse> ReloadSecureSettingsForAllAsync<TResponse>(
             PostData body,
@@ -278,10 +278,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_nodes/{node_id}/reload_secure_settings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.</param>
-        ///<param name="body">An object containing the password for the opensearch keystore</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_nodes/{node_id}/reload_secure_settings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.</param>
+        /// <param name="body">An object containing the password for the opensearch keystore</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse ReloadSecureSettings<TResponse>(
             string nodeId,
             PostData body,
@@ -295,10 +295,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_nodes/{node_id}/reload_secure_settings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.</param>
-        ///<param name="body">An object containing the password for the opensearch keystore</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_nodes/{node_id}/reload_secure_settings <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.</param>
+        /// <param name="body">An object containing the password for the opensearch keystore</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.reload_secure_settings", "node_id, body")]
         public Task<TResponse> ReloadSecureSettingsAsync<TResponse>(
             string nodeId,
@@ -315,16 +315,16 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse StatsForAll<TResponse>(
             NodesStatsRequestParameters requestParameters = null
         )
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_nodes/stats", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_nodes/stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.stats", "")]
         public Task<TResponse> StatsForAllAsync<TResponse>(
             NodesStatsRequestParameters requestParameters = null,
@@ -339,9 +339,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/stats/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/stats/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse StatsForAll<TResponse>(
             string metric,
             NodesStatsRequestParameters requestParameters = null
@@ -354,9 +354,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/stats/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/stats/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.stats", "metric")]
         public Task<TResponse> StatsForAllAsync<TResponse>(
             string metric,
@@ -372,10 +372,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/stats/{metric}/{index_metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="indexMetric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#x27;t used if `indices` (or `all`) metric isn&#x27;t specified.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/stats/{metric}/{index_metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="indexMetric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#x27;t used if `indices` (or `all`) metric isn&#x27;t specified.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse StatsForAll<TResponse>(
             string metric,
             string indexMetric,
@@ -389,10 +389,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/stats/{metric}/{index_metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="indexMetric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#x27;t used if `indices` (or `all`) metric isn&#x27;t specified.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/stats/{metric}/{index_metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="indexMetric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#x27;t used if `indices` (or `all`) metric isn&#x27;t specified.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.stats", "metric, index_metric")]
         public Task<TResponse> StatsForAllAsync<TResponse>(
             string metric,
@@ -409,9 +409,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Stats<TResponse>(
             string nodeId,
             NodesStatsRequestParameters requestParameters = null
@@ -424,9 +424,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/stats <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.stats", "node_id")]
         public Task<TResponse> StatsAsync<TResponse>(
             string nodeId,
@@ -442,10 +442,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/stats/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/stats/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Stats<TResponse>(
             string nodeId,
             string metric,
@@ -459,10 +459,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/stats/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/stats/{metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.stats", "node_id, metric")]
         public Task<TResponse> StatsAsync<TResponse>(
             string nodeId,
@@ -479,11 +479,11 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/stats/{metric}/{index_metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="indexMetric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#x27;t used if `indices` (or `all`) metric isn&#x27;t specified.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/stats/{metric}/{index_metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="indexMetric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#x27;t used if `indices` (or `all`) metric isn&#x27;t specified.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Stats<TResponse>(
             string nodeId,
             string metric,
@@ -498,11 +498,11 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/stats/{metric}/{index_metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="indexMetric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#x27;t used if `indices` (or `all`) metric isn&#x27;t specified.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/stats/{metric}/{index_metric} <para>https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="indexMetric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#x27;t used if `indices` (or `all`) metric isn&#x27;t specified.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.stats", "node_id, metric, index_metric")]
         public Task<TResponse> StatsAsync<TResponse>(
             string nodeId,
@@ -520,16 +520,16 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/usage <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/usage <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse UsageForAll<TResponse>(
             NodesUsageRequestParameters requestParameters = null
         )
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_nodes/usage", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_nodes/usage <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/usage <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.usage", "")]
         public Task<TResponse> UsageForAllAsync<TResponse>(
             NodesUsageRequestParameters requestParameters = null,
@@ -544,9 +544,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/usage/{metric} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/usage/{metric} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse UsageForAll<TResponse>(
             string metric,
             NodesUsageRequestParameters requestParameters = null
@@ -559,9 +559,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/usage/{metric} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/usage/{metric} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.usage", "metric")]
         public Task<TResponse> UsageForAllAsync<TResponse>(
             string metric,
@@ -577,9 +577,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/usage <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/usage <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Usage<TResponse>(
             string nodeId,
             NodesUsageRequestParameters requestParameters = null
@@ -592,9 +592,9 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/usage <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/usage <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.usage", "node_id")]
         public Task<TResponse> UsageAsync<TResponse>(
             string nodeId,
@@ -610,10 +610,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/usage/{metric} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/usage/{metric} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Usage<TResponse>(
             string nodeId,
             string metric,
@@ -627,10 +627,10 @@ namespace OpenSearch.Net.Specification.NodesApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_nodes/{node_id}/usage/{metric} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
-        ///<param name="metric">Limit the information returned to the specified metrics.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_nodes/{node_id}/usage/{metric} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="nodeId">Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#x27;re connecting to, leave empty to get information from all nodes.</param>
+        /// <param name="metric">Limit the information returned to the specified metrics.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("nodes.usage", "node_id, metric")]
         public Task<TResponse> UsageAsync<TResponse>(
             string nodeId,

--- a/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Snapshot.cs
+++ b/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Snapshot.cs
@@ -58,20 +58,20 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net.Specification.SnapshotApi
 {
-    ///<summary>
+    /// <summary>
     /// Snapshot APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchLowLevelClient.Snapshot"/> property
     /// on <see cref="IOpenSearchLowLevelClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class LowLevelSnapshotNamespace : NamespacedClientProxy
     {
         internal LowLevelSnapshotNamespace(OpenSearchLowLevelClient client)
             : base(client) { }
 
-        ///<summary>POST on /_snapshot/{repository}/_cleanup <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_snapshot/{repository}/_cleanup <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse CleanupRepository<TResponse>(
             string repository,
             CleanupRepositoryRequestParameters requestParameters = null
@@ -84,9 +84,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_snapshot/{repository}/_cleanup <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_snapshot/{repository}/_cleanup <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.cleanup_repository", "repository")]
         public Task<TResponse> CleanupRepositoryAsync<TResponse>(
             string repository,
@@ -102,12 +102,12 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>PUT on /_snapshot/{repository}/{snapshot}/_clone/{target_snapshot} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Snapshot name.</param>
-        ///<param name="targetSnapshot">The name of the cloned snapshot to create.</param>
-        ///<param name="body">The snapshot clone definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>PUT on /_snapshot/{repository}/{snapshot}/_clone/{target_snapshot} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Snapshot name.</param>
+        /// <param name="targetSnapshot">The name of the cloned snapshot to create.</param>
+        /// <param name="body">The snapshot clone definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Clone<TResponse>(
             string repository,
             string snapshot,
@@ -125,12 +125,12 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>PUT on /_snapshot/{repository}/{snapshot}/_clone/{target_snapshot} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Snapshot name.</param>
-        ///<param name="targetSnapshot">The name of the cloned snapshot to create.</param>
-        ///<param name="body">The snapshot clone definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>PUT on /_snapshot/{repository}/{snapshot}/_clone/{target_snapshot} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Snapshot name.</param>
+        /// <param name="targetSnapshot">The name of the cloned snapshot to create.</param>
+        /// <param name="body">The snapshot clone definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.clone", "repository, snapshot, target_snapshot, body")]
         public Task<TResponse> CloneAsync<TResponse>(
             string repository,
@@ -151,11 +151,11 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>PUT on /_snapshot/{repository}/{snapshot}</summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Snapshot name.</param>
-        ///<param name="body">The snapshot definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>PUT on /_snapshot/{repository}/{snapshot}</summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Snapshot name.</param>
+        /// <param name="body">The snapshot definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Snapshot<TResponse>(
             string repository,
             string snapshot,
@@ -170,11 +170,11 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>PUT on /_snapshot/{repository}/{snapshot}</summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Snapshot name.</param>
-        ///<param name="body">The snapshot definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>PUT on /_snapshot/{repository}/{snapshot}</summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Snapshot name.</param>
+        /// <param name="body">The snapshot definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.create", "repository, snapshot, body")]
         public Task<TResponse> SnapshotAsync<TResponse>(
             string repository,
@@ -192,10 +192,10 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>PUT on /_snapshot/{repository}</summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="body">The repository definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>PUT on /_snapshot/{repository}</summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="body">The repository definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse CreateRepository<TResponse>(
             string repository,
             PostData body,
@@ -209,10 +209,10 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>PUT on /_snapshot/{repository}</summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="body">The repository definition</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>PUT on /_snapshot/{repository}</summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="body">The repository definition</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.create_repository", "repository, body")]
         public Task<TResponse> CreateRepositoryAsync<TResponse>(
             string repository,
@@ -229,10 +229,10 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_snapshot/{repository}/{snapshot} <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Snapshot name.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_snapshot/{repository}/{snapshot} <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Snapshot name.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Delete<TResponse>(
             string repository,
             string snapshot,
@@ -246,10 +246,10 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_snapshot/{repository}/{snapshot} <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Snapshot name.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_snapshot/{repository}/{snapshot} <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Snapshot name.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.delete", "repository, snapshot")]
         public Task<TResponse> DeleteAsync<TResponse>(
             string repository,
@@ -266,9 +266,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_snapshot/{repository} <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
-        ///<param name="repository">Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_snapshot/{repository} <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
+        /// <param name="repository">Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse DeleteRepository<TResponse>(
             string repository,
             DeleteRepositoryRequestParameters requestParameters = null
@@ -281,9 +281,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>DELETE on /_snapshot/{repository} <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
-        ///<param name="repository">Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>DELETE on /_snapshot/{repository} <para>https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</para></summary>
+        /// <param name="repository">Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.delete_repository", "repository")]
         public Task<TResponse> DeleteRepositoryAsync<TResponse>(
             string repository,
@@ -299,10 +299,10 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/{repository}/{snapshot} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Comma-separated list of snapshot names.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/{repository}/{snapshot} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Comma-separated list of snapshot names.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Get<TResponse>(
             string repository,
             string snapshot,
@@ -316,10 +316,10 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/{repository}/{snapshot} <para>https://opensearch.org/docs/latest</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Comma-separated list of snapshot names.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/{repository}/{snapshot} <para>https://opensearch.org/docs/latest</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Comma-separated list of snapshot names.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.get", "repository, snapshot")]
         public Task<TResponse> GetAsync<TResponse>(
             string repository,
@@ -336,16 +336,16 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GetRepository<TResponse>(
             GetRepositoryRequestParameters requestParameters = null
         )
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_snapshot", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_snapshot <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.get_repository", "")]
         public Task<TResponse> GetRepositoryAsync<TResponse>(
             GetRepositoryRequestParameters requestParameters = null,
@@ -360,9 +360,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/{repository} <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
-        ///<param name="repository">Comma-separated list of repository names.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/{repository} <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
+        /// <param name="repository">Comma-separated list of repository names.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GetRepository<TResponse>(
             string repository,
             GetRepositoryRequestParameters requestParameters = null
@@ -375,9 +375,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/{repository} <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
-        ///<param name="repository">Comma-separated list of repository names.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/{repository} <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</para></summary>
+        /// <param name="repository">Comma-separated list of repository names.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.get_repository", "repository")]
         public Task<TResponse> GetRepositoryAsync<TResponse>(
             string repository,
@@ -393,11 +393,11 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_snapshot/{repository}/{snapshot}/_restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Snapshot name.</param>
-        ///<param name="body">Details of what to restore</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_snapshot/{repository}/{snapshot}/_restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Snapshot name.</param>
+        /// <param name="body">Details of what to restore</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Restore<TResponse>(
             string repository,
             string snapshot,
@@ -412,11 +412,11 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_snapshot/{repository}/{snapshot}/_restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Snapshot name.</param>
-        ///<param name="body">Details of what to restore</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_snapshot/{repository}/{snapshot}/_restore <para>https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Snapshot name.</param>
+        /// <param name="body">Details of what to restore</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.restore", "repository, snapshot, body")]
         public Task<TResponse> RestoreAsync<TResponse>(
             string repository,
@@ -434,14 +434,14 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Status<TResponse>(SnapshotStatusRequestParameters requestParameters = null)
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_snapshot/_status", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_snapshot/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.status", "")]
         public Task<TResponse> StatusAsync<TResponse>(
             SnapshotStatusRequestParameters requestParameters = null,
@@ -456,9 +456,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/{repository}/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/{repository}/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Status<TResponse>(
             string repository,
             SnapshotStatusRequestParameters requestParameters = null
@@ -471,9 +471,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/{repository}/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/{repository}/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.status", "repository")]
         public Task<TResponse> StatusAsync<TResponse>(
             string repository,
@@ -489,10 +489,10 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/{repository}/{snapshot}/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Comma-separated list of snapshot names.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/{repository}/{snapshot}/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Comma-separated list of snapshot names.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Status<TResponse>(
             string repository,
             string snapshot,
@@ -506,10 +506,10 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_snapshot/{repository}/{snapshot}/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="snapshot">Comma-separated list of snapshot names.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_snapshot/{repository}/{snapshot}/_status <para>https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="snapshot">Comma-separated list of snapshot names.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.status", "repository, snapshot")]
         public Task<TResponse> StatusAsync<TResponse>(
             string repository,
@@ -526,9 +526,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_snapshot/{repository}/_verify <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_snapshot/{repository}/_verify <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse VerifyRepository<TResponse>(
             string repository,
             VerifyRepositoryRequestParameters requestParameters = null
@@ -541,9 +541,9 @@ namespace OpenSearch.Net.Specification.SnapshotApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_snapshot/{repository}/_verify <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
-        ///<param name="repository">Repository name.</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_snapshot/{repository}/_verify <para>https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</para></summary>
+        /// <param name="repository">Repository name.</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("snapshot.verify_repository", "repository")]
         public Task<TResponse> VerifyRepositoryAsync<TResponse>(
             string repository,

--- a/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Tasks.cs
+++ b/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.Tasks.cs
@@ -58,25 +58,25 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net.Specification.TasksApi
 {
-    ///<summary>
+    /// <summary>
     /// Tasks APIs.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchLowLevelClient.Tasks"/> property
     /// on <see cref="IOpenSearchLowLevelClient"/>.
-    ///</para>
-    ///</summary>
+    /// </para>
+    /// </summary>
     public partial class LowLevelTasksNamespace : NamespacedClientProxy
     {
         internal LowLevelTasksNamespace(OpenSearchLowLevelClient client)
             : base(client) { }
 
-        ///<summary>POST on /_tasks/_cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_tasks/_cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Cancel<TResponse>(CancelTasksRequestParameters requestParameters = null)
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(POST, "_tasks/_cancel", null, RequestParams(requestParameters));
 
-        ///<summary>POST on /_tasks/_cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_tasks/_cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("tasks.cancel", "")]
         public Task<TResponse> CancelAsync<TResponse>(
             CancelTasksRequestParameters requestParameters = null,
@@ -91,9 +91,9 @@ namespace OpenSearch.Net.Specification.TasksApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_tasks/{task_id}/_cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
-        ///<param name="taskId">Cancel the task with specified task id (node_id:task_number).</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_tasks/{task_id}/_cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
+        /// <param name="taskId">Cancel the task with specified task id (node_id:task_number).</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse Cancel<TResponse>(
             string taskId,
             CancelTasksRequestParameters requestParameters = null
@@ -106,9 +106,9 @@ namespace OpenSearch.Net.Specification.TasksApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>POST on /_tasks/{task_id}/_cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
-        ///<param name="taskId">Cancel the task with specified task id (node_id:task_number).</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>POST on /_tasks/{task_id}/_cancel <para>https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</para></summary>
+        /// <param name="taskId">Cancel the task with specified task id (node_id:task_number).</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("tasks.cancel", "task_id")]
         public Task<TResponse> CancelAsync<TResponse>(
             string taskId,
@@ -124,9 +124,9 @@ namespace OpenSearch.Net.Specification.TasksApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_tasks/{task_id} <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
-        ///<param name="taskId">Return the task with specified id (node_id:task_number).</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_tasks/{task_id} <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+        /// <param name="taskId">Return the task with specified id (node_id:task_number).</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse GetTask<TResponse>(
             string taskId,
             GetTaskRequestParameters requestParameters = null
@@ -139,9 +139,9 @@ namespace OpenSearch.Net.Specification.TasksApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_tasks/{task_id} <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
-        ///<param name="taskId">Return the task with specified id (node_id:task_number).</param>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_tasks/{task_id} <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+        /// <param name="taskId">Return the task with specified id (node_id:task_number).</param>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("tasks.get", "task_id")]
         public Task<TResponse> GetTaskAsync<TResponse>(
             string taskId,
@@ -157,14 +157,14 @@ namespace OpenSearch.Net.Specification.TasksApi
                 RequestParams(requestParameters)
             );
 
-        ///<summary>GET on /_tasks <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_tasks <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         public TResponse List<TResponse>(ListTasksRequestParameters requestParameters = null)
             where TResponse : class, IOpenSearchResponse, new() =>
             DoRequest<TResponse>(GET, "_tasks", null, RequestParams(requestParameters));
 
-        ///<summary>GET on /_tasks <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
-        ///<param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+        /// <summary>GET on /_tasks <para>https://opensearch.org/docs/latest/api-reference/tasks/</para></summary>
+        /// <param name="requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
         [MapsApi("tasks.list", "")]
         public Task<TResponse> ListAsync<TResponse>(
             ListTasksRequestParameters requestParameters = null,

--- a/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.cs
+++ b/src/OpenSearch.Net/_Generated/OpenSearchLowLevelClient.cs
@@ -62,9 +62,9 @@ using static OpenSearch.Net.HttpMethod;
 // ReSharper disable RedundantExtendsListEntry
 namespace OpenSearch.Net
 {
-    ///<summary>
-    ///OpenSearch low level client
-    ///</summary>
+    /// <summary>
+    /// OpenSearch low level client
+    /// </summary>
     public partial class OpenSearchLowLevelClient : IOpenSearchLowLevelClient
     {
         public LowLevelClusterNamespace Cluster { get; private set; }


### PR DESCRIPTION
### Description
Adds support for generating obsoletion attributes and remarks for added versions on API methods in the ApiGenerator. Also minorly tweaks whitespace in xmldocs.

Will become relevant when generating the CAT APIs for master/cluster_manager as one was deprecated and other only added in 2.0. Also relevant for generation of new APIs such as point-in-time.

### Issues Resolved
Part of #193 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
