### PR TITLE
Support list for `opensearch_version` in PluginStats

### DIFF
--- a/.github/workflows/integration-yaml-tests.yml
+++ b/.github/workflows/integration-yaml-tests.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 2.12.0
           - 2.11.1
           - 2.10.0
           - 2.8.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 2.12.0
           - 2.11.1
           - 2.10.0
           - 2.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed the `Features` API which is not supported by OpenSearch from the low-level client ([#331](https://github.com/opensearch-project/opensearch-net/pull/331))
 - Removed the deprecated low-level `IndexTemplateV2` APIs in favour of the `ComposableIndexTemplate` APIs ([#437](https://github.com/opensearch-project/opensearch-net/pull/437))
 
+### Changed
+- Changed `PluginStats.OpenSearchVersion` to support both a single value and a list returned by OpenSearch `>=2.13.0` ([#568](https://github.com/opensearch-project/opensearch-net/pull/568))
+
 ### Dependencies
 - Bumps `System.Diagnostics.DiagnosticSource` from 6.0.1 to 8.0.0
 

--- a/src/OpenSearch.Client/CommonOptions/Stats/PluginStats.cs
+++ b/src/OpenSearch.Client/CommonOptions/Stats/PluginStats.cs
@@ -27,7 +27,10 @@
 */
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
+using OpenSearch.Net;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -41,7 +44,15 @@ namespace OpenSearch.Client
 		public string Description { get; set; }
 
 		[DataMember(Name ="opensearch_version")]
-		public string OpenSearchVersion { get; set; }
+		[JsonFormatter(typeof(InterfaceReadOnlyCollectionSingleOrEnumerableFormatter<string>))]
+		public IReadOnlyCollection<string> OpenSearchVersions { get; set; }
+
+		[IgnoreDataMember]
+		public string OpenSearchVersion
+		{
+			get => OpenSearchVersions?.SingleOrDefault();
+			set => OpenSearchVersions = new [] { value };
+		}
 
 		[DataMember(Name ="extended_plugins")]
 		public IReadOnlyCollection<string> ExtendedPlugins { get; set; }


### PR DESCRIPTION
### Description
Support list for `opensearch_version` in PluginStats. Fixes failing tests against unreleased OpenSearch `2.x` & `main`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
