### PR TITLE
[Backport 1.x] Bump JetBrains.Annotations from 2023.2.0 to 2023.3.0 (#494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `CSharpier.Core` from 0.26.3 to 0.26.7
 - Bumps `xunit` from 2.6.2 to 2.6.3
 - Bumps `Argu` from 6.1.1 to 6.1.4
+- Bumps `JetBrains.Annotations` from 2023.2.0 to 2023.3.0
 
 ## [1.6.0]
 ### Added

--- a/abstractions/src/OpenSearch.OpenSearch.Ephemeral/OpenSearch.OpenSearch.Ephemeral.csproj
+++ b/abstractions/src/OpenSearch.OpenSearch.Ephemeral/OpenSearch.OpenSearch.Ephemeral.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Condition="'$(TargetFramework)' == 'net461'" Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
### Description
Backports 74d542be829a598b4e8c7dab947a453f36fc0bf8 from #494 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
