### PR TITLE
Backport dependabot updates & #624 to `1.x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `AWSSDK.Core` from 3.7.204.12 to 3.7.303.18
 - Bumps `Bogus` from 35.3.0 to 35.5.1
+- Bumps `xunit` from 2.7.1 to 2.8.0
 
 ## [1.7.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Added
+- Added support for `MinScore` on `ScriptScoreQuery` ([#624](https://github.com/opensearch-project/opensearch-net/pull/624))
+
 ### Dependencies
 - Bumps `AWSSDK.Core` from 3.7.204.12 to 3.7.303.18
 - Bumps `Bogus` from 35.3.0 to 35.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Dependencies
+- Bumps `AWSSDK.Core` from 3.7.204.12 to 3.7.303.18
 
 ## [1.7.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `AWSSDK.Core` from 3.7.204.12 to 3.7.303.18
 - Bumps `Bogus` from 35.3.0 to 35.5.1
 - Bumps `xunit` from 2.7.1 to 2.8.0
+- Bumps `FSharp.Core` from 8.0.100 to 8.0.200
 
 ## [1.7.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Dependencies
 - Bumps `AWSSDK.Core` from 3.7.204.12 to 3.7.303.18
+- Bumps `Bogus` from 35.3.0 to 35.5.1
 
 ## [1.7.1]
 ### Fixed

--- a/abstractions/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
+++ b/abstractions/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
@@ -8,7 +8,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit" Version="2.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenSearch.OpenSearch.Ephemeral\OpenSearch.OpenSearch.Ephemeral.csproj" />

--- a/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
@@ -52,6 +52,12 @@ namespace OpenSearch.Client
 		/// </summary>
 		[DataMember(Name = "script")]
 		IScript Script { get; set; }
+
+        /// <summary>
+		/// The score above which documents will be returned
+		/// </summary>
+		[DataMember(Name = "min_score")]
+        double? MinScore { get; set; }
 	}
 
 	/// <inheritdoc cref="IScriptScoreQuery" />
@@ -62,6 +68,9 @@ namespace OpenSearch.Client
 
 		/// <inheritdoc />
 		public IScript Script { get; set; }
+
+        /// <inheritdoc />
+        public double? MinScore { get; set; }
 
 		protected override bool Conditionless => IsConditionless(this);
 
@@ -94,6 +103,8 @@ namespace OpenSearch.Client
 
 		IScript IScriptScoreQuery.Script { get; set; }
 
+        double? IScriptScoreQuery.MinScore { get; set; }
+
 		/// <inheritdoc cref="IScriptScoreQuery.Query" />
 		public ScriptScoreQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(selector, (a, v) => a.Query = v?.Invoke(new QueryContainerDescriptor<T>()));
@@ -101,5 +112,9 @@ namespace OpenSearch.Client
 		/// <inheritdoc cref="IScriptScoreQuery.Script" />
 		public ScriptScoreQueryDescriptor<T> Script(Func<ScriptDescriptor, IScript> selector) =>
 			Assign(selector, (a, v) => a.Script = v?.Invoke(new ScriptDescriptor()));
-	}
+
+        /// <inheritdoc cref="IScriptScoreQuery.MinScore" />
+        public ScriptScoreQueryDescriptor<T> MinScore(double? minScore) => Assign(minScore, (a, v) => a.MinScore = v);
+
+    }
 }

--- a/src/OpenSearch.Net.Auth.AwsSigV4/OpenSearch.Net.Auth.AwsSigV4.csproj
+++ b/src/OpenSearch.Net.Auth.AwsSigV4/OpenSearch.Net.Auth.AwsSigV4.csproj
@@ -20,7 +20,7 @@
     <ProjectReference Include="$(SolutionRoot)\src\OpenSearch.Net\OpenSearch.Net.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.204.12" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.303.18" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <Reference Include="System.Web" />

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Domain\Tests.Domain.csproj" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
 
-    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit" Version="2.8.0" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Xunit\OpenSearch.OpenSearch.Xunit.csproj" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.1.12" />
 

--- a/tests/Tests.Domain/Tests.Domain.csproj
+++ b/tests/Tests.Domain/Tests.Domain.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="$(SolutionRoot)\src\OpenSearch.Client\OpenSearch.Client.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.3.0" />
+    <PackageReference Include="Bogus" Version="35.5.1" />
     <ProjectReference Include="$(SolutionRoot)\abstractions\src\OpenSearch.OpenSearch.Managed\OpenSearch.OpenSearch.Managed.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Configuration\Tests.Configuration.csproj" />

--- a/tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
@@ -79,6 +79,7 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 		{
 			Name = "named_query",
 			Boost = 1.1,
+            MinScore = 1.2,
 			Query = new NumericRangeQuery
 			{
 				Field = Infer.Field<Project>(f => f.NumberOfCommits),
@@ -102,6 +103,7 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 			{
 				_name = "named_query",
 				boost = 1.1,
+                min_score = 1.2,
 				query = new
 				{
 					range = new
@@ -130,6 +132,7 @@ namespace Tests.QueryDsl.Specialized.ScriptScore
 			.ScriptScore(sn => sn
 				.Name("named_query")
 				.Boost(1.1)
+                .MinScore(1.2)
 				.Query(qq => qq
 					.Range(r => r
 						.Field(f => f.NumberOfCommits)

--- a/tests/Tests/Tests.csproj
+++ b/tests/Tests/Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="FSharp.Core" Version="8.0.100" />
+    <PackageReference Include="FSharp.Core" Version="8.0.200" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8" />


### PR DESCRIPTION
### Description
Backports recent `main` changes to `1.x` that could not be automatically backported due to CHANGELOG conflicts.

------

** ❗ SHOULD BE REBASE MERGED ❗ **

-------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
