### PR TITLE
[Backport 1.x] Bump NSwag.Core.Yaml from 13.20.0 to 14.0.2 (#530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix `HttpConnection.ConvertHttpMethod` to support `Patch` method ([#489](https://github.com/opensearch-project/opensearch-net/pull/489))
 
 ### Dependencies
+- Bumps `NSwag.Core.Yaml` from 13.19.0 to 14.0.2
 - Bumps `BenchMarkDotNet` from 0.13.10 to 0.13.11
 - Bumps `xunit.runner.visualstudio` from 2.5.4 to 2.5.6
 - Bumps `CSharpier.Core` from 0.26.3 to 0.26.7

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="CSharpier.Core" Version="0.26.7" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NSwag.Core.Yaml" Version="13.20.0" />
+    <PackageReference Include="NSwag.Core.Yaml" Version="14.0.2" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.48.0" />


### PR DESCRIPTION
### Description
Backports a63e4d84aa101ffffa97ffcdcc54df935be475dd from #530 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
