### PR TITLE
Bump Spectre.Console from 0.48.0 to 0.49.1 (#640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `FSharp.Core` from 8.0.100 to 8.0.200
 - Bumps `xunit.runner.visualstudio` from 2.5.8 to 2.8.0
 - Bumps `CSharpier.Core` from 0.27.3 to 0.28.2
+- Bumps `Spectre.Console` from 0.48.0 to 0.49.1
 
 ## [1.7.1]
 ### Fixed

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NSwag.Core.Yaml" Version="14.0.7" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
-    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20371.2" />
     <PackageReference Include="RazorLight" Version="2.3.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />


### PR DESCRIPTION
### Description
Backport f6f62096a1593f36e8889c53a03ed3e4e4940455 from #640

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
