### PR TITLE
Fix k-NN plugin build

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,6 +75,12 @@ jobs:
         with:
           path: client
 
+      # k-NN build requires git user to be set
+      - name: Setup git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |


### PR DESCRIPTION
### Description
Building the k-NN plugin (specifically one of its submodule dependencies) requires the git user to be configured.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
