### PR TITLE
Automate the version bump workflow

### DIFF
--- a/.github/bump-version.sh
+++ b/.github/bump-version.sh
@@ -28,5 +28,4 @@ GLOBAL_JSON=$(jq \
 	global.json)
 echo "$GLOBAL_JSON" > global.json
 
-sed -i'' -E "s/^([[:space:]]+VERSION: )([0-9]+\.){2}[0-9]+$/\1$VERSION/" .github/workflows/release.yml
 sed -i'' -E "s/<(Current(Assembly(File)?)?Version)>([0-9]+\.){2}[0-9]+<\/\1>/<\1>$VERSION<\/\1>/" Directory.Build.props

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,5 +1,10 @@
+name: Bump Version
+
 on:
-  workflow_dispatch: 
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
     inputs:
       branch:
         description: 'Branch to bump version on'
@@ -9,37 +14,177 @@ on:
         required: true
 
 jobs:
-  bump-version:
-    name: Bump Version
+  bump-version-manual:
+    name: Bump Version (Manual)
     runs-on: ubuntu-latest
+    if: github.repository == 'opensearch-project/opensearch-net' && github.event_name == 'workflow_dispatch'
     steps:
       - name: GitHub App Token
         id: github_app_token
         uses: tibdex/github-app-token@v1.5.0
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{secrets.APP_ID}}
+          private_key: ${{secrets.APP_PRIVATE_KEY}}
           installation_id: 22958780
-          
-      - uses: actions/checkout@v3
+
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
-          token: ${{ steps.github_app_token.outputs.token }}
-      
+          ref: ${{github.event.inputs.branch}}
+          token: ${{steps.github_app_token.outputs.token}}
+
       - name: Bump Version
-        run: bash .github/bump-version.sh "${{ github.event.inputs.version }}"
-        
+        run: bash .github/bump-version.sh "${{github.event.inputs.version}}"
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ steps.github_app_token.outputs.token }}
-          base: ${{ github.event.inputs.branch }}
-          branch: "feat/${{ github.event.inputs.branch }}/bump-version"
-          commit-message: Bump version to ${{ github.event.inputs.version }}
+          token: ${{steps.github_app_token.outputs.token}}
+          base: ${{github.event.inputs.branch}}
+          branch: "feat/${{github.event.inputs.branch}}/bump-version"
+          commit-message: Bump version to ${{github.event.inputs.version}}
           signoff: true
           delete-branch: true
-          title: 'Bump version on ${{ github.event.inputs.branch }} to ${{ github.event.inputs.version }}.'
+          title: '[AUTO] Bump version on `${{github.event.inputs.branch}}` to `${{github.event.inputs.version}}`'
           labels: skip-changelog
           body: |
-            Bumping version on `${{ github.event.inputs.branch }}` to `${{ github.event.inputs.version }}`.
+            Bumping version on `${{github.event.inputs.branch}}` to `${{github.event.inputs.version}}`.
 
+  bump-version-auto:
+    name: Bump Version (Auto)
+    runs-on: ubuntu-latest
+    if: github.repository == 'opensearch-project/opensearch-net' && github.event_name == 'push'
+    steps:
+      - name: GitHub App Token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{secrets.APP_ID}}
+          private_key: ${{secrets.APP_PRIVATE_KEY}}
+          installation_id: 22958780
+
+      - name: Checkout ${{github.ref}}
+        uses: actions/checkout@v4
+        with:
+          token: ${{steps.github_app_token.outputs.token}}
+
+      - name: Fetch Version Information
+        run: |
+          echo "GITHUB_REF=${GITHUB_REF}"
+          VERSION=$(echo "${GITHUB_REF#refs/*/v}")
+          VERSION_COMPONENTS=(${VERSION//./ })
+          MAJOR="${VERSION_COMPONENTS[0]}"
+          MINOR="${VERSION_COMPONENTS[1]}"
+          PATCH="${VERSION_COMPONENTS[2]}"
+          BASE="${MAJOR}.${MINOR}"
+          BASE_X="${MAJOR}.x"
+          
+          IS_MAJOR_BUMP=false
+          IS_MINOR_BUMP=false
+          
+          if [ "${PATCH}" = "0" ]; then
+            IS_MINOR_BUMP=true
+            if [ "${MINOR}" = "0" ]; then
+              IS_MAJOR_BUMP=true
+            fi
+          fi
+          
+          NEXT_MAJOR="$((MAJOR + 1)).0.0"
+          NEXT_MINOR="${MAJOR}.$((MINOR + 1)).0"
+          NEXT_PATCH="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          
+          {
+            echo "VERSION=${VERSION}"
+            echo "MAJOR=${MAJOR}"
+            echo "MINOR=${MINOR}"
+            echo "PATCH=${PATCH}"
+            echo "BASE=${BASE}"
+            echo "BASE_X=${BASE_X}"
+            echo "IS_MAJOR_BUMP=${IS_MAJOR_BUMP}"
+            echo "IS_MINOR_BUMP=${IS_MINOR_BUMP}"
+            echo "NEXT_MAJOR=${NEXT_MAJOR}"
+            echo "NEXT_MINOR=${NEXT_MINOR}"
+            echo "NEXT_PATCH=${NEXT_PATCH}"
+          } | tee -a "${GITHUB_ENV}"
+
+      - name: Create ${{env.BASE_X}} branch
+        if: env.IS_MAJOR_BUMP == 'true'
+        run: git branch ${BASE_X} && git push origin ${BASE_X}
+
+      - name: Create ${{env.BASE}} branch
+        if: env.IS_MINOR_BUMP == 'true'
+        run: git branch ${BASE} && git push origin ${BASE}
+
+      - name: Checkout ${{env.BASE}} branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{env.BASE}}
+          token: ${{steps.github_app_token.outputs.token}}
+
+      - name: Bump Patch Version
+        run: bash .github/bump-version.sh "${{env.NEXT_PATCH}}"
+
+      - name: Create Patch Version Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{steps.github_app_token.outputs.token}}
+          base: ${{env.BASE}}
+          branch: 'feat/${{env.BASE}}/bump-version'
+          commit-message: Bump version to ${{env.NEXT_PATCH}}
+          signoff: true
+          delete-branch: true
+          title: '[AUTO] Bump version on `${{env.BASE}}` to `${{env.NEXT_PATCH}}`'
+          labels: skip-changelog
+          body: |
+            Bumping version on `${{env.BASE}}` to `${{env.NEXT_PATCH}}`.
+
+      - name: Checkout ${{env.BASE_X}} branch
+        if: env.IS_MINOR_BUMP == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{env.BASE_X}}
+          token: ${{steps.github_app_token.outputs.token}}
+
+      - name: Bump Minor Version
+        if: env.IS_MINOR_BUMP == 'true'
+        run: bash .github/bump-version.sh "${{env.NEXT_MINOR}}"
+
+      - name: Create Minor Version Pull Request
+        if: env.IS_MINOR_BUMP == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{steps.github_app_token.outputs.token}}
+          base: ${{env.BASE_X}}
+          branch: 'feat/${{env.BASE_X}}/bump-version'
+          commit-message: Bump version to ${{env.NEXT_MINOR}}
+          signoff: true
+          delete-branch: true
+          title: '[AUTO] Bump version on `${{env.BASE_X}}` to `${{env.NEXT_MINOR}}`'
+          labels: skip-changelog
+          body: |
+            Bumping version on `${{env.BASE_X}}` to `${{env.NEXT_MINOR}}`.
+
+      - name: Checkout main branch
+        if: env.IS_MAJOR_BUMP == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{steps.github_app_token.outputs.token}}
+
+      - name: Bump Major Version
+        if: env.IS_MAJOR_BUMP == 'true'
+        run: bash .github/bump-version.sh "${{env.NEXT_MAJOR}}"
+
+      - name: Create Major Version Pull Request
+        if: env.IS_MAJOR_BUMP == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{steps.github_app_token.outputs.token}}
+          base: main
+          branch: 'feat/main/bump-version'
+          commit-message: Bump version to ${{env.NEXT_MAJOR}}
+          signoff: true
+          delete-branch: true
+          title: '[AUTO] Bump version on `main` to `${{env.NEXT_MAJOR}}`'
+          labels: skip-changelog
+          body: |
+            Bumping version on `main` to `${{env.NEXT_MAJOR}}`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Create Release Candidate
 
 on: [pull_request, push]
-env:
-    VERSION: 2.0.0
 jobs:
   create-release-artifacts:
     name: Create Release Artifacts
@@ -21,6 +19,8 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
+    - name: Determine Version
+      run: echo "VERSION=$(jq -r '.version' global.json)" | tee -a "$GITHUB_ENV"
     - name: Generate Release
       run: |
         ./build.sh release $VERSION


### PR DESCRIPTION
### Description
Automates the version bump workflow so that it will create PRs into the relevant version branches when a new version tag is pushed. As well as creating the `{major}.x` and/or `{major}.{minor}` branches when a `v{major}.0.0` or `v{major}.{minor}.0` tag is pushed.

Additionally removes one of the hardcoded versions out of a workflow and has it read from elsewhere, so that version bump workflow doesn't need "modify workflow" permission to bump the version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
