### PR TITLE
[Backport 1.x] Re-add and deprecate replaced operations to avoid breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for the component template APIs ([#411](https://github.com/opensearch-project/opensearch-net/pull/411))
 - Added support for the composable index template APIs ([#437](https://github.com/opensearch-project/opensearch-net/pull/437))
 
+### Deprecated
+- Deprecated the low-level `IndexTemplateV2` APIs in favour of the new `ComposableIndexTemplate` APIs ([#454](https://github.com/opensearch-project/opensearch-net/pull/454))
+
 ### Dependencies
 - Bumps `FSharp.Data` from 6.2.0 to 6.3.0
 - Bumps `BenchMarkDotNet` from 0.13.7 to 0.13.10

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs
@@ -56,6 +56,30 @@ namespace OpenSearch.Net.Specification.ClusterApi
 		}
 	}
 
+	///<summary>Request options for DeleteComponentTemplate <para>https://opensearch.org/docs/latest/opensearch/index-templates/</para></summary>
+	public partial class DeleteComponentTemplateRequestParameters : RequestParameters<DeleteComponentTemplateRequestParameters>
+	{
+#pragma warning disable 618
+		///<summary>Specify timeout for connection to master node</summary>
+		///<seealso cref="MasterTimeout"/>
+		[Obsolete($"Replaced by {nameof(MasterTimeout)}")]
+		public TimeSpan MasterTimeSpanout
+		{
+			get => Q<TimeSpan>("master_timeout");
+			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<seealso cref="ClusterManagerTimeout"/>
+		[Obsolete($"Replaced by {nameof(ClusterManagerTimeout)}")]
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
+		}
+#pragma warning restore 618
+	}
+
 	///<summary>Request options for DeleteVotingConfigExclusions <para></para></summary>
 	public class DeleteVotingConfigExclusionsRequestParameters : RequestParameters<DeleteVotingConfigExclusionsRequestParameters>
 	{
@@ -67,6 +91,61 @@ namespace OpenSearch.Net.Specification.ClusterApi
 			get => Q<bool? >("wait_for_removal");
 			set => Q("wait_for_removal", value);
 		}
+	}
+
+	///<summary>Request options for ExistsComponentTemplate <para>https://opensearch.org/docs/latest/opensearch/index-templates/</para></summary>
+	///<seealso cref="ComponentTemplateExistsRequestParameters"/>
+	[Obsolete($"Replaced by {nameof(ComponentTemplateExistsRequestParameters)}")]
+	public class ExistsComponentTemplateRequestParameters : RequestParameters<ExistsComponentTemplateRequestParameters>
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
+		public override bool SupportsBody => false;
+		///<summary>Return local information, do not retrieve the state from cluster_manager node (default: false)</summary>
+		public bool? Local
+		{
+			get => Q<bool? >("local");
+			set => Q("local", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
+		{
+			get => Q<TimeSpan>("master_timeout");
+			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
+		}
+	}
+
+	///<summary>Request options for GetComponentTemplate <para>https://opensearch.org/docs/latest/opensearch/index-templates/</para></summary>
+	public partial class GetComponentTemplateRequestParameters : RequestParameters<GetComponentTemplateRequestParameters>
+	{
+#pragma warning disable 618
+		///<summary>Specify timeout for connection to master node</summary>
+		///<seealso cref="MasterTimeout"/>
+		[Obsolete($"Replaced by {nameof(MasterTimeout)}")]
+		public TimeSpan MasterTimeSpanout
+		{
+			get => Q<TimeSpan>("master_timeout");
+			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<seealso cref="ClusterManagerTimeout"/>
+		[Obsolete($"Replaced by {nameof(ClusterManagerTimeout)}")]
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
+		}
+#pragma warning restore 618
 	}
 
 	///<summary>Request options for GetSettings <para>https://opensearch.org/docs/latest/opensearch/rest-api/cluster-settings/</para></summary>
@@ -264,6 +343,30 @@ namespace OpenSearch.Net.Specification.ClusterApi
 			get => Q<TimeSpan>("timeout");
 			set => Q("timeout", value);
 		}
+	}
+
+	///<summary>Request options for PutComponentTemplate <para>https://opensearch.org/docs/latest/opensearch/index-templates/</para></summary>
+	public partial class PutComponentTemplateRequestParameters : RequestParameters<PutComponentTemplateRequestParameters>
+	{
+#pragma warning disable 618
+		///<summary>Specify timeout for connection to master node</summary>
+		///<seealso cref="MasterTimeout"/>
+		[Obsolete($"Replaced by {nameof(MasterTimeout)}")]
+		public TimeSpan MasterTimeSpanout
+		{
+			get => Q<TimeSpan>("master_timeout");
+			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<seealso cref="ClusterManagerTimeout"/>
+		[Obsolete($"Replaced by {nameof(ClusterManagerTimeout)}")]
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
+		}
+#pragma warning restore 618
 	}
 
 	///<summary>Request options for PutSettings <para>https://opensearch.org/docs/latest/opensearch/rest-api/cluster-settings/</para></summary>

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
@@ -389,6 +389,37 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		}
 	}
 
+	///<summary>Request options for DeleteTemplateV2 <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
+	///<seealso cref="DeleteComposableIndexTemplateRequestParameters"/>
+	[Obsolete($"Replaced by {nameof(DeleteComposableIndexTemplateRequestParameters)}")]
+	public class DeleteIndexTemplateV2RequestParameters : RequestParameters<DeleteIndexTemplateV2RequestParameters>
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
+		public override bool SupportsBody => false;
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
+		{
+			get => Q<TimeSpan>("master_timeout");
+			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout</summary>
+		public TimeSpan Timeout
+		{
+			get => Q<TimeSpan>("timeout");
+			set => Q("timeout", value);
+		}
+	}
+
 	///<summary>Request options for DeleteTemplate <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
 	public class DeleteIndexTemplateRequestParameters : RequestParameters<DeleteIndexTemplateRequestParameters>
 	{
@@ -504,6 +535,8 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	}
 
 	///<summary>Request options for ExistsTemplate <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
+	///<seealso cref="ComposableIndexTemplateExistsRequestParameters"/>
+	[Obsolete($"Replaced by {nameof(ComposableIndexTemplateExistsRequestParameters)}")]
 	public class ExistsIndexTemplateRequestParameters : RequestParameters<ExistsIndexTemplateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
@@ -906,6 +939,8 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	}
 
 	///<summary>Request options for GetTemplateV2 <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
+	///<seealso cref="GetComposableIndexTemplateRequestParameters"/>
+	[Obsolete($"Replaced by {nameof(GetComposableIndexTemplateRequestParameters)}")]
 	public class GetIndexTemplateV2RequestParameters : RequestParameters<GetIndexTemplateV2RequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -1192,6 +1227,44 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		{
 			get => Q<TimeSpan>("timeout");
 			set => Q("timeout", value);
+		}
+	}
+
+	///<summary>Request options for PutTemplateV2 <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
+	///<seealso cref="PutComposableIndexTemplateRequestParameters"/>
+	[Obsolete($"Replaced by {nameof(PutComposableIndexTemplateRequestParameters)}")]
+	public class PutIndexTemplateV2RequestParameters : RequestParameters<PutIndexTemplateV2RequestParameters>
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
+		public override bool SupportsBody => true;
+		///<summary>User defined reason for creating/updating the index template</summary>
+		public string Cause
+		{
+			get => Q<string>("cause");
+			set => Q("cause", value);
+		}
+
+		///<summary>Whether the index template should only be added if new or can also replace an existing one</summary>
+		public bool? Create
+		{
+			get => Q<bool? >("create");
+			set => Q("create", value);
+		}
+
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
+		{
+			get => Q<TimeSpan>("master_timeout");
+			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Cluster.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Cluster.cs
@@ -71,6 +71,21 @@ namespace OpenSearch.Net.Specification.ClusterApi
 		[MapsApi("cluster.delete_voting_config_exclusions", "")]
 		public Task<TResponse> DeleteVotingConfigExclusionsAsync<TResponse>(DeleteVotingConfigExclusionsRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(DELETE, "_cluster/voting_config_exclusions", ctx, null, RequestParams(requestParameters));
+		///<summary>HEAD on /_component_template/{name} <para>https://opensearch.org/docs/latest/opensearch/index-templates/</para></summary>
+		///<param name = "name">The name of the template</param>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="ComponentTemplateExists{TResponse}"/>
+		[Obsolete($"Replaced by {nameof(ComponentTemplateExists)}")]
+		public TResponse ExistsComponentTemplate<TResponse>(string name, ExistsComponentTemplateRequestParameters requestParameters = null)
+			where TResponse : class, IOpenSearchResponse, new() => DoRequest<TResponse>(HEAD, Url($"_component_template/{name:name}"), null, RequestParams(requestParameters));
+		///<summary>HEAD on /_component_template/{name} <para>https://opensearch.org/docs/latest/opensearch/index-templates/</para></summary>
+		///<param name = "name">The name of the template</param>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="ComponentTemplateExistsAsync{TResponse}"/>
+		[MapsApi("cluster.exists_component_template", "name")]
+		[Obsolete($"Replaced by {nameof(ComponentTemplateExistsAsync)}")]
+		public Task<TResponse> ExistsComponentTemplateAsync<TResponse>(string name, ExistsComponentTemplateRequestParameters requestParameters = null, CancellationToken ctx = default)
+			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(HEAD, Url($"_component_template/{name:name}"), ctx, null, RequestParams(requestParameters));
 		///<summary>GET on /_cluster/settings <para>https://opensearch.org/docs/latest/opensearch/rest-api/cluster-settings/</para></summary>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		public TResponse GetSettings<TResponse>(ClusterGetSettingsRequestParameters requestParameters = null)

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Indices.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Indices.cs
@@ -171,6 +171,21 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		[MapsApi("indices.delete_alias", "index, name")]
 		public Task<TResponse> DeleteAliasAsync<TResponse>(string index, string name, DeleteAliasRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(DELETE, Url($"{index:index}/_alias/{name:name}"), ctx, null, RequestParams(requestParameters));
+		///<summary>DELETE on /_index_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
+		///<param name = "name">The name of the template</param>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="DeleteComposableTemplateForAll{TResponse}"/>
+		[Obsolete($"Replaced by {nameof(DeleteComposableTemplateForAll)}")]
+		public TResponse DeleteTemplateV2ForAll<TResponse>(string name, DeleteIndexTemplateV2RequestParameters requestParameters = null)
+			where TResponse : class, IOpenSearchResponse, new() => DoRequest<TResponse>(DELETE, Url($"_index_template/{name:name}"), null, RequestParams(requestParameters));
+		///<summary>DELETE on /_index_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
+		///<param name = "name">The name of the template</param>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="DeleteComposableTemplateForAllAsync{TResponse}"/>
+		[MapsApi("indices.delete_index_template", "name")]
+		[Obsolete($"Replaced by {nameof(DeleteComposableTemplateForAllAsync)}")]
+		public Task<TResponse> DeleteTemplateV2ForAllAsync<TResponse>(string name, DeleteIndexTemplateV2RequestParameters requestParameters = null, CancellationToken ctx = default)
+			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(DELETE, Url($"_index_template/{name:name}"), ctx, null, RequestParams(requestParameters));
 		///<summary>DELETE on /_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
 		///<param name = "name">The name of the template</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
@@ -220,12 +235,16 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		///<summary>HEAD on /_index_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
 		///<param name = "name">The name of the template</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="ComposableTemplateExistsForAll{TResponse}"/>
+		[Obsolete($"Replaced by {nameof(ComposableTemplateExistsForAll)}")]
 		public TResponse ExistsTemplateForAll<TResponse>(string name, ExistsIndexTemplateRequestParameters requestParameters = null)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequest<TResponse>(HEAD, Url($"_index_template/{name:name}"), null, RequestParams(requestParameters));
 		///<summary>HEAD on /_index_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
 		///<param name = "name">The name of the template</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="ComposableTemplateExistsForAllAsync{TResponse}"/>
 		[MapsApi("indices.exists_index_template", "name")]
+		[Obsolete($"Replaced by {nameof(ComposableTemplateExistsForAllAsync)}")]
 		public Task<TResponse> ExistsTemplateForAllAsync<TResponse>(string name, ExistsIndexTemplateRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(HEAD, Url($"_index_template/{name:name}"), ctx, null, RequestParams(requestParameters));
 		///<summary>HEAD on /_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
@@ -375,22 +394,30 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(GET, Url($"{index:index}/_mapping/field/{fields:fields}"), ctx, null, RequestParams(requestParameters));
 		///<summary>GET on /_index_template <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="GetComposableTemplateForAll{TResponse}(OpenSearch.Net.Specification.IndicesApi.GetComposableIndexTemplateRequestParameters)"/>
+		[Obsolete($"Replaced by {nameof(GetComposableTemplateForAll)}")]
 		public TResponse GetTemplateV2ForAll<TResponse>(GetIndexTemplateV2RequestParameters requestParameters = null)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequest<TResponse>(GET, "_index_template", null, RequestParams(requestParameters));
 		///<summary>GET on /_index_template <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="GetComposableTemplateForAllAsync{TResponse}(OpenSearch.Net.Specification.IndicesApi.GetComposableIndexTemplateRequestParameters,System.Threading.CancellationToken)" />
 		[MapsApi("indices.get_index_template", "")]
+		[Obsolete($"Replaced by {nameof(GetComposableTemplateForAllAsync)}")]
 		public Task<TResponse> GetTemplateV2ForAllAsync<TResponse>(GetIndexTemplateV2RequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(GET, "_index_template", ctx, null, RequestParams(requestParameters));
 		///<summary>GET on /_index_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
 		///<param name = "name">The comma separated names of the index templates</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="GetComposableTemplateForAll{TResponse}(string,OpenSearch.Net.Specification.IndicesApi.GetComposableIndexTemplateRequestParameters)"/>
+		[Obsolete($"Replaced by {nameof(GetComposableTemplateForAll)}")]
 		public TResponse GetTemplateV2ForAll<TResponse>(string name, GetIndexTemplateV2RequestParameters requestParameters = null)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequest<TResponse>(GET, Url($"_index_template/{name:name}"), null, RequestParams(requestParameters));
 		///<summary>GET on /_index_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
 		///<param name = "name">The comma separated names of the index templates</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="GetComposableTemplateForAllAsync{TResponse}(string,OpenSearch.Net.Specification.IndicesApi.GetComposableIndexTemplateRequestParameters,System.Threading.CancellationToken)"/>
 		[MapsApi("indices.get_index_template", "name")]
+		[Obsolete($"Replaced by {nameof(GetComposableTemplateForAllAsync)}")]
 		public Task<TResponse> GetTemplateV2ForAllAsync<TResponse>(string name, GetIndexTemplateV2RequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(GET, Url($"_index_template/{name:name}"), ctx, null, RequestParams(requestParameters));
 		///<summary>GET on /_mapping <para>https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</para></summary>
@@ -503,6 +530,23 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		[MapsApi("indices.put_alias", "index, name, body")]
 		public Task<TResponse> PutAliasAsync<TResponse>(string index, string name, PostData body, PutAliasRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(PUT, Url($"{index:index}/_alias/{name:name}"), ctx, body, RequestParams(requestParameters));
+		///<summary>PUT on /_index_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
+		///<param name = "name">The name of the template</param>
+		///<param name = "body">The template definition</param>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="PutComposableTemplateForAll{TResponse}"/>
+		[Obsolete($"Replaced by {nameof(PutComposableTemplateForAll)}")]
+		public TResponse PutTemplateV2ForAll<TResponse>(string name, PostData body, PutIndexTemplateV2RequestParameters requestParameters = null)
+			where TResponse : class, IOpenSearchResponse, new() => DoRequest<TResponse>(PUT, Url($"_index_template/{name:name}"), body, RequestParams(requestParameters));
+		///<summary>PUT on /_index_template/{name} <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
+		///<param name = "name">The name of the template</param>
+		///<param name = "body">The template definition</param>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		///<seealso cref="PutComposableTemplateForAllAsync{TResponse}"/>
+		[Obsolete($"Replaced by {nameof(PutComposableTemplateForAllAsync)}")]
+		[MapsApi("indices.put_index_template", "name, body")]
+		public Task<TResponse> PutTemplateV2ForAllAsync<TResponse>(string name, PostData body, PutIndexTemplateV2RequestParameters requestParameters = null, CancellationToken ctx = default)
+			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(PUT, Url($"_index_template/{name:name}"), ctx, body, RequestParams(requestParameters));
 		///<summary>PUT on /{index}/_mapping <para>https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</para></summary>
 		///<param name = "index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name = "body">The mapping definition</param>


### PR DESCRIPTION
### Description
Re-adds and deprecates some of the low-level operations that were removed in #411 & #437  to avoid breaking changes in 1.x. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
