### PR TITLE
[Backport 1.x] Bump xunit from 2.6.1 to 2.6.2 (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `xunit.runner.visualstudio` from 2.5.0 to 2.5.3
 - Bumps `Octokit` from 7.1.0 to 9.0.0
 - Bumps `FSharp.Core` from 7.0.400 to 7.0.401
-- Bumps `xunit` from 2.4.2 to 2.6.1
+- Bumps `xunit` from 2.4.2 to 2.6.2
 - Bumps `Microsoft.TestPlatform.ObjectModel` from 17.7.2 to 17.8.0
 
 ## [1.5.0]

--- a/abstractions/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
+++ b/abstractions/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
@@ -8,7 +8,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenSearch.OpenSearch.Ephemeral\OpenSearch.OpenSearch.Ephemeral.csproj" />

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Domain\Tests.Domain.csproj" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.8.0" />
     
-    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit" Version="2.6.2" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Xunit\OpenSearch.OpenSearch.Xunit.csproj" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
     


### PR DESCRIPTION
### Description
Backport e8919eff60f5235a68af74733603f7bee246a2e5 from #441 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
