### PR TITLE
Actually use ConnectionConfiguration.DefaultMemoryStreamFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed `HttpConnection.ConvertHttpMethod` to support `Patch` method ([#489](https://github.com/opensearch-project/opensearch-net/pull/489))
 - Fixed `IEnumerable<int?>` property mapping. ([#503](https://github.com/opensearch-project/opensearch-net/pull/503))
+- Fixed `ConnectionConfiguration.DefaultMemoryStreamFactory` actually used as default. ([#552](https://github.com/opensearch-project/opensearch-net/pull/552))
 
 ### Dependencies
 - Bumps `Microsoft.CodeAnalysis.CSharp` from 4.2.0 to 4.6.0

--- a/src/OpenSearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/OpenSearch.Net/Configuration/ConnectionConfiguration.cs
@@ -192,9 +192,8 @@ namespace OpenSearch.Net
 		private bool _sniffOnStartup;
 		private bool _throwExceptions;
 		private bool _transferEncodingChunked;
-		private IMemoryStreamFactory _memoryStreamFactory = RecyclableMemoryStreamFactory.Default;
+		private IMemoryStreamFactory _memoryStreamFactory = DefaultMemoryStreamFactory;
 		private bool _enableTcpStats;
-		//public static IMemoryStreamFactory Default { get; } = RecyclableMemoryStreamFactory.Default;
 		public static IMemoryStreamFactory DefaultMemoryStreamFactory { get; } = OpenSearch.Net.MemoryStreamFactory.Default;
 		private bool _enableThreadPoolStats;
 
@@ -615,7 +614,7 @@ namespace OpenSearch.Net
 		public T TransferEncodingChunked(bool transferEncodingChunked = true) => Assign(transferEncodingChunked, (a, v) => a._transferEncodingChunked = v);
 
 		/// <summary>
-		/// The memory stream factory to use, defaults to <see cref="RecyclableMemoryStreamFactory.Default"/>
+		/// The memory stream factory to use, defaults to <see cref="MemoryStreamFactory.Default"/>
 		/// </summary>
 		public T MemoryStreamFactory(IMemoryStreamFactory memoryStreamFactory) => Assign(memoryStreamFactory, (a, v) => a._memoryStreamFactory = v);
 


### PR DESCRIPTION
### Description
Use DefaultMemoryStreamFactory static property for the default in ConnectionConfiguration - currently the private member is initialized to a different value, which is confusing.

### Issues Resolved
Resolves #551 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
