### PR TITLE
[Backport 1.x] Bump CSharpier.Core from 0.27.2 to 0.27.3 (#556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `NSwag.Core.Yaml` from 13.19.0 to 14.0.3
-- Bumps `CSharpier.Core` from 0.25.0 to 0.27.2
+- Bumps `CSharpier.Core` from 0.25.0 to 0.27.3
 - Bumps `System.Text.Encodings.Web` from 7.0.0 to 8.0.0
 - Bumps `xunit.runner.visualstudio` from 2.5.4 to 2.5.7
 - Bumps `xunit` from 2.6.2 to 2.7.0

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -9,7 +9,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CSharpier.Core" Version="0.27.2" />
+    <PackageReference Include="CSharpier.Core" Version="0.27.3" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.0.3" />


### PR DESCRIPTION
### Description
Backport 2d4e632f98d8ccfc4fd2b904804abafd0508a80e from #556 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
