### PR TITLE
[Backport 1.x] Bump NSwag.Core.Yaml from 14.0.2 to 14.0.3 (#541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix `HttpConnection.ConvertHttpMethod` to support `Patch` method ([#489](https://github.com/opensearch-project/opensearch-net/pull/489))
 
 ### Dependencies
-- Bumps `NSwag.Core.Yaml` from 13.19.0 to 14.0.2
+- Bumps `NSwag.Core.Yaml` from 13.19.0 to 14.0.3
 - Bumps `CSharpier.Core` from 0.25.0 to 0.27.2
 - Bumps `System.Text.Encodings.Web` from 7.0.0 to 8.0.0
 - Bumps `xunit.runner.visualstudio` from 2.5.4 to 2.5.6

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="CSharpier.Core" Version="0.27.2" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NSwag.Core.Yaml" Version="14.0.2" />
+    <PackageReference Include="NSwag.Core.Yaml" Version="14.0.3" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.48.0" />


### PR DESCRIPTION
### Description
Backports 47eecef24f663aa597d94d9ca8d0cc5f5c35ad8e from #541 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
