### PR TITLE
Add support for MinScore in ScriptScoreQuery

### DIFF
--- a/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
@@ -68,7 +68,7 @@ namespace OpenSearch.Client
 		/// <inheritdoc />
 		public IScript Script { get; set; }
 
-		/// <inhertidoc />
+		/// <inheritdoc />
 		public double? MinScore { get; set;}
 
 		protected override bool Conditionless => IsConditionless(this);

--- a/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
@@ -52,6 +52,11 @@ namespace OpenSearch.Client
 		/// </summary>
 		[DataMember(Name = "script")]
 		IScript Script { get; set; }
+
+		/// <summary>
+		/// The minimum score above which hits are returned
+		/// </summary>
+		double? MinScore { get; set;}
 	}
 
 	/// <inheritdoc cref="IScriptScoreQuery" />
@@ -62,6 +67,9 @@ namespace OpenSearch.Client
 
 		/// <inheritdoc />
 		public IScript Script { get; set; }
+
+		/// <inhertidoc />
+		public double? MinScore { get; set;}
 
 		protected override bool Conditionless => IsConditionless(this);
 
@@ -93,6 +101,8 @@ namespace OpenSearch.Client
 		QueryContainer IScriptScoreQuery.Query { get; set; }
 
 		IScript IScriptScoreQuery.Script { get; set; }
+
+		double? MinScore { get; set;}
 
 		/// <inheritdoc cref="IScriptScoreQuery.Query" />
 		public ScriptScoreQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>

--- a/tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
@@ -94,6 +94,7 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 					{ "offset", 0 }
 				}
 			},
+			MinScore = 0.2
 		};
 
 		protected override object QueryJson => new
@@ -122,7 +123,8 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 						decay = 0.5,
 						offset = 0
 					}
-				}
+				},
+				min_score = 0.2
 			}
 		};
 
@@ -145,6 +147,7 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 						.Add("offset", 0)
 					)
 				)
+				.MinScore(0.2)
 			);
 	}
 }


### PR DESCRIPTION
### Description
Add support for `min_score` property in ScriptScoreQuery

### Issues Resolved
Closes #622 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
