### PR TITLE
feat: add support for min_score on ScriptScoreQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Added support for `MinScore` on `ScriptScoreQuery` ([#624](https://github.com/opensearch-project/opensearch-net/pull/624))
-
 - Added support for the `Cat.PitSegments` and `Cat.SegmentReplication` APIs ([#527](https://github.com/opensearch-project/opensearch-net/pull/527))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - As part of [efforts to re-generate the client](https://github.com/opensearch-project/opensearch-net/pulls?q=is%3Apr+label%3Acode-gen+is%3Aclosed) from our [OpenAPI specification](https://github.com/opensearch-project/opensearch-api-specification) there have been numerous corrections and changes that resulted in breaking changes. Please refer to [UPGRADING.md](UPGRADING.md) for a complete list of these breakages and any relevant guidance for upgrading to this version of the client.
 
 ### Added
+- Added support for `MinScore` on `ScriptScoreQuery` ([#624](https://github.com/opensearch-project/opensearch-net/pull/624))
+
 - Added support for the `Cat.PitSegments` and `Cat.SegmentReplication` APIs ([#527](https://github.com/opensearch-project/opensearch-net/pull/527))
 
 ### Removed

--- a/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
@@ -52,6 +52,12 @@ namespace OpenSearch.Client
 		/// </summary>
 		[DataMember(Name = "script")]
 		IScript Script { get; set; }
+
+        /// <summary>
+		/// The score above which documents will be returned
+		/// </summary>
+		[DataMember(Name = "min_score")]
+        double? MinScore { get; set; }
 	}
 
 	/// <inheritdoc cref="IScriptScoreQuery" />
@@ -62,6 +68,9 @@ namespace OpenSearch.Client
 
 		/// <inheritdoc />
 		public IScript Script { get; set; }
+
+        /// <inheritdoc />
+        public double? MinScore { get; set; }
 
 		protected override bool Conditionless => IsConditionless(this);
 
@@ -94,6 +103,8 @@ namespace OpenSearch.Client
 
 		IScript IScriptScoreQuery.Script { get; set; }
 
+        double? IScriptScoreQuery.MinScore { get; set; }
+
 		/// <inheritdoc cref="IScriptScoreQuery.Query" />
 		public ScriptScoreQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(selector, (a, v) => a.Query = v?.Invoke(new QueryContainerDescriptor<T>()));
@@ -101,5 +112,9 @@ namespace OpenSearch.Client
 		/// <inheritdoc cref="IScriptScoreQuery.Script" />
 		public ScriptScoreQueryDescriptor<T> Script(Func<ScriptDescriptor, IScript> selector) =>
 			Assign(selector, (a, v) => a.Script = v?.Invoke(new ScriptDescriptor()));
-	}
+
+        /// <inheritdoc cref="IScriptScoreQuery.MinScore" />
+        public ScriptScoreQueryDescriptor<T> MinScore(double? minScore) => Assign(minScore, (a, v) => a.MinScore = v);
+
+    }
 }

--- a/tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
@@ -79,6 +79,7 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 		{
 			Name = "named_query",
 			Boost = 1.1,
+            MinScore = 1.2,
 			Query = new NumericRangeQuery
 			{
 				Field = Infer.Field<Project>(f => f.NumberOfCommits),
@@ -102,6 +103,7 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 			{
 				_name = "named_query",
 				boost = 1.1,
+                min_score = 1.2,
 				query = new
 				{
 					range = new
@@ -130,6 +132,7 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 			.ScriptScore(sn => sn
 				.Name("named_query")
 				.Boost(1.1)
+                .MinScore(1.2)
 				.Query(qq => qq
 					.Range(r => r
 						.Field(f => f.NumberOfCommits)


### PR DESCRIPTION
### Description
Add support for `min_score` property in `ScriptScoreQuery`. This also is a proper version of https://github.com/opensearch-project/opensearch-net/pull/623 which I closed after realising trying to add something to an SDK in the github browser editor was probably a bad idea.

Also, when running `build.bat` locally I get a few errors, I don't want to take the action minutes up with another duff run, so could someone check if this is just something not correctly set up on my machine, or an actual error I've caused?
![image](https://github.com/opensearch-project/opensearch-net/assets/6514954/d76c897d-d2f0-41d4-ae57-47d2764b4b7b)
![image](https://github.com/opensearch-project/opensearch-net/assets/6514954/329d50f3-6841-409e-bd55-041bbcb3eccd)
I could be missing it, but I couldn't find a guide on how to run these tests so I'm assuming I'm missing some setup

### Issues Resolved
Closes #622 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
