### PR TITLE
[Backport 1.x] Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `xunit` from 2.6.2 to 2.6.3
 - Bumps `Argu` from 6.1.1 to 6.1.4
 - Bumps `JetBrains.Annotations` from 2023.2.0 to 2023.3.0
+- Bumps `Microsoft.NET.Test.Sdk` from 17.7.2 to 17.8.0
 
 ## [1.6.0]
 ### Added

--- a/abstractions/tests/OpenSearch.OpenSearch.EphemeralTests/OpenSearch.OpenSearch.EphemeralTests.csproj
+++ b/abstractions/tests/OpenSearch.OpenSearch.EphemeralTests/OpenSearch.OpenSearch.EphemeralTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
   

--- a/abstractions/tests/OpenSearch.Stack.ArtifactsApiTests/OpenSearch.Stack.ArtifactsApiTests.csproj
+++ b/abstractions/tests/OpenSearch.Stack.ArtifactsApiTests/OpenSearch.Stack.ArtifactsApiTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 

--- a/tests/Tests.Auth.AwsSigV4/Tests.Auth.AwsSigV4.csproj
+++ b/tests/Tests.Auth.AwsSigV4/Tests.Auth.AwsSigV4.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.Reproduce/Tests.Reproduce.csproj
+++ b/tests/Tests.Reproduce/Tests.Reproduce.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 </Project>

--- a/tests/Tests/Tests.csproj
+++ b/tests/Tests/Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="FSharp.Core" Version="8.0.100" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />


### PR DESCRIPTION
### Description
Backports 6ac8f9aaa142a76b95fbffeca1a238ba89049fc4 from #496 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
