### PR TITLE
Fix RemoteInfoApiTests

### DIFF
--- a/tests/Tests/Cluster/RemoteInfo/RemoteInfoApiTests.cs
+++ b/tests/Tests/Cluster/RemoteInfo/RemoteInfoApiTests.cs
@@ -51,14 +51,12 @@ namespace Tests.Cluster.RemoteInfo
 
 		protected override void IntegrationSetup(IOpenSearchClient client, CallUniqueValues values)
 		{
-			var enableRemoteClusters = client.Cluster.PutSettings(new ClusterPutSettingsRequest
-			{
-				Transient = new RemoteClusterConfiguration()
-				{
-					{ "cluster_one", "127.0.0.1:9300", "127.0.0.1:9301" },
-					{ "cluster_two", "127.0.0.1:9300" }
-				}
-			});
+			var enableRemoteClusters = client.Cluster.PutSettings(s => s
+				.Transient(t => t
+					.Add("cluster.remote.cluster_one.seeds", new[] { "127.0.0.1:9300", "127.0.0.1:9301" })
+					.Add("cluster.remote.cluster_one.skip_unavailable", true)
+					.Add("cluster.remote.cluster_two.seeds", new[] { "127.0.0.1:9300" })
+					.Add("cluster.remote.cluster_two.skip_unavailable", true)));
 			enableRemoteClusters.ShouldBeValid();
 
 			var remoteSearch = client.Search<Project>(s => s.Index(Index<Project>("cluster_one").And<Project>("cluster_two")));


### PR DESCRIPTION
### Description
Fixes the RemoteInfoApiTests that were failing due to changes to security plugin in 2.9+.

### Issues Resolved
Fixes #311 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
