### PR TITLE
Add support for `PATCH` in `HttpConnection.ConvertHttpMethod`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed the `Features` API which is not supported by OpenSearch from the low-level client ([#331](https://github.com/opensearch-project/opensearch-net/pull/331))
 - Removed the deprecated low-level `IndexTemplateV2` APIs in favour of the `ComposableIndexTemplate` APIs ([#437](https://github.com/opensearch-project/opensearch-net/pull/437))
 
+### Fixed
+- Fix `HttpConnection.ConvertHttpMethod` to support `Patch` method ([#489](https://github.com/opensearch-project/opensearch-net/pull/489))
+
 ### Dependencies
 - Bumps `Microsoft.CodeAnalysis.CSharp` from 4.2.0 to 4.6.0
 - Bumps `NSwag.Core.Yaml` from 13.19.0 to 13.20.0

--- a/src/OpenSearch.Net/Connection/HttpConnection.cs
+++ b/src/OpenSearch.Net/Connection/HttpConnection.cs
@@ -27,7 +27,6 @@
 */
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -69,6 +68,8 @@ namespace OpenSearch.Net
 			$"Your target platform does not support {nameof(ConnectionConfiguration.ConnectionLimit)}"
 			+ $" please set {nameof(ConnectionConfiguration.ConnectionLimit)} to -1 on your connection configuration/settings."
 			+ $" this will cause the {nameof(HttpClientHandler.MaxConnectionsPerServer)} not to be set on {nameof(HttpClientHandler)}";
+
+		private static readonly System.Net.Http.HttpMethod Patch = new System.Net.Http.HttpMethod("PATCH");
 
 		private RequestDataHttpClientFactory HttpClientFactory { get; }
 
@@ -430,19 +431,17 @@ namespace OpenSearch.Net
 			}
 		}
 
-		private static System.Net.Http.HttpMethod ConvertHttpMethod(HttpMethod httpMethod)
-		{
-			switch (httpMethod)
+		private static System.Net.Http.HttpMethod ConvertHttpMethod(HttpMethod httpMethod) =>
+			httpMethod switch
 			{
-				case HttpMethod.GET: return System.Net.Http.HttpMethod.Get;
-				case HttpMethod.POST: return System.Net.Http.HttpMethod.Post;
-				case HttpMethod.PUT: return System.Net.Http.HttpMethod.Put;
-				case HttpMethod.DELETE: return System.Net.Http.HttpMethod.Delete;
-				case HttpMethod.HEAD: return System.Net.Http.HttpMethod.Head;
-				default:
-					throw new ArgumentException("Invalid value for HttpMethod", nameof(httpMethod));
-			}
-		}
+				HttpMethod.GET => System.Net.Http.HttpMethod.Get,
+				HttpMethod.POST => System.Net.Http.HttpMethod.Post,
+				HttpMethod.PUT => System.Net.Http.HttpMethod.Put,
+				HttpMethod.DELETE => System.Net.Http.HttpMethod.Delete,
+				HttpMethod.HEAD => System.Net.Http.HttpMethod.Head,
+				HttpMethod.PATCH => Patch,
+				_ => throw new ArgumentException("Invalid value for HttpMethod", nameof(httpMethod))
+			};
 
 		internal static int GetClientKey(RequestData requestData)
 		{

--- a/tests/Tests.Auth.AwsSigV4/AwsSigV4HttpConnectionTests.cs
+++ b/tests/Tests.Auth.AwsSigV4/AwsSigV4HttpConnectionTests.cs
@@ -16,6 +16,7 @@ using FluentAssertions;
 using OpenSearch.Client;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using Tests.Auth.AwsSigV4.Utils;
+using Tests.Core.Connection.Http;
 using Xunit;
 
 namespace Tests.Auth.AwsSigV4;

--- a/tests/Tests.Auth.AwsSigV4/Utils/TestableAwsSigV4HttpConnection.cs
+++ b/tests/Tests.Auth.AwsSigV4/Utils/TestableAwsSigV4HttpConnection.cs
@@ -10,6 +10,7 @@ using Amazon;
 using Amazon.Runtime;
 using OpenSearch.Net;
 using OpenSearch.Net.Auth.AwsSigV4;
+using Tests.Core.Connection.Http;
 
 namespace Tests.Auth.AwsSigV4.Utils;
 

--- a/tests/Tests.Core/Connection/Http/HttpRequestMessageAssertions.cs
+++ b/tests/Tests.Core/Connection/Http/HttpRequestMessageAssertions.cs
@@ -8,10 +8,13 @@
 using System.Net.Http;
 using FluentAssertions;
 
-namespace Tests.Auth.AwsSigV4.Utils;
+namespace Tests.Core.Connection.Http;
 
-internal static class HttpRequestMessageAssertions
+public static class HttpRequestMessageAssertions
 {
+	public static void ShouldHaveMethod(this HttpRequestMessage request, string method) =>
+		request.Method.Should().Be(new HttpMethod(method));
+
 	public static void ShouldHaveHeader(this HttpRequestMessage request, string name, string value) =>
 		request.Headers.GetValues(name).Should().BeEquivalentTo(value);
 }

--- a/tests/Tests.Core/Connection/Http/MockHttpMessageHandler.cs
+++ b/tests/Tests.Core/Connection/Http/MockHttpMessageHandler.cs
@@ -9,9 +9,9 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Tests.Auth.AwsSigV4.Utils;
+namespace Tests.Core.Connection.Http;
 
-internal class MockHttpMessageHandler : HttpMessageHandler
+public class MockHttpMessageHandler : HttpMessageHandler
 {
 	public delegate HttpResponseMessage Handler(HttpRequestMessage request);
 

--- a/tests/Tests/Connection/Http/HttpConnectionTests.cs
+++ b/tests/Tests/Connection/Http/HttpConnectionTests.cs
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+using System;
+using System.Net.Http;
+using FluentAssertions;
+using OpenSearch.Net;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
+using Xunit;
+using HttpMethod = OpenSearch.Net.HttpMethod;
+
+namespace Tests.Connection.Http;
+
+public class HttpConnectionTests
+{
+	public static TheoryData<HttpMethod> HttpMethods()
+	{
+		var data = new TheoryData<HttpMethod>();
+		foreach (var httpMethod in Enum.GetValues<HttpMethod>()) data.Add(httpMethod);
+		return data;
+	}
+
+	[TU]
+	[MemberData(nameof(HttpMethods))]
+	public void UsesCorrectHttpMethod(HttpMethod method)
+	{
+		var mockHttpConnection = new MockHttpConnection();
+		mockHttpConnection.Request<StringResponse>(new RequestData(method, "", null, null, null, null));
+		mockHttpConnection.LastRequest.Method.Should().Be(new System.Net.Http.HttpMethod(method.ToString()));
+	}
+
+	private class MockHttpConnection : HttpConnection
+	{
+		public HttpRequestMessage LastRequest { get; private set; }
+
+		protected override HttpRequestMessage CreateHttpRequestMessage(RequestData requestData)
+		{
+			LastRequest = base.CreateHttpRequestMessage(requestData);
+			return LastRequest;
+		}
+
+		public override TResponse Request<TResponse>(RequestData requestData)
+		{
+			CreateHttpRequestMessage(requestData);
+			return new TResponse();
+		}
+	}
+}

--- a/tests/Tests/Connection/Http/MockableHttpConnection.cs
+++ b/tests/Tests/Connection/Http/MockableHttpConnection.cs
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Net.Http;
+using OpenSearch.Net;
+using Tests.Core.Connection.Http;
+
+namespace Tests.Connection.Http;
+
+public class MockableHttpConnection : HttpConnection
+{
+	private readonly MockHttpMessageHandler _handler;
+
+	public MockableHttpConnection(MockHttpMessageHandler.Handler handler) =>
+		_handler = new MockHttpMessageHandler(handler);
+
+	protected override HttpMessageHandler CreateHttpClientHandler(RequestData requestData) => _handler;
+}


### PR DESCRIPTION
### Description
Add support for `PATCH` in `HttpConnection.ConvertHttpMethod`.

### Issues Resolved
Fixes #488 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).






