### PR TITLE
[Backport 1.x] Bump Bogus from 34.0.2 to 35.3.0 (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `Argu` from 6.1.1 to 6.1.4
 - Bumps `JetBrains.Annotations` from 2023.2.0 to 2023.3.0
 - Bumps `Microsoft.NET.Test.Sdk` from 17.7.2 to 17.8.0
+- Bumps `Bogus` from 34.0.2 to 35.3.0
 
 ## [1.6.0]
 ### Added

--- a/tests/Tests.Domain/Tests.Domain.csproj
+++ b/tests/Tests.Domain/Tests.Domain.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="$(SolutionRoot)\src\OpenSearch.Client\OpenSearch.Client.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="Bogus" Version="35.3.0" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Managed\OpenSearch.OpenSearch.Managed.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Configuration\Tests.Configuration.csproj" />


### PR DESCRIPTION
### Description
Backport 4e38cb60c5492b36d1c5e492d3fde357b9ac83d5 from #495

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
