### PR TITLE
[Backport 1.x] Bump Microsoft.TestPlatform.ObjectModel from 17.7.2 to 17.8.0 (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `Octokit` from 7.1.0 to 9.0.0
 - Bumps `FSharp.Core` from 7.0.400 to 7.0.401
 - Bumps `xunit` from 2.4.2 to 2.6.1
+- Bumps `Microsoft.TestPlatform.ObjectModel` from 17.7.2 to 17.8.0
 
 ## [1.5.0]
 ### Fixed

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.8.0" />
     
     <PackageReference Include="xunit" Version="2.6.1" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Xunit\OpenSearch.OpenSearch.Xunit.csproj" />


### PR DESCRIPTION
### Description
Backport 35a0fd8f3b9fd5b0f82473cde2c3e8e1b252e89b from #431 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
