### PR TITLE
[Backport 1.x] Bump BenchMarkDotNet, xunit, xunit.runner.visualstudio & CSharpier.Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `BenchMarkDotNet` from 0.13.10 to 0.13.11
 - Bumps `xunit.runner.visualstudio` from 2.5.4 to 2.5.5
 - Bumps `CSharpier.Core` from 0.26.3 to 0.26.7
+- Bumps `xunit` from 2.6.2 to 2.6.3
 
 ## [1.6.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `BenchMarkDotNet` from 0.13.10 to 0.13.11
 - Bumps `xunit.runner.visualstudio` from 2.5.4 to 2.5.5
+- Bumps `CSharpier.Core` from 0.26.3 to 0.26.7
 
 ## [1.6.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Dependencies
+- Bumps `BenchMarkDotNet` from 0.13.10 to 0.13.11
 
 ## [1.6.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Dependencies
 - Bumps `BenchMarkDotNet` from 0.13.10 to 0.13.11
+- Bumps `xunit.runner.visualstudio` from 2.5.4 to 2.5.5
 
 ## [1.6.0]
 ### Added

--- a/abstractions/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
+++ b/abstractions/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
@@ -8,7 +8,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit" Version="2.6.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenSearch.OpenSearch.Ephemeral\OpenSearch.OpenSearch.Ephemeral.csproj" />

--- a/abstractions/tests/OpenSearch.OpenSearch.EphemeralTests/OpenSearch.OpenSearch.EphemeralTests.csproj
+++ b/abstractions/tests/OpenSearch.OpenSearch.EphemeralTests/OpenSearch.OpenSearch.EphemeralTests.csproj
@@ -9,7 +9,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
   
   <ItemGroup>

--- a/abstractions/tests/OpenSearch.Stack.ArtifactsApiTests/OpenSearch.Stack.ArtifactsApiTests.csproj
+++ b/abstractions/tests/OpenSearch.Stack.ArtifactsApiTests/OpenSearch.Stack.ArtifactsApiTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -9,7 +9,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CSharpier.Core" Version="0.26.3" />
+    <PackageReference Include="CSharpier.Core" Version="0.26.7" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSwag.Core.Yaml" Version="13.20.0" />

--- a/tests/Tests.Auth.AwsSigV4/Tests.Auth.AwsSigV4.csproj
+++ b/tests/Tests.Auth.AwsSigV4/Tests.Auth.AwsSigV4.csproj
@@ -13,6 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Domain\Tests.Domain.csproj" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.8.0" />
     
-    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit" Version="2.6.3" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Xunit\OpenSearch.OpenSearch.Xunit.csproj" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
     

--- a/tests/Tests.Reproduce/Tests.Reproduce.csproj
+++ b/tests/Tests.Reproduce/Tests.Reproduce.csproj
@@ -6,6 +6,6 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -12,6 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <PackageReference Include="BenchMarkDotNet" Version="0.13.10" />
+    <PackageReference Include="BenchMarkDotNet" Version="0.13.11" />
   </ItemGroup>
 </Project>

--- a/tests/Tests/Tests.csproj
+++ b/tests/Tests/Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="FSharp.Core" Version="8.0.100" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description
Backports recent dependabot PRs to 1.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
