### PR TITLE
[Backport 1.x] Bump System.Text.Json from 8.0.2 to 8.0.3 (#575)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Dependencies
-- Bumps `System.Text.Json` from 8.0.1 to 8.0.2
+- Bumps `System.Text.Json` from 8.0.1 to 8.0.3
 - Bumps `Argu` from 6.2.1 to 6.2.2
 
 ## [1.7.0]

--- a/abstractions/src/OpenSearch.Stack.ArtifactsApi/OpenSearch.Stack.ArtifactsApi.csproj
+++ b/abstractions/src/OpenSearch.Stack.ArtifactsApi/OpenSearch.Stack.ArtifactsApi.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="SemanticVersioning" Version="2.0.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.2" />
+        <PackageReference Include="System.Text.Json" Version="8.0.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description
Backport daae8d1bc0179694e6cdd65eb57d77b6dd8445c9 from #575 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
