### PR TITLE
[Backport 1.x] Bump xunit.runner.visualstudio from 2.5.5 to 2.5.6 (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Dependencies
 - Bumps `BenchMarkDotNet` from 0.13.10 to 0.13.11
-- Bumps `xunit.runner.visualstudio` from 2.5.4 to 2.5.5
+- Bumps `xunit.runner.visualstudio` from 2.5.4 to 2.5.6
 - Bumps `CSharpier.Core` from 0.26.3 to 0.26.7
 - Bumps `xunit` from 2.6.2 to 2.6.3
 - Bumps `Argu` from 6.1.1 to 6.1.4

--- a/abstractions/tests/OpenSearch.OpenSearch.EphemeralTests/OpenSearch.OpenSearch.EphemeralTests.csproj
+++ b/abstractions/tests/OpenSearch.OpenSearch.EphemeralTests/OpenSearch.OpenSearch.EphemeralTests.csproj
@@ -9,7 +9,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
   
   <ItemGroup>

--- a/abstractions/tests/OpenSearch.Stack.ArtifactsApiTests/OpenSearch.Stack.ArtifactsApiTests.csproj
+++ b/abstractions/tests/OpenSearch.Stack.ArtifactsApiTests/OpenSearch.Stack.ArtifactsApiTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.Auth.AwsSigV4/Tests.Auth.AwsSigV4.csproj
+++ b/tests/Tests.Auth.AwsSigV4/Tests.Auth.AwsSigV4.csproj
@@ -13,6 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.Reproduce/Tests.Reproduce.csproj
+++ b/tests/Tests.Reproduce/Tests.Reproduce.csproj
@@ -6,6 +6,6 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 </Project>

--- a/tests/Tests/Tests.csproj
+++ b/tests/Tests/Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="FSharp.Core" Version="8.0.100" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description
Backports f97e43317768be97d159980f306bac96874d9cfc from #486 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
