### PR TITLE
Add interfaces to OpenSearchClient's namespaces API specifications (fixes #423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### ⚠️ Breaking Changes ⚠️
 - As part of [efforts to re-generate the client](https://github.com/opensearch-project/opensearch-net/pulls?q=is%3Apr+label%3Acode-gen+is%3Aclosed) from our [OpenAPI specification](https://github.com/opensearch-project/opensearch-api-specification) there have been numerous corrections and changes that resulted in breaking changes. Please refer to [UPGRADING.md](UPGRADING.md) for a complete list of these breakages and any relevant guidance for upgrading to this version of the client.
-- To allow easier unit testing of code using OpenSearch, interfaces were introduced for all classes under OpenSearch.Client.Specification, and the properties in IOpenServiceClient and OpenServiceClient were changed from the concrete classes to the new interfaces.
+
+### Changed
+- Changed the namespace client properties on `IOpenSearchClient` to return corresponding interfaces to better enable mocking & unit testing ([#646](https://github.com/opensearch-project/opensearch-net/pull/646))
 
 ### Added
 - Added support for `MinScore` on `ScriptScoreQuery` ([#624](https://github.com/opensearch-project/opensearch-net/pull/624))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### ⚠️ Breaking Changes ⚠️
 - As part of [efforts to re-generate the client](https://github.com/opensearch-project/opensearch-net/pulls?q=is%3Apr+label%3Acode-gen+is%3Aclosed) from our [OpenAPI specification](https://github.com/opensearch-project/opensearch-api-specification) there have been numerous corrections and changes that resulted in breaking changes. Please refer to [UPGRADING.md](UPGRADING.md) for a complete list of these breakages and any relevant guidance for upgrading to this version of the client.
+- To allow easier unit testing of code using OpenSearch, interfaces were introduced for all classes under OpenSearch.Client.Specification, and the properties in IOpenServiceClient and OpenServiceClient were changed from the concrete classes to the new interfaces.
 
 ### Added
 - Added support for `MinScore` on `ScriptScoreQuery` ([#624](https://github.com/opensearch-project/opensearch-net/pull/624))

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,8 @@
 <!-- TOC -->
 * [Upgrading OpenSearch.Net & OpenSearch.Client](#upgrading-opensearchnet--opensearchclient)
+  * [2.0.0 to unreleased](#200-to-unreleased)
+    * [OpenSearch.Client](#opensearchclient-1)
+      * [General](#general-2)
   * [1.x.y to 2.0.0](#1xy-to-200)
     * [OpenSearch.Net](#opensearchnet)
       * [General](#general)
@@ -35,6 +38,13 @@
 <!-- TOC -->
 
 # Upgrading OpenSearch.Net & OpenSearch.Client
+
+## [Unreleased]
+
+### OpenSearch.Client
+
+#### General
+- Namespaced APIs, exposed in `IOpenSearchClient`, have gained an interface, and the properties on `IOpenSearchClient` and `OpenSearchClient` have been changed to the new interfaces. For example, `IOpenSearchClient.Cluster` was `ClusterNamespace` and now is `IClusterNamespace`.
 
 ## 1.x.y to 2.0.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,8 +1,5 @@
 <!-- TOC -->
 * [Upgrading OpenSearch.Net & OpenSearch.Client](#upgrading-opensearchnet--opensearchclient)
-  * [2.0.0 to unreleased](#200-to-unreleased)
-    * [OpenSearch.Client](#opensearchclient-1)
-      * [General](#general-2)
   * [1.x.y to 2.0.0](#1xy-to-200)
     * [OpenSearch.Net](#opensearchnet)
       * [General](#general)
@@ -38,13 +35,6 @@
 <!-- TOC -->
 
 # Upgrading OpenSearch.Net & OpenSearch.Client
-
-## [Unreleased]
-
-### OpenSearch.Client
-
-#### General
-- Namespaced APIs, exposed in `IOpenSearchClient`, have gained an interface, and the properties on `IOpenSearchClient` and `OpenSearchClient` have been changed to the new interfaces. For example, `IOpenSearchClient.Cluster` was `ClusterNamespace` and now is `IClusterNamespace`.
 
 ## 1.x.y to 2.0.0
 
@@ -112,6 +102,7 @@
 #### General
 - The `MasterTimeout` parameters on all actions have been marked `[Obsolete]`, please migrate to using `ClusterManagerTimeout` if your OpenSearch cluster is at least version `2.0.0` as `MasterTimeout` may be removed in future major versions.
 - The `ExpandWildcards` enum is now attributed with `[Flags]` to allow combining of multiple values e.g. `ExpandWildcards.Open | ExpandWildcards.Closed` to match open and closed indexes but not hidden.
+- The namespaced APIs exposed in `IOpenSearchClient` have each gained a corresponding interface and the types of the properties on `IOpenSearchClient` and `OpenSearchClient` have been changed from the concrete implementations to the matching interfaces. For example, `IOpenSearchClient.Cluster` was `ClusterNamespace` and now is `IClusterNamespace`.
 
 #### Cat.Indices Action
 - The `Health` parameter now accepts a new `HealthStatus` enum instead of the `Health` enum. The values are identical and are now unified with other parts of the API that utilize the same enum.

--- a/src/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentInterfaceMethod.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentInterfaceMethod.cshtml
@@ -1,0 +1,5 @@
+@using System
+@using ApiGenerator.Domain.Code.HighLevel.Methods
+@inherits ApiGenerator.CodeTemplatePage<FluentSyntaxView>
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", Model.Syntax); }
+@{ await IncludeAsync("HighLevel/Client/FluentSyntax/FluentMethodHeader.cshtml", Model);}@Raw(";")

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/MethodInterface.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/MethodInterface.cshtml
@@ -1,0 +1,19 @@
+@using ApiGenerator
+@using ApiGenerator.Domain.Code.HighLevel.Methods
+@using HighLevelModel = ApiGenerator.Domain.Code.HighLevel.Methods.HighLevelModel
+@inherits CodeTemplatePage<HighLevelModel>
+@{
+	const string fluentPath = "HighLevel/Client/FluentSyntax/FluentInterfaceMethod.cshtml";
+	const string initializerPath = "HighLevel/Client/InitializerSyntax/InitializerInterfaceMethod.cshtml";
+}
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.Fluent, async: false)); }
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.Fluent, async: true)); }
+@if (Model.FluentBound != null)
+{
+<text>
+    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.FluentBound, async: false)); }
+    @{ await IncludeAsync(fluentPath, new FluentSyntaxView(Model.FluentBound, async: true)); }
+</text>
+}
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(Model.Initializer, async: false)); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(Model.Initializer, async: true)); }

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.Http.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.Http.cshtml
@@ -3,6 +3,7 @@
 @inherits ApiGenerator.CodeTemplatePage<IEnumerable<HttpMethod>>
 @{
 	const string ns = "Http";
+	var generic = Raw("<TResponse>");
 }
 @{ await IncludeGeneratorNotice(); }
 
@@ -15,16 +16,43 @@ namespace OpenSearch.Client.@(CsharpNames.ApiNamespace).@ns@(CsharpNames.ApiName
 
 /// <summary>
 /// @ns.SplitPascalCase() APIs.
+/// <para>Use the <see cref="IOpenSearchClient.@ns"/> property on <see cref="IOpenSearchClient"/>.</para>
+/// </summary>
+public interface @(CsharpNames.HighLevelClientNamespacePrefix)I@(ns)@(CsharpNames.ClientNamespaceSuffix)
+{
+@{
+	foreach (var m in Model)
+	{
+		var selector = Raw($"Func<{m.Descriptor}, {m.IRequest}> selector = null");
+	<text>
+
+		TResponse @(m)@(generic)(string path, @(selector))
+			where TResponse : class, IOpenSearchResponse, new();
+
+		Task@(generic) @(m)Async@(generic)(string path, @(selector), CancellationToken ct = default)
+			where TResponse : class, IOpenSearchResponse, new();
+
+		TResponse @(m)@(generic)(@m.IRequest request)
+			where TResponse : class, IOpenSearchResponse, new();
+
+		Task@(generic) @(m)Async@(generic)(@m.IRequest request, CancellationToken ct = default)
+			where TResponse : class, IOpenSearchResponse, new();
+
+	</text>
+	}
+}
+}
+
+/// <summary>
+/// @ns.SplitPascalCase() implementation.
 /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.@ns"/> property
 /// on <see cref="IOpenSearchClient"/>.
 /// </para>
 /// </summary>
-public class @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy
+public class @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy, @(CsharpNames.HighLevelClientNamespacePrefix)I@(ns)@(CsharpNames.ClientNamespaceSuffix)
 {
     internal @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix)(OpenSearchClient client) : base(client) {}
 @{
-	var generic = Raw("<TResponse>");
-
 	foreach (var m in Model)
 	{
 		var bodySelector = Raw(m.TakesBody ? "r => r.Body" : "_ => null");

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.Namespace.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.Namespace.cshtml
@@ -20,11 +20,23 @@ namespace OpenSearch.Client.@(CsharpNames.ApiNamespace).@ns@(CsharpNames.ApiName
 {
     /// <summary>
     /// @ns.SplitPascalCase() APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.@ns"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface I@(CsharpNames.HighLevelClientNamespacePrefix)@(ns)@(CsharpNames.ClientNamespaceSuffix)
+    {
+        @foreach(var e in endpoints)
+        {
+            await IncludeAsync("HighLevel/Client/Implementation/MethodInterface.cshtml", e.HighLevelModel);
+        }
+    }
+
+    /// <summary>
+    /// @ns.SplitPascalCase() implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.@ns"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy
+    public partial class @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix) : NamespacedClientProxy, I@(CsharpNames.HighLevelClientNamespacePrefix)@(ns)@(CsharpNames.ClientNamespaceSuffix)
     {
         internal @(CsharpNames.HighLevelClientNamespacePrefix)@ns@(CsharpNames.ClientNamespaceSuffix)(OpenSearchClient client) : base(client) {}
         @foreach(var e in endpoints)

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.cshtml
@@ -28,9 +28,8 @@ namespace OpenSearch.Client
 </text>
     foreach (var ns in namespaces)
     {
-        var prefix = ns == "Http" ? "" : "I";
 <text>      /// <summary>@(ns.SplitPascalCase()) APIs</summary>
-            public @(CsharpNames.HighLevelClientNamespacePrefix)@(prefix)@(ns)@(CsharpNames.ClientNamespaceSuffix) @ns { get; private set; }
+            public @(CsharpNames.HighLevelClientNamespacePrefix)I@(ns)@(CsharpNames.ClientNamespaceSuffix) @ns { get; private set; }
 </text>
     }
 <text>

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/OpenSearchClient.cshtml
@@ -28,8 +28,9 @@ namespace OpenSearch.Client
 </text>
     foreach (var ns in namespaces)
     {
+        var prefix = ns == "Http" ? "" : "I";
 <text>      /// <summary>@(ns.SplitPascalCase()) APIs</summary>
-            public @CsharpNames.HighLevelClientNamespacePrefix@(ns)@CsharpNames.ClientNamespaceSuffix @ns { get; private set; }
+            public @(CsharpNames.HighLevelClientNamespacePrefix)@(prefix)@(ns)@(CsharpNames.ClientNamespaceSuffix) @ns { get; private set; }
 </text>
     }
 <text>

--- a/src/ApiGenerator/Views/HighLevel/Client/InitializerSyntax/InitializerInterfaceMethod.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/InitializerSyntax/InitializerInterfaceMethod.cshtml
@@ -1,0 +1,6 @@
+@using System
+@using ApiGenerator.Domain.Code.HighLevel.Methods
+@inherits ApiGenerator.CodeTemplatePage<InitializerSyntaxView>
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", Model.Syntax); }
+@{ await IncludeAsync("HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml", Model); }@Raw(";")
+

--- a/src/ApiGenerator/Views/HighLevel/Client/Interface/IOpenSearchClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Interface/IOpenSearchClient.cshtml
@@ -27,9 +27,8 @@ namespace OpenSearch.Client
 
 			foreach (var ns in namespaces)
 			{
-                var prefix = ns == "Http" ? "" : "I";
 <text>      /// <summary>@ns.SplitPascalCase() APIs</summary>
-			@(CsharpNames.HighLevelClientNamespacePrefix)@(prefix)@(ns)@(CsharpNames.ClientNamespaceSuffix) @ns { get; }
+			@(CsharpNames.HighLevelClientNamespacePrefix)I@(ns)@(CsharpNames.ClientNamespaceSuffix) @ns { get; }
 </text>
 			}
 

--- a/src/ApiGenerator/Views/HighLevel/Client/Interface/IOpenSearchClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Interface/IOpenSearchClient.cshtml
@@ -27,8 +27,9 @@ namespace OpenSearch.Client
 
 			foreach (var ns in namespaces)
 			{
+                var prefix = ns == "Http" ? "" : "I";
 <text>      /// <summary>@ns.SplitPascalCase() APIs</summary>
-			@CsharpNames.HighLevelClientNamespacePrefix@(ns)@CsharpNames.ClientNamespaceSuffix @ns { get; }
+			@(CsharpNames.HighLevelClientNamespacePrefix)@(prefix)@(ns)@(CsharpNames.ClientNamespaceSuffix) @ns { get; }
 </text>
 			}
 

--- a/src/OpenSearch.Client/OpenSearchClient.Indices.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Indices.cs
@@ -51,8 +51,819 @@ using OpenSearch.Net.Specification.IndicesApi;
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace OpenSearch.Client.Specification.IndicesApi
 {
+
 	///<summary>
-	/// Indices APIs.
+	/// Indices API.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IOpenSearchClient.Indices"/> property
+	/// on <see cref = "IOpenSearchClient"/>.
+	///</para>
+	///</summary>
+	public partial interface IIndicesNamespace
+	{
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.add_block</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		AddIndexBlockResponse AddBlock(Indices index, IndexBlock block, Func<AddIndexBlockDescriptor, IAddIndexBlockRequest> selector = null);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.add_block</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<AddIndexBlockResponse> AddBlockAsync(Indices index, IndexBlock block, Func<AddIndexBlockDescriptor, IAddIndexBlockRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.add_block</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		AddIndexBlockResponse AddBlock(IAddIndexBlockRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.add_block</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<AddIndexBlockResponse> AddBlockAsync(IAddIndexBlockRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.analyze</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		AnalyzeResponse Analyze(Func<AnalyzeDescriptor, IAnalyzeRequest> selector = null);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.analyze</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<AnalyzeResponse> AnalyzeAsync(Func<AnalyzeDescriptor, IAnalyzeRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.analyze</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		AnalyzeResponse Analyze(IAnalyzeRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.analyze</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<AnalyzeResponse> AnalyzeAsync(IAnalyzeRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.clear_cache</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		ClearCacheResponse ClearCache(Indices index = null, Func<ClearCacheDescriptor, IClearCacheRequest> selector = null);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.clear_cache</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<ClearCacheResponse> ClearCacheAsync(Indices index = null, Func<ClearCacheDescriptor, IClearCacheRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.clear_cache</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		ClearCacheResponse ClearCache(IClearCacheRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.clear_cache</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<ClearCacheResponse> ClearCacheAsync(IClearCacheRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.clone</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/clone/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/clone/</a>
+		/// </summary>
+		CloneIndexResponse Clone(IndexName index, IndexName target, Func<CloneIndexDescriptor, ICloneIndexRequest> selector = null);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.clone</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/clone/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/clone/</a>
+		/// </summary>
+		Task<CloneIndexResponse> CloneAsync(IndexName index, IndexName target, Func<CloneIndexDescriptor, ICloneIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.clone</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/clone/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/clone/</a>
+		/// </summary>
+		CloneIndexResponse Clone(ICloneIndexRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.clone</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/clone/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/clone/</a>
+		/// </summary>
+		Task<CloneIndexResponse> CloneAsync(ICloneIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</a>
+		/// </summary>
+		CloseIndexResponse Close(Indices index, Func<CloseIndexDescriptor, ICloseIndexRequest> selector = null);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</a>
+		/// </summary>
+		Task<CloseIndexResponse> CloseAsync(Indices index, Func<CloseIndexDescriptor, ICloseIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</a>
+		/// </summary>
+		CloseIndexResponse Close(ICloseIndexRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</a>
+		/// </summary>
+		Task<CloseIndexResponse> CloseAsync(ICloseIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.create</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/</a>
+		/// </summary>
+		CreateIndexResponse Create(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest> selector = null);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.create</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/</a>
+		/// </summary>
+		Task<CreateIndexResponse> CreateAsync(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.create</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/</a>
+		/// </summary>
+		CreateIndexResponse Create(ICreateIndexRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.create</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/</a>
+		/// </summary>
+		Task<CreateIndexResponse> CreateAsync(ICreateIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/delete-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/delete-index/</a>
+		/// </summary>
+		DeleteIndexResponse Delete(Indices index, Func<DeleteIndexDescriptor, IDeleteIndexRequest> selector = null);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/delete-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/delete-index/</a>
+		/// </summary>
+		Task<DeleteIndexResponse> DeleteAsync(Indices index, Func<DeleteIndexDescriptor, IDeleteIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/delete-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/delete-index/</a>
+		/// </summary>
+		DeleteIndexResponse Delete(IDeleteIndexRequest request);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/delete-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/delete-index/</a>
+		/// </summary>
+		Task<DeleteIndexResponse> DeleteAsync(IDeleteIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		DeleteAliasResponse DeleteAlias(Indices index, Names name, Func<DeleteAliasDescriptor, IDeleteAliasRequest> selector = null);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<DeleteAliasResponse> DeleteAliasAsync(Indices index, Names name, Func<DeleteAliasDescriptor, IDeleteAliasRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		DeleteAliasResponse DeleteAlias(IDeleteAliasRequest request);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<DeleteAliasResponse> DeleteAliasAsync(IDeleteAliasRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		DeleteIndexTemplateResponse DeleteTemplate(Name name, Func<DeleteIndexTemplateDescriptor, IDeleteIndexTemplateRequest> selector = null);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		Task<DeleteIndexTemplateResponse> DeleteTemplateAsync(Name name, Func<DeleteIndexTemplateDescriptor, IDeleteIndexTemplateRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		DeleteIndexTemplateResponse DeleteTemplate(IDeleteIndexTemplateRequest request);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>indices.delete_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		Task<DeleteIndexTemplateResponse> DeleteTemplateAsync(IDeleteIndexTemplateRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</a>
+		/// </summary>
+		ExistsResponse Exists(Indices index, Func<IndexExistsDescriptor, IIndexExistsRequest> selector = null);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</a>
+		/// </summary>
+		Task<ExistsResponse> ExistsAsync(Indices index, Func<IndexExistsDescriptor, IIndexExistsRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</a>
+		/// </summary>
+		ExistsResponse Exists(IIndexExistsRequest request);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</a>
+		/// </summary>
+		Task<ExistsResponse> ExistsAsync(IIndexExistsRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		ExistsResponse AliasExists(Names name, Func<AliasExistsDescriptor, IAliasExistsRequest> selector = null);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<ExistsResponse> AliasExistsAsync(Names name, Func<AliasExistsDescriptor, IAliasExistsRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		ExistsResponse AliasExists(IAliasExistsRequest request);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<ExistsResponse> AliasExistsAsync(IAliasExistsRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		ExistsResponse TemplateExists(Names name, Func<IndexTemplateExistsDescriptor, IIndexTemplateExistsRequest> selector = null);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		Task<ExistsResponse> TemplateExistsAsync(Names name, Func<IndexTemplateExistsDescriptor, IIndexTemplateExistsRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		ExistsResponse TemplateExists(IIndexTemplateExistsRequest request);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		Task<ExistsResponse> TemplateExistsAsync(IIndexTemplateExistsRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_type</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</a>
+		/// </summary>
+		/// <remarks>Deprecated as of OpenSearch 2.0</remarks>
+		ExistsResponse TypeExists(Indices index, Names type, Func<TypeExistsDescriptor, ITypeExistsRequest> selector = null);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_type</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</a>
+		/// </summary>
+		/// <remarks>Deprecated as of OpenSearch 2.0</remarks>
+		Task<ExistsResponse> TypeExistsAsync(Indices index, Names type, Func<TypeExistsDescriptor, ITypeExistsRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_type</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</a>
+		/// </summary>
+		/// <remarks>Deprecated as of OpenSearch 2.0</remarks>
+		ExistsResponse TypeExists(ITypeExistsRequest request);
+		/// <summary>
+		/// <c>HEAD</c> request to the <c>indices.exists_type</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</a>
+		/// </summary>
+		/// <remarks>Deprecated as of OpenSearch 2.0</remarks>
+		Task<ExistsResponse> TypeExistsAsync(ITypeExistsRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.flush</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		FlushResponse Flush(Indices index = null, Func<FlushDescriptor, IFlushRequest> selector = null);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.flush</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<FlushResponse> FlushAsync(Indices index = null, Func<FlushDescriptor, IFlushRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.flush</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		FlushResponse Flush(IFlushRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.flush</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<FlushResponse> FlushAsync(IFlushRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.forcemerge</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		ForceMergeResponse ForceMerge(Indices index = null, Func<ForceMergeDescriptor, IForceMergeRequest> selector = null);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.forcemerge</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<ForceMergeResponse> ForceMergeAsync(Indices index = null, Func<ForceMergeDescriptor, IForceMergeRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.forcemerge</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		ForceMergeResponse ForceMerge(IForceMergeRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.forcemerge</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<ForceMergeResponse> ForceMergeAsync(IForceMergeRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-index/</a>
+		/// </summary>
+		GetIndexResponse Get(Indices index, Func<GetIndexDescriptor, IGetIndexRequest> selector = null);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-index/</a>
+		/// </summary>
+		Task<GetIndexResponse> GetAsync(Indices index, Func<GetIndexDescriptor, IGetIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-index/</a>
+		/// </summary>
+		GetIndexResponse Get(IGetIndexRequest request);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-index/</a>
+		/// </summary>
+		Task<GetIndexResponse> GetAsync(IGetIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		GetAliasResponse GetAlias(Indices index = null, Func<GetAliasDescriptor, IGetAliasRequest> selector = null);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<GetAliasResponse> GetAliasAsync(Indices index = null, Func<GetAliasDescriptor, IGetAliasRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		GetAliasResponse GetAlias(IGetAliasRequest request);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<GetAliasResponse> GetAliasAsync(IGetAliasRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_field_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		GetFieldMappingResponse GetFieldMapping<TDocument>(Fields fields, Func<GetFieldMappingDescriptor<TDocument>, IGetFieldMappingRequest> selector = null)
+			where TDocument : class;
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_field_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		Task<GetFieldMappingResponse> GetFieldMappingAsync<TDocument>(Fields fields, Func<GetFieldMappingDescriptor<TDocument>, IGetFieldMappingRequest> selector = null, CancellationToken ct = default)
+			where TDocument : class;
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_field_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		GetFieldMappingResponse GetFieldMapping(IGetFieldMappingRequest request);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_field_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		Task<GetFieldMappingResponse> GetFieldMappingAsync(IGetFieldMappingRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		GetMappingResponse GetMapping<TDocument>(Func<GetMappingDescriptor<TDocument>, IGetMappingRequest> selector = null)
+			where TDocument : class;
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		Task<GetMappingResponse> GetMappingAsync<TDocument>(Func<GetMappingDescriptor<TDocument>, IGetMappingRequest> selector = null, CancellationToken ct = default)
+			where TDocument : class;
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		GetMappingResponse GetMapping(IGetMappingRequest request);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		Task<GetMappingResponse> GetMappingAsync(IGetMappingRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_settings</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		GetIndexSettingsResponse GetSettings(Indices index = null, Func<GetIndexSettingsDescriptor, IGetIndexSettingsRequest> selector = null);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_settings</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<GetIndexSettingsResponse> GetSettingsAsync(Indices index = null, Func<GetIndexSettingsDescriptor, IGetIndexSettingsRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_settings</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		GetIndexSettingsResponse GetSettings(IGetIndexSettingsRequest request);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_settings</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<GetIndexSettingsResponse> GetSettingsAsync(IGetIndexSettingsRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		GetIndexTemplateResponse GetTemplate(Names name = null, Func<GetIndexTemplateDescriptor, IGetIndexTemplateRequest> selector = null);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		Task<GetIndexTemplateResponse> GetTemplateAsync(Names name = null, Func<GetIndexTemplateDescriptor, IGetIndexTemplateRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		GetIndexTemplateResponse GetTemplate(IGetIndexTemplateRequest request);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.get_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		Task<GetIndexTemplateResponse> GetTemplateAsync(IGetIndexTemplateRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.open</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</a>
+		/// </summary>
+		OpenIndexResponse Open(Indices index, Func<OpenIndexDescriptor, IOpenIndexRequest> selector = null);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.open</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</a>
+		/// </summary>
+		Task<OpenIndexResponse> OpenAsync(Indices index, Func<OpenIndexDescriptor, IOpenIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.open</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</a>
+		/// </summary>
+		OpenIndexResponse Open(IOpenIndexRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.open</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</a>
+		/// </summary>
+		Task<OpenIndexResponse> OpenAsync(IOpenIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		PutAliasResponse PutAlias(Indices index, Name name, Func<PutAliasDescriptor, IPutAliasRequest> selector = null);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<PutAliasResponse> PutAliasAsync(Indices index, Name name, Func<PutAliasDescriptor, IPutAliasRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		PutAliasResponse PutAlias(IPutAliasRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_alias</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<PutAliasResponse> PutAliasAsync(IPutAliasRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		PutMappingResponse PutMapping<TDocument>(Func<PutMappingDescriptor<TDocument>, IPutMappingRequest> selector)
+			where TDocument : class;
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		Task<PutMappingResponse> PutMappingAsync<TDocument>(Func<PutMappingDescriptor<TDocument>, IPutMappingRequest> selector, CancellationToken ct = default)
+			where TDocument : class;
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		PutMappingResponse PutMapping(IPutMappingRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_mapping</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/">https://opensearch.org/docs/latest/opensearch/rest-api/update-mapping/</a>
+		/// </summary>
+		Task<PutMappingResponse> PutMappingAsync(IPutMappingRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_settings</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		UpdateIndexSettingsResponse UpdateSettings(Indices index, Func<UpdateIndexSettingsDescriptor, IUpdateIndexSettingsRequest> selector);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_settings</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<UpdateIndexSettingsResponse> UpdateSettingsAsync(Indices index, Func<UpdateIndexSettingsDescriptor, IUpdateIndexSettingsRequest> selector, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_settings</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		UpdateIndexSettingsResponse UpdateSettings(IUpdateIndexSettingsRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_settings</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<UpdateIndexSettingsResponse> UpdateSettingsAsync(IUpdateIndexSettingsRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		PutIndexTemplateResponse PutTemplate(Name name, Func<PutIndexTemplateDescriptor, IPutIndexTemplateRequest> selector);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		Task<PutIndexTemplateResponse> PutTemplateAsync(Name name, Func<PutIndexTemplateDescriptor, IPutIndexTemplateRequest> selector, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		PutIndexTemplateResponse PutTemplate(IPutIndexTemplateRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.put_template</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</a>
+		/// </summary>
+		Task<PutIndexTemplateResponse> PutTemplateAsync(IPutIndexTemplateRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.recovery</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		RefreshResponse Refresh(Indices index = null, Func<RefreshDescriptor, IRefreshRequest> selector = null);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.refresh</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/document-apis/get-documents/">https://opensearch.org/docs/latest/opensearch/rest-api/document-apis/get-documents/</a>
+		/// </summary>
+		Task<RefreshResponse> RefreshAsync(Indices index = null, Func<RefreshDescriptor, IRefreshRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.refresh</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/document-apis/get-documents/">https://opensearch.org/docs/latest/opensearch/rest-api/document-apis/get-documents/</a>
+		/// </summary>
+		RefreshResponse Refresh(IRefreshRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.refresh</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/document-apis/get-documents/">https://opensearch.org/docs/latest/opensearch/rest-api/document-apis/get-documents/</a>
+		/// </summary>
+		Task<RefreshResponse> RefreshAsync(IRefreshRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.resolve_index</c> API, read more about this API online:
+		/// <para></para>
+		/// </summary>
+		ResolveIndexResponse Resolve(Names name, Func<ResolveIndexDescriptor, IResolveIndexRequest> selector = null);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.resolve_index</c> API, read more about this API online:
+		/// <para></para>
+		/// </summary>
+		Task<ResolveIndexResponse> ResolveAsync(Names name, Func<ResolveIndexDescriptor, IResolveIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.resolve_index</c> API, read more about this API online:
+		/// <para></para>
+		/// </summary>
+		ResolveIndexResponse Resolve(IResolveIndexRequest request);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.resolve_index</c> API, read more about this API online:
+		/// <para></para>
+		/// </summary>
+		Task<ResolveIndexResponse> ResolveAsync(IResolveIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.rollover</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream">https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream</a>
+		/// </summary>
+		RolloverIndexResponse Rollover(Name alias, Func<RolloverIndexDescriptor, IRolloverIndexRequest> selector = null);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.rollover</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream">https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream</a>
+		/// </summary>
+		Task<RolloverIndexResponse> RolloverAsync(Name alias, Func<RolloverIndexDescriptor, IRolloverIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.rollover</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream">https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream</a>
+		/// </summary>
+		RolloverIndexResponse Rollover(IRolloverIndexRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.rollover</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream">https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream</a>
+		/// </summary>
+		Task<RolloverIndexResponse> RolloverAsync(IRolloverIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.segments</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-segments/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-segments/</a>
+		/// </summary>
+		ShrinkIndexResponse Shrink(IndexName index, IndexName target, Func<ShrinkIndexDescriptor, IShrinkIndexRequest> selector = null);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.shrink</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/shrink-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/shrink-index/</a>
+		/// </summary>
+		Task<ShrinkIndexResponse> ShrinkAsync(IndexName index, IndexName target, Func<ShrinkIndexDescriptor, IShrinkIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.shrink</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/shrink-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/shrink-index/</a>
+		/// </summary>
+		ShrinkIndexResponse Shrink(IShrinkIndexRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.shrink</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/shrink-index/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/shrink-index/</a>
+		/// </summary>
+		Task<ShrinkIndexResponse> ShrinkAsync(IShrinkIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.split</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/split/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/split/</a>
+		/// </summary>
+		SplitIndexResponse Split(IndexName index, IndexName target, Func<SplitIndexDescriptor, ISplitIndexRequest> selector = null);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.split</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/split/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/split/</a>
+		/// </summary>
+		Task<SplitIndexResponse> SplitAsync(IndexName index, IndexName target, Func<SplitIndexDescriptor, ISplitIndexRequest> selector = null, CancellationToken ct = default);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.split</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/split/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/split/</a>
+		/// </summary>
+		SplitIndexResponse Split(ISplitIndexRequest request);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.split</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/split/">https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/split/</a>
+		/// </summary>
+		Task<SplitIndexResponse> SplitAsync(ISplitIndexRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>GET</c> request to the <c>indices.stats</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/stats-api/">https://opensearch.org/docs/latest/opensearch/stats-api/</a>
+		/// </summary>
+		BulkAliasResponse BulkAlias(Func<BulkAliasDescriptor, IBulkAliasRequest> selector);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<BulkAliasResponse> BulkAliasAsync(Func<BulkAliasDescriptor, IBulkAliasRequest> selector, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		BulkAliasResponse BulkAlias(IBulkAliasRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
+		/// </summary>
+		Task<BulkAliasResponse> BulkAliasAsync(IBulkAliasRequest request, CancellationToken ct = default);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.validate_query</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		ValidateQueryResponse ValidateQuery<TDocument>(Func<ValidateQueryDescriptor<TDocument>, IValidateQueryRequest> selector = null)
+			where TDocument : class;
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.validate_query</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<ValidateQueryResponse> ValidateQueryAsync<TDocument>(Func<ValidateQueryDescriptor<TDocument>, IValidateQueryRequest> selector = null, CancellationToken ct = default)
+			where TDocument : class;
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.validate_query</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		ValidateQueryResponse ValidateQuery(IValidateQueryRequest request);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.validate_query</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = ""></a>
+		/// </summary>
+		Task<ValidateQueryResponse> ValidateQueryAsync(IValidateQueryRequest request, CancellationToken ct = default);
+	}
+
+	///<summary>
+	/// Indices implementation.
 	/// <para>Not intended to be instantiated directly. Use the <see cref = "IOpenSearchClient.Indices"/> property
 	/// on <see cref = "IOpenSearchClient"/>.
 	///</para>

--- a/src/OpenSearch.Client/_Generated/IOpenSearchClient.cs
+++ b/src/OpenSearch.Client/_Generated/IOpenSearchClient.cs
@@ -84,7 +84,7 @@ namespace OpenSearch.Client
         INodesNamespace Nodes { get; }
 
         /// <summary>Http APIs</summary>
-        HttpNamespace Http { get; }
+        IHttpNamespace Http { get; }
 
         /// <summary>Snapshot APIs</summary>
         ISnapshotNamespace Snapshot { get; }

--- a/src/OpenSearch.Client/_Generated/IOpenSearchClient.cs
+++ b/src/OpenSearch.Client/_Generated/IOpenSearchClient.cs
@@ -66,31 +66,31 @@ namespace OpenSearch.Client
     public partial interface IOpenSearchClient
     {
         /// <summary>Cat APIs</summary>
-        CatNamespace Cat { get; }
+        ICatNamespace Cat { get; }
 
         /// <summary>Cluster APIs</summary>
-        ClusterNamespace Cluster { get; }
+        IClusterNamespace Cluster { get; }
 
         /// <summary>Dangling Indices APIs</summary>
-        DanglingIndicesNamespace DanglingIndices { get; }
+        IDanglingIndicesNamespace DanglingIndices { get; }
 
         /// <summary>Indices APIs</summary>
-        IndicesNamespace Indices { get; }
+        IIndicesNamespace Indices { get; }
 
         /// <summary>Ingest APIs</summary>
-        IngestNamespace Ingest { get; }
+        IIngestNamespace Ingest { get; }
 
         /// <summary>Nodes APIs</summary>
-        NodesNamespace Nodes { get; }
+        INodesNamespace Nodes { get; }
 
         /// <summary>Http APIs</summary>
         HttpNamespace Http { get; }
 
         /// <summary>Snapshot APIs</summary>
-        SnapshotNamespace Snapshot { get; }
+        ISnapshotNamespace Snapshot { get; }
 
         /// <summary>Tasks APIs</summary>
-        TasksNamespace Tasks { get; }
+        ITasksNamespace Tasks { get; }
 
         /// <summary>
         /// <c>POST</c> request to the <c>create_pit</c> API, read more about this API online:

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Cat.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Cat.cs
@@ -53,11 +53,910 @@ namespace OpenSearch.Client.Specification.CatApi
 {
     /// <summary>
     /// Cat APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.Cat"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface ICatNamespace
+    {
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.aliases</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/">https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/</a>
+        /// </summary>
+        CatResponse<CatAliasesRecord> Aliases(
+            Func<CatAliasesDescriptor, ICatAliasesRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.aliases</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/">https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/</a>
+        /// </summary>
+        Task<CatResponse<CatAliasesRecord>> AliasesAsync(
+            Func<CatAliasesDescriptor, ICatAliasesRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.aliases</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/">https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/</a>
+        /// </summary>
+        CatResponse<CatAliasesRecord> Aliases(ICatAliasesRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.aliases</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/">https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/</a>
+        /// </summary>
+        Task<CatResponse<CatAliasesRecord>> AliasesAsync(
+            ICatAliasesRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.all_pit_segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/search-plugins/point-in-time-api/">https://opensearch.org/docs/latest/search-plugins/point-in-time-api/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.4.0 or greater.</remarks>
+        CatResponse<CatAllPitSegmentsRecord> AllPitSegments(
+            Func<CatAllPitSegmentsDescriptor, ICatAllPitSegmentsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.all_pit_segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/search-plugins/point-in-time-api/">https://opensearch.org/docs/latest/search-plugins/point-in-time-api/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.4.0 or greater.</remarks>
+        Task<CatResponse<CatAllPitSegmentsRecord>> AllPitSegmentsAsync(
+            Func<CatAllPitSegmentsDescriptor, ICatAllPitSegmentsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.all_pit_segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/search-plugins/point-in-time-api/">https://opensearch.org/docs/latest/search-plugins/point-in-time-api/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.4.0 or greater.</remarks>
+        CatResponse<CatAllPitSegmentsRecord> AllPitSegments(ICatAllPitSegmentsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.all_pit_segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/search-plugins/point-in-time-api/">https://opensearch.org/docs/latest/search-plugins/point-in-time-api/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.4.0 or greater.</remarks>
+        Task<CatResponse<CatAllPitSegmentsRecord>> AllPitSegmentsAsync(
+            ICatAllPitSegmentsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.allocation</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/">https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/</a>
+        /// </summary>
+        CatResponse<CatAllocationRecord> Allocation(
+            Func<CatAllocationDescriptor, ICatAllocationRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.allocation</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/">https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/</a>
+        /// </summary>
+        Task<CatResponse<CatAllocationRecord>> AllocationAsync(
+            Func<CatAllocationDescriptor, ICatAllocationRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.allocation</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/">https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/</a>
+        /// </summary>
+        CatResponse<CatAllocationRecord> Allocation(ICatAllocationRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.allocation</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/">https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/</a>
+        /// </summary>
+        Task<CatResponse<CatAllocationRecord>> AllocationAsync(
+            ICatAllocationRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.cluster_manager</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        CatResponse<CatClusterManagerRecord> ClusterManager(
+            Func<CatClusterManagerDescriptor, ICatClusterManagerRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.cluster_manager</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        Task<CatResponse<CatClusterManagerRecord>> ClusterManagerAsync(
+            Func<CatClusterManagerDescriptor, ICatClusterManagerRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.cluster_manager</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        CatResponse<CatClusterManagerRecord> ClusterManager(ICatClusterManagerRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.cluster_manager</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.0.0 or greater.</remarks>
+        Task<CatResponse<CatClusterManagerRecord>> ClusterManagerAsync(
+            ICatClusterManagerRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.count</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-count/">https://opensearch.org/docs/latest/api-reference/cat/cat-count/</a>
+        /// </summary>
+        CatResponse<CatCountRecord> Count(
+            Func<CatCountDescriptor, ICatCountRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.count</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-count/">https://opensearch.org/docs/latest/api-reference/cat/cat-count/</a>
+        /// </summary>
+        Task<CatResponse<CatCountRecord>> CountAsync(
+            Func<CatCountDescriptor, ICatCountRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.count</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-count/">https://opensearch.org/docs/latest/api-reference/cat/cat-count/</a>
+        /// </summary>
+        CatResponse<CatCountRecord> Count(ICatCountRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.count</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-count/">https://opensearch.org/docs/latest/api-reference/cat/cat-count/</a>
+        /// </summary>
+        Task<CatResponse<CatCountRecord>> CountAsync(
+            ICatCountRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.fielddata</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/">https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/</a>
+        /// </summary>
+        CatResponse<CatFielddataRecord> Fielddata(
+            Func<CatFielddataDescriptor, ICatFielddataRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.fielddata</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/">https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/</a>
+        /// </summary>
+        Task<CatResponse<CatFielddataRecord>> FielddataAsync(
+            Func<CatFielddataDescriptor, ICatFielddataRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.fielddata</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/">https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/</a>
+        /// </summary>
+        CatResponse<CatFielddataRecord> Fielddata(ICatFielddataRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.fielddata</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/">https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/</a>
+        /// </summary>
+        Task<CatResponse<CatFielddataRecord>> FielddataAsync(
+            ICatFielddataRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.health</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-health/">https://opensearch.org/docs/latest/api-reference/cat/cat-health/</a>
+        /// </summary>
+        CatResponse<CatHealthRecord> Health(
+            Func<CatHealthDescriptor, ICatHealthRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.health</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-health/">https://opensearch.org/docs/latest/api-reference/cat/cat-health/</a>
+        /// </summary>
+        Task<CatResponse<CatHealthRecord>> HealthAsync(
+            Func<CatHealthDescriptor, ICatHealthRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.health</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-health/">https://opensearch.org/docs/latest/api-reference/cat/cat-health/</a>
+        /// </summary>
+        CatResponse<CatHealthRecord> Health(ICatHealthRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.health</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-health/">https://opensearch.org/docs/latest/api-reference/cat/cat-health/</a>
+        /// </summary>
+        Task<CatResponse<CatHealthRecord>> HealthAsync(
+            ICatHealthRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.help</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/index/">https://opensearch.org/docs/latest/api-reference/cat/index/</a>
+        /// </summary>
+        CatResponse<CatHelpRecord> Help(Func<CatHelpDescriptor, ICatHelpRequest> selector = null);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.help</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/index/">https://opensearch.org/docs/latest/api-reference/cat/index/</a>
+        /// </summary>
+        Task<CatResponse<CatHelpRecord>> HelpAsync(
+            Func<CatHelpDescriptor, ICatHelpRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.help</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/index/">https://opensearch.org/docs/latest/api-reference/cat/index/</a>
+        /// </summary>
+        CatResponse<CatHelpRecord> Help(ICatHelpRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.help</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/index/">https://opensearch.org/docs/latest/api-reference/cat/index/</a>
+        /// </summary>
+        Task<CatResponse<CatHelpRecord>> HelpAsync(
+            ICatHelpRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.indices</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-indices/">https://opensearch.org/docs/latest/api-reference/cat/cat-indices/</a>
+        /// </summary>
+        CatResponse<CatIndicesRecord> Indices(
+            Func<CatIndicesDescriptor, ICatIndicesRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.indices</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-indices/">https://opensearch.org/docs/latest/api-reference/cat/cat-indices/</a>
+        /// </summary>
+        Task<CatResponse<CatIndicesRecord>> IndicesAsync(
+            Func<CatIndicesDescriptor, ICatIndicesRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.indices</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-indices/">https://opensearch.org/docs/latest/api-reference/cat/cat-indices/</a>
+        /// </summary>
+        CatResponse<CatIndicesRecord> Indices(ICatIndicesRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.indices</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-indices/">https://opensearch.org/docs/latest/api-reference/cat/cat-indices/</a>
+        /// </summary>
+        Task<CatResponse<CatIndicesRecord>> IndicesAsync(
+            ICatIndicesRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/</a>
+        /// </summary>
+        [Obsolete(
+            "Deprecated as of: 2.0, reason: To promote inclusive language, please use '/_cat/cluster_manager' instead."
+        )]
+        CatResponse<CatMasterRecord> Master(
+            Func<CatMasterDescriptor, ICatMasterRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/</a>
+        /// </summary>
+        [Obsolete(
+            "Deprecated as of: 2.0, reason: To promote inclusive language, please use '/_cat/cluster_manager' instead."
+        )]
+        Task<CatResponse<CatMasterRecord>> MasterAsync(
+            Func<CatMasterDescriptor, ICatMasterRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/</a>
+        /// </summary>
+        [Obsolete(
+            "Deprecated as of: 2.0, reason: To promote inclusive language, please use '/_cat/cluster_manager' instead."
+        )]
+        CatResponse<CatMasterRecord> Master(ICatMasterRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/</a>
+        /// </summary>
+        [Obsolete(
+            "Deprecated as of: 2.0, reason: To promote inclusive language, please use '/_cat/cluster_manager' instead."
+        )]
+        Task<CatResponse<CatMasterRecord>> MasterAsync(
+            ICatMasterRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.nodeattrs</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/">https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/</a>
+        /// </summary>
+        CatResponse<CatNodeAttributesRecord> NodeAttributes(
+            Func<CatNodeAttributesDescriptor, ICatNodeAttributesRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.nodeattrs</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/">https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/</a>
+        /// </summary>
+        Task<CatResponse<CatNodeAttributesRecord>> NodeAttributesAsync(
+            Func<CatNodeAttributesDescriptor, ICatNodeAttributesRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.nodeattrs</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/">https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/</a>
+        /// </summary>
+        CatResponse<CatNodeAttributesRecord> NodeAttributes(ICatNodeAttributesRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.nodeattrs</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/">https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/</a>
+        /// </summary>
+        Task<CatResponse<CatNodeAttributesRecord>> NodeAttributesAsync(
+            ICatNodeAttributesRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.nodes</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/">https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/</a>
+        /// </summary>
+        CatResponse<CatNodesRecord> Nodes(
+            Func<CatNodesDescriptor, ICatNodesRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.nodes</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/">https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/</a>
+        /// </summary>
+        Task<CatResponse<CatNodesRecord>> NodesAsync(
+            Func<CatNodesDescriptor, ICatNodesRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.nodes</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/">https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/</a>
+        /// </summary>
+        CatResponse<CatNodesRecord> Nodes(ICatNodesRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.nodes</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/">https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/</a>
+        /// </summary>
+        Task<CatResponse<CatNodesRecord>> NodesAsync(
+            ICatNodesRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.pending_tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/">https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/</a>
+        /// </summary>
+        CatResponse<CatPendingTasksRecord> PendingTasks(
+            Func<CatPendingTasksDescriptor, ICatPendingTasksRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.pending_tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/">https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/</a>
+        /// </summary>
+        Task<CatResponse<CatPendingTasksRecord>> PendingTasksAsync(
+            Func<CatPendingTasksDescriptor, ICatPendingTasksRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.pending_tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/">https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/</a>
+        /// </summary>
+        CatResponse<CatPendingTasksRecord> PendingTasks(ICatPendingTasksRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.pending_tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/">https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/</a>
+        /// </summary>
+        Task<CatResponse<CatPendingTasksRecord>> PendingTasksAsync(
+            ICatPendingTasksRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.pit_segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/search-plugins/point-in-time-api/">https://opensearch.org/docs/latest/search-plugins/point-in-time-api/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.4.0 or greater.</remarks>
+        CatResponse<CatPitSegmentsRecord> PitSegments(
+            Func<CatPitSegmentsDescriptor, ICatPitSegmentsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.pit_segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/search-plugins/point-in-time-api/">https://opensearch.org/docs/latest/search-plugins/point-in-time-api/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.4.0 or greater.</remarks>
+        Task<CatResponse<CatPitSegmentsRecord>> PitSegmentsAsync(
+            Func<CatPitSegmentsDescriptor, ICatPitSegmentsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.pit_segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/search-plugins/point-in-time-api/">https://opensearch.org/docs/latest/search-plugins/point-in-time-api/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.4.0 or greater.</remarks>
+        CatResponse<CatPitSegmentsRecord> PitSegments(ICatPitSegmentsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.pit_segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/search-plugins/point-in-time-api/">https://opensearch.org/docs/latest/search-plugins/point-in-time-api/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.4.0 or greater.</remarks>
+        Task<CatResponse<CatPitSegmentsRecord>> PitSegmentsAsync(
+            ICatPitSegmentsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.plugins</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/">https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/</a>
+        /// </summary>
+        CatResponse<CatPluginsRecord> Plugins(
+            Func<CatPluginsDescriptor, ICatPluginsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.plugins</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/">https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/</a>
+        /// </summary>
+        Task<CatResponse<CatPluginsRecord>> PluginsAsync(
+            Func<CatPluginsDescriptor, ICatPluginsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.plugins</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/">https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/</a>
+        /// </summary>
+        CatResponse<CatPluginsRecord> Plugins(ICatPluginsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.plugins</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/">https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/</a>
+        /// </summary>
+        Task<CatResponse<CatPluginsRecord>> PluginsAsync(
+            ICatPluginsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.recovery</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/">https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/</a>
+        /// </summary>
+        CatResponse<CatRecoveryRecord> Recovery(
+            Func<CatRecoveryDescriptor, ICatRecoveryRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.recovery</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/">https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/</a>
+        /// </summary>
+        Task<CatResponse<CatRecoveryRecord>> RecoveryAsync(
+            Func<CatRecoveryDescriptor, ICatRecoveryRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.recovery</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/">https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/</a>
+        /// </summary>
+        CatResponse<CatRecoveryRecord> Recovery(ICatRecoveryRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.recovery</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/">https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/</a>
+        /// </summary>
+        Task<CatResponse<CatRecoveryRecord>> RecoveryAsync(
+            ICatRecoveryRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.repositories</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/">https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/</a>
+        /// </summary>
+        CatResponse<CatRepositoriesRecord> Repositories(
+            Func<CatRepositoriesDescriptor, ICatRepositoriesRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.repositories</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/">https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/</a>
+        /// </summary>
+        Task<CatResponse<CatRepositoriesRecord>> RepositoriesAsync(
+            Func<CatRepositoriesDescriptor, ICatRepositoriesRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.repositories</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/">https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/</a>
+        /// </summary>
+        CatResponse<CatRepositoriesRecord> Repositories(ICatRepositoriesRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.repositories</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/">https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/</a>
+        /// </summary>
+        Task<CatResponse<CatRepositoriesRecord>> RepositoriesAsync(
+            ICatRepositoriesRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.segment_replication</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-segment-replication/">https://opensearch.org/docs/latest/api-reference/cat/cat-segment-replication/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.6.0 or greater.</remarks>
+        CatResponse<CatSegmentReplicationRecord> SegmentReplication(
+            Func<CatSegmentReplicationDescriptor, ICatSegmentReplicationRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.segment_replication</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-segment-replication/">https://opensearch.org/docs/latest/api-reference/cat/cat-segment-replication/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.6.0 or greater.</remarks>
+        Task<CatResponse<CatSegmentReplicationRecord>> SegmentReplicationAsync(
+            Func<CatSegmentReplicationDescriptor, ICatSegmentReplicationRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.segment_replication</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-segment-replication/">https://opensearch.org/docs/latest/api-reference/cat/cat-segment-replication/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.6.0 or greater.</remarks>
+        CatResponse<CatSegmentReplicationRecord> SegmentReplication(
+            ICatSegmentReplicationRequest request
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.segment_replication</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-segment-replication/">https://opensearch.org/docs/latest/api-reference/cat/cat-segment-replication/</a>
+        /// </summary>
+        /// <remarks>Supported by OpenSearch servers of version 2.6.0 or greater.</remarks>
+        Task<CatResponse<CatSegmentReplicationRecord>> SegmentReplicationAsync(
+            ICatSegmentReplicationRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-segments/">https://opensearch.org/docs/latest/api-reference/cat/cat-segments/</a>
+        /// </summary>
+        CatResponse<CatSegmentsRecord> Segments(
+            Func<CatSegmentsDescriptor, ICatSegmentsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-segments/">https://opensearch.org/docs/latest/api-reference/cat/cat-segments/</a>
+        /// </summary>
+        Task<CatResponse<CatSegmentsRecord>> SegmentsAsync(
+            Func<CatSegmentsDescriptor, ICatSegmentsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-segments/">https://opensearch.org/docs/latest/api-reference/cat/cat-segments/</a>
+        /// </summary>
+        CatResponse<CatSegmentsRecord> Segments(ICatSegmentsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.segments</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-segments/">https://opensearch.org/docs/latest/api-reference/cat/cat-segments/</a>
+        /// </summary>
+        Task<CatResponse<CatSegmentsRecord>> SegmentsAsync(
+            ICatSegmentsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.shards</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-shards/">https://opensearch.org/docs/latest/api-reference/cat/cat-shards/</a>
+        /// </summary>
+        CatResponse<CatShardsRecord> Shards(
+            Func<CatShardsDescriptor, ICatShardsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.shards</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-shards/">https://opensearch.org/docs/latest/api-reference/cat/cat-shards/</a>
+        /// </summary>
+        Task<CatResponse<CatShardsRecord>> ShardsAsync(
+            Func<CatShardsDescriptor, ICatShardsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.shards</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-shards/">https://opensearch.org/docs/latest/api-reference/cat/cat-shards/</a>
+        /// </summary>
+        CatResponse<CatShardsRecord> Shards(ICatShardsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.shards</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-shards/">https://opensearch.org/docs/latest/api-reference/cat/cat-shards/</a>
+        /// </summary>
+        Task<CatResponse<CatShardsRecord>> ShardsAsync(
+            ICatShardsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.snapshots</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/">https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/</a>
+        /// </summary>
+        CatResponse<CatSnapshotsRecord> Snapshots(
+            Func<CatSnapshotsDescriptor, ICatSnapshotsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.snapshots</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/">https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/</a>
+        /// </summary>
+        Task<CatResponse<CatSnapshotsRecord>> SnapshotsAsync(
+            Func<CatSnapshotsDescriptor, ICatSnapshotsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.snapshots</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/">https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/</a>
+        /// </summary>
+        CatResponse<CatSnapshotsRecord> Snapshots(ICatSnapshotsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.snapshots</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/">https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/</a>
+        /// </summary>
+        Task<CatResponse<CatSnapshotsRecord>> SnapshotsAsync(
+            ICatSnapshotsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/">https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/</a>
+        /// </summary>
+        CatResponse<CatTasksRecord> Tasks(
+            Func<CatTasksDescriptor, ICatTasksRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/">https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/</a>
+        /// </summary>
+        Task<CatResponse<CatTasksRecord>> TasksAsync(
+            Func<CatTasksDescriptor, ICatTasksRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/">https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/</a>
+        /// </summary>
+        CatResponse<CatTasksRecord> Tasks(ICatTasksRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/">https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/</a>
+        /// </summary>
+        Task<CatResponse<CatTasksRecord>> TasksAsync(
+            ICatTasksRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.templates</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-templates/">https://opensearch.org/docs/latest/api-reference/cat/cat-templates/</a>
+        /// </summary>
+        CatResponse<CatTemplatesRecord> Templates(
+            Func<CatTemplatesDescriptor, ICatTemplatesRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.templates</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-templates/">https://opensearch.org/docs/latest/api-reference/cat/cat-templates/</a>
+        /// </summary>
+        Task<CatResponse<CatTemplatesRecord>> TemplatesAsync(
+            Func<CatTemplatesDescriptor, ICatTemplatesRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.templates</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-templates/">https://opensearch.org/docs/latest/api-reference/cat/cat-templates/</a>
+        /// </summary>
+        CatResponse<CatTemplatesRecord> Templates(ICatTemplatesRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.templates</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-templates/">https://opensearch.org/docs/latest/api-reference/cat/cat-templates/</a>
+        /// </summary>
+        Task<CatResponse<CatTemplatesRecord>> TemplatesAsync(
+            ICatTemplatesRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.thread_pool</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/">https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/</a>
+        /// </summary>
+        CatResponse<CatThreadPoolRecord> ThreadPool(
+            Func<CatThreadPoolDescriptor, ICatThreadPoolRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.thread_pool</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/">https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/</a>
+        /// </summary>
+        Task<CatResponse<CatThreadPoolRecord>> ThreadPoolAsync(
+            Func<CatThreadPoolDescriptor, ICatThreadPoolRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.thread_pool</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/">https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/</a>
+        /// </summary>
+        CatResponse<CatThreadPoolRecord> ThreadPool(ICatThreadPoolRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cat.thread_pool</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/">https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/</a>
+        /// </summary>
+        Task<CatResponse<CatThreadPoolRecord>> ThreadPoolAsync(
+            ICatThreadPoolRequest request,
+            CancellationToken ct = default
+        );
+    }
+
+    /// <summary>
+    /// Cat implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Cat"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class CatNamespace : NamespacedClientProxy
+    public partial class CatNamespace : NamespacedClientProxy, ICatNamespace
     {
         internal CatNamespace(OpenSearchClient client)
             : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Cluster.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Cluster.cs
@@ -53,11 +53,594 @@ namespace OpenSearch.Client.Specification.ClusterApi
 {
     /// <summary>
     /// Cluster APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.Cluster"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface IClusterNamespace
+    {
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.allocation_explain</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</a>
+        /// </summary>
+        ClusterAllocationExplainResponse AllocationExplain(
+            Func<ClusterAllocationExplainDescriptor, IClusterAllocationExplainRequest> selector =
+                null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.allocation_explain</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</a>
+        /// </summary>
+        Task<ClusterAllocationExplainResponse> AllocationExplainAsync(
+            Func<ClusterAllocationExplainDescriptor, IClusterAllocationExplainRequest> selector =
+                null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.allocation_explain</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</a>
+        /// </summary>
+        ClusterAllocationExplainResponse AllocationExplain(
+            IClusterAllocationExplainRequest request
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.allocation_explain</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-allocation/</a>
+        /// </summary>
+        Task<ClusterAllocationExplainResponse> AllocationExplainAsync(
+            IClusterAllocationExplainRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>cluster.delete_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        DeleteComponentTemplateResponse DeleteComponentTemplate(
+            Name name,
+            Func<DeleteComponentTemplateDescriptor, IDeleteComponentTemplateRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>cluster.delete_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<DeleteComponentTemplateResponse> DeleteComponentTemplateAsync(
+            Name name,
+            Func<DeleteComponentTemplateDescriptor, IDeleteComponentTemplateRequest> selector =
+                null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>cluster.delete_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        DeleteComponentTemplateResponse DeleteComponentTemplate(
+            IDeleteComponentTemplateRequest request
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>cluster.delete_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<DeleteComponentTemplateResponse> DeleteComponentTemplateAsync(
+            IDeleteComponentTemplateRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>cluster.delete_voting_config_exclusions</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        DeleteVotingConfigExclusionsResponse DeleteVotingConfigExclusions(
+            Func<
+                DeleteVotingConfigExclusionsDescriptor,
+                IDeleteVotingConfigExclusionsRequest
+            > selector = null
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>cluster.delete_voting_config_exclusions</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<DeleteVotingConfigExclusionsResponse> DeleteVotingConfigExclusionsAsync(
+            Func<
+                DeleteVotingConfigExclusionsDescriptor,
+                IDeleteVotingConfigExclusionsRequest
+            > selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>cluster.delete_voting_config_exclusions</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        DeleteVotingConfigExclusionsResponse DeleteVotingConfigExclusions(
+            IDeleteVotingConfigExclusionsRequest request
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>cluster.delete_voting_config_exclusions</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<DeleteVotingConfigExclusionsResponse> DeleteVotingConfigExclusionsAsync(
+            IDeleteVotingConfigExclusionsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>HEAD</c> request to the <c>cluster.exists_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        ExistsResponse ComponentTemplateExists(
+            Name name,
+            Func<ComponentTemplateExistsDescriptor, IComponentTemplateExistsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>HEAD</c> request to the <c>cluster.exists_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<ExistsResponse> ComponentTemplateExistsAsync(
+            Name name,
+            Func<ComponentTemplateExistsDescriptor, IComponentTemplateExistsRequest> selector =
+                null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>HEAD</c> request to the <c>cluster.exists_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        ExistsResponse ComponentTemplateExists(IComponentTemplateExistsRequest request);
+
+        /// <summary>
+        /// <c>HEAD</c> request to the <c>cluster.exists_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<ExistsResponse> ComponentTemplateExistsAsync(
+            IComponentTemplateExistsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.get_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        GetComponentTemplateResponse GetComponentTemplate(
+            Name name = null,
+            Func<GetComponentTemplateDescriptor, IGetComponentTemplateRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.get_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<GetComponentTemplateResponse> GetComponentTemplateAsync(
+            Name name = null,
+            Func<GetComponentTemplateDescriptor, IGetComponentTemplateRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.get_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        GetComponentTemplateResponse GetComponentTemplate(IGetComponentTemplateRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.get_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<GetComponentTemplateResponse> GetComponentTemplateAsync(
+            IGetComponentTemplateRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.get_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</a>
+        /// </summary>
+        ClusterGetSettingsResponse GetSettings(
+            Func<ClusterGetSettingsDescriptor, IClusterGetSettingsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.get_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</a>
+        /// </summary>
+        Task<ClusterGetSettingsResponse> GetSettingsAsync(
+            Func<ClusterGetSettingsDescriptor, IClusterGetSettingsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.get_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</a>
+        /// </summary>
+        ClusterGetSettingsResponse GetSettings(IClusterGetSettingsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.get_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/</a>
+        /// </summary>
+        Task<ClusterGetSettingsResponse> GetSettingsAsync(
+            IClusterGetSettingsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.health</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</a>
+        /// </summary>
+        ClusterHealthResponse Health(
+            Indices index = null,
+            Func<ClusterHealthDescriptor, IClusterHealthRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.health</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</a>
+        /// </summary>
+        Task<ClusterHealthResponse> HealthAsync(
+            Indices index = null,
+            Func<ClusterHealthDescriptor, IClusterHealthRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.health</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</a>
+        /// </summary>
+        ClusterHealthResponse Health(IClusterHealthRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.health</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-health/</a>
+        /// </summary>
+        Task<ClusterHealthResponse> HealthAsync(
+            IClusterHealthRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.pending_tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        ClusterPendingTasksResponse PendingTasks(
+            Func<ClusterPendingTasksDescriptor, IClusterPendingTasksRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.pending_tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<ClusterPendingTasksResponse> PendingTasksAsync(
+            Func<ClusterPendingTasksDescriptor, IClusterPendingTasksRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.pending_tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        ClusterPendingTasksResponse PendingTasks(IClusterPendingTasksRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.pending_tasks</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<ClusterPendingTasksResponse> PendingTasksAsync(
+            IClusterPendingTasksRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.post_voting_config_exclusions</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        PostVotingConfigExclusionsResponse PostVotingConfigExclusions(
+            Func<
+                PostVotingConfigExclusionsDescriptor,
+                IPostVotingConfigExclusionsRequest
+            > selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.post_voting_config_exclusions</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<PostVotingConfigExclusionsResponse> PostVotingConfigExclusionsAsync(
+            Func<
+                PostVotingConfigExclusionsDescriptor,
+                IPostVotingConfigExclusionsRequest
+            > selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.post_voting_config_exclusions</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        PostVotingConfigExclusionsResponse PostVotingConfigExclusions(
+            IPostVotingConfigExclusionsRequest request
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.post_voting_config_exclusions</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<PostVotingConfigExclusionsResponse> PostVotingConfigExclusionsAsync(
+            IPostVotingConfigExclusionsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>cluster.put_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        PutComponentTemplateResponse PutComponentTemplate(
+            Name name,
+            Func<PutComponentTemplateDescriptor, IPutComponentTemplateRequest> selector
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>cluster.put_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        Task<PutComponentTemplateResponse> PutComponentTemplateAsync(
+            Name name,
+            Func<PutComponentTemplateDescriptor, IPutComponentTemplateRequest> selector,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>cluster.put_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        PutComponentTemplateResponse PutComponentTemplate(IPutComponentTemplateRequest request);
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>cluster.put_component_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        Task<PutComponentTemplateResponse> PutComponentTemplateAsync(
+            IPutComponentTemplateRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>cluster.put_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-settings/">https://opensearch.org/docs/latest/api-reference/cluster-settings/</a>
+        /// </summary>
+        ClusterPutSettingsResponse PutSettings(
+            Func<ClusterPutSettingsDescriptor, IClusterPutSettingsRequest> selector
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>cluster.put_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-settings/">https://opensearch.org/docs/latest/api-reference/cluster-settings/</a>
+        /// </summary>
+        Task<ClusterPutSettingsResponse> PutSettingsAsync(
+            Func<ClusterPutSettingsDescriptor, IClusterPutSettingsRequest> selector,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>cluster.put_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-settings/">https://opensearch.org/docs/latest/api-reference/cluster-settings/</a>
+        /// </summary>
+        ClusterPutSettingsResponse PutSettings(IClusterPutSettingsRequest request);
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>cluster.put_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-settings/">https://opensearch.org/docs/latest/api-reference/cluster-settings/</a>
+        /// </summary>
+        Task<ClusterPutSettingsResponse> PutSettingsAsync(
+            IClusterPutSettingsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.remote_info</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/remote-info/">https://opensearch.org/docs/latest/api-reference/remote-info/</a>
+        /// </summary>
+        RemoteInfoResponse RemoteInfo(
+            Func<RemoteInfoDescriptor, IRemoteInfoRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.remote_info</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/remote-info/">https://opensearch.org/docs/latest/api-reference/remote-info/</a>
+        /// </summary>
+        Task<RemoteInfoResponse> RemoteInfoAsync(
+            Func<RemoteInfoDescriptor, IRemoteInfoRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.remote_info</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/remote-info/">https://opensearch.org/docs/latest/api-reference/remote-info/</a>
+        /// </summary>
+        RemoteInfoResponse RemoteInfo(IRemoteInfoRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.remote_info</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/remote-info/">https://opensearch.org/docs/latest/api-reference/remote-info/</a>
+        /// </summary>
+        Task<RemoteInfoResponse> RemoteInfoAsync(
+            IRemoteInfoRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.reroute</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        ClusterRerouteResponse Reroute(
+            Func<ClusterRerouteDescriptor, IClusterRerouteRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.reroute</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<ClusterRerouteResponse> RerouteAsync(
+            Func<ClusterRerouteDescriptor, IClusterRerouteRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.reroute</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        ClusterRerouteResponse Reroute(IClusterRerouteRequest request);
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>cluster.reroute</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<ClusterRerouteResponse> RerouteAsync(
+            IClusterRerouteRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.state</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        ClusterStateResponse State(
+            Indices index = null,
+            Func<ClusterStateDescriptor, IClusterStateRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.state</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<ClusterStateResponse> StateAsync(
+            Indices index = null,
+            Func<ClusterStateDescriptor, IClusterStateRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.state</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        ClusterStateResponse State(IClusterStateRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.state</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<ClusterStateResponse> StateAsync(
+            IClusterStateRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.stats</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/</a>
+        /// </summary>
+        ClusterStatsResponse Stats(
+            Func<ClusterStatsDescriptor, IClusterStatsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.stats</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/</a>
+        /// </summary>
+        Task<ClusterStatsResponse> StatsAsync(
+            Func<ClusterStatsDescriptor, IClusterStatsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.stats</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/</a>
+        /// </summary>
+        ClusterStatsResponse Stats(IClusterStatsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>cluster.stats</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/">https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/</a>
+        /// </summary>
+        Task<ClusterStatsResponse> StatsAsync(
+            IClusterStatsRequest request,
+            CancellationToken ct = default
+        );
+    }
+
+    /// <summary>
+    /// Cluster implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Cluster"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class ClusterNamespace : NamespacedClientProxy
+    public partial class ClusterNamespace : NamespacedClientProxy, IClusterNamespace
     {
         internal ClusterNamespace(OpenSearchClient client)
             : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.DanglingIndices.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.DanglingIndices.cs
@@ -53,11 +53,130 @@ namespace OpenSearch.Client.Specification.DanglingIndicesApi
 {
     /// <summary>
     /// Dangling Indices APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.DanglingIndices"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface IDanglingIndicesNamespace
+    {
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>dangling_indices.delete_dangling_index</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        DeleteDanglingIndexResponse DeleteDanglingIndex(
+            IndexUuid indexUuid,
+            Func<DeleteDanglingIndexDescriptor, IDeleteDanglingIndexRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>dangling_indices.delete_dangling_index</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        Task<DeleteDanglingIndexResponse> DeleteDanglingIndexAsync(
+            IndexUuid indexUuid,
+            Func<DeleteDanglingIndexDescriptor, IDeleteDanglingIndexRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>dangling_indices.delete_dangling_index</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        DeleteDanglingIndexResponse DeleteDanglingIndex(IDeleteDanglingIndexRequest request);
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>dangling_indices.delete_dangling_index</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        Task<DeleteDanglingIndexResponse> DeleteDanglingIndexAsync(
+            IDeleteDanglingIndexRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>dangling_indices.import_dangling_index</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        ImportDanglingIndexResponse ImportDanglingIndex(
+            IndexUuid indexUuid,
+            Func<ImportDanglingIndexDescriptor, IImportDanglingIndexRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>dangling_indices.import_dangling_index</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        Task<ImportDanglingIndexResponse> ImportDanglingIndexAsync(
+            IndexUuid indexUuid,
+            Func<ImportDanglingIndexDescriptor, IImportDanglingIndexRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>dangling_indices.import_dangling_index</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        ImportDanglingIndexResponse ImportDanglingIndex(IImportDanglingIndexRequest request);
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>dangling_indices.import_dangling_index</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        Task<ImportDanglingIndexResponse> ImportDanglingIndexAsync(
+            IImportDanglingIndexRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>dangling_indices.list_dangling_indices</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        ListDanglingIndicesResponse List(
+            Func<ListDanglingIndicesDescriptor, IListDanglingIndicesRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>dangling_indices.list_dangling_indices</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        Task<ListDanglingIndicesResponse> ListAsync(
+            Func<ListDanglingIndicesDescriptor, IListDanglingIndicesRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>dangling_indices.list_dangling_indices</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        ListDanglingIndicesResponse List(IListDanglingIndicesRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>dangling_indices.list_dangling_indices</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/">https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/</a>
+        /// </summary>
+        Task<ListDanglingIndicesResponse> ListAsync(
+            IListDanglingIndicesRequest request,
+            CancellationToken ct = default
+        );
+    }
+
+    /// <summary>
+    /// Dangling Indices implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.DanglingIndices"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class DanglingIndicesNamespace : NamespacedClientProxy
+    public partial class DanglingIndicesNamespace : NamespacedClientProxy, IDanglingIndicesNamespace
     {
         internal DanglingIndicesNamespace(OpenSearchClient client)
             : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Http.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Http.cs
@@ -30,11 +30,129 @@ namespace OpenSearch.Client.Specification.HttpApi;
 
 /// <summary>
 /// Http APIs.
+/// <para>Use the <see cref="IOpenSearchClient.Http"/> property on <see cref="IOpenSearchClient"/>.</para>
+/// </summary>
+public interface IHttpNamespace
+{
+    TResponse Delete<TResponse>(
+        string path,
+        Func<HttpDeleteDescriptor, IHttpDeleteRequest> selector = null
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> DeleteAsync<TResponse>(
+        string path,
+        Func<HttpDeleteDescriptor, IHttpDeleteRequest> selector = null,
+        CancellationToken ct = default
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Delete<TResponse>(IHttpDeleteRequest request)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> DeleteAsync<TResponse>(
+        IHttpDeleteRequest request,
+        CancellationToken ct = default
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Get<TResponse>(string path, Func<HttpGetDescriptor, IHttpGetRequest> selector = null)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> GetAsync<TResponse>(
+        string path,
+        Func<HttpGetDescriptor, IHttpGetRequest> selector = null,
+        CancellationToken ct = default
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Get<TResponse>(IHttpGetRequest request)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> GetAsync<TResponse>(IHttpGetRequest request, CancellationToken ct = default)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Head<TResponse>(
+        string path,
+        Func<HttpHeadDescriptor, IHttpHeadRequest> selector = null
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> HeadAsync<TResponse>(
+        string path,
+        Func<HttpHeadDescriptor, IHttpHeadRequest> selector = null,
+        CancellationToken ct = default
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Head<TResponse>(IHttpHeadRequest request)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> HeadAsync<TResponse>(IHttpHeadRequest request, CancellationToken ct = default)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Patch<TResponse>(
+        string path,
+        Func<HttpPatchDescriptor, IHttpPatchRequest> selector = null
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> PatchAsync<TResponse>(
+        string path,
+        Func<HttpPatchDescriptor, IHttpPatchRequest> selector = null,
+        CancellationToken ct = default
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Patch<TResponse>(IHttpPatchRequest request)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> PatchAsync<TResponse>(IHttpPatchRequest request, CancellationToken ct = default)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Post<TResponse>(
+        string path,
+        Func<HttpPostDescriptor, IHttpPostRequest> selector = null
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> PostAsync<TResponse>(
+        string path,
+        Func<HttpPostDescriptor, IHttpPostRequest> selector = null,
+        CancellationToken ct = default
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Post<TResponse>(IHttpPostRequest request)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> PostAsync<TResponse>(IHttpPostRequest request, CancellationToken ct = default)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Put<TResponse>(string path, Func<HttpPutDescriptor, IHttpPutRequest> selector = null)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> PutAsync<TResponse>(
+        string path,
+        Func<HttpPutDescriptor, IHttpPutRequest> selector = null,
+        CancellationToken ct = default
+    )
+        where TResponse : class, IOpenSearchResponse, new();
+
+    TResponse Put<TResponse>(IHttpPutRequest request)
+        where TResponse : class, IOpenSearchResponse, new();
+
+    Task<TResponse> PutAsync<TResponse>(IHttpPutRequest request, CancellationToken ct = default)
+        where TResponse : class, IOpenSearchResponse, new();
+}
+
+/// <summary>
+/// Http implementation.
 /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Http"/> property
 /// on <see cref="IOpenSearchClient"/>.
 /// </para>
 /// </summary>
-public class HttpNamespace : NamespacedClientProxy
+public class HttpNamespace : NamespacedClientProxy, IHttpNamespace
 {
     internal HttpNamespace(OpenSearchClient client)
         : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Indices.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Indices.cs
@@ -53,11 +53,194 @@ namespace OpenSearch.Client.Specification.IndicesApi
 {
     /// <summary>
     /// Indices APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.Indices"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface IIndicesNamespace
+    {
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>indices.delete_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/#delete-a-template">https://opensearch.org/docs/latest/im-plugin/index-templates/#delete-a-template</a>
+        /// </summary>
+        DeleteComposableIndexTemplateResponse DeleteComposableTemplate(
+            Name name,
+            Func<
+                DeleteComposableIndexTemplateDescriptor,
+                IDeleteComposableIndexTemplateRequest
+            > selector = null
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>indices.delete_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/#delete-a-template">https://opensearch.org/docs/latest/im-plugin/index-templates/#delete-a-template</a>
+        /// </summary>
+        Task<DeleteComposableIndexTemplateResponse> DeleteComposableTemplateAsync(
+            Name name,
+            Func<
+                DeleteComposableIndexTemplateDescriptor,
+                IDeleteComposableIndexTemplateRequest
+            > selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>indices.delete_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/#delete-a-template">https://opensearch.org/docs/latest/im-plugin/index-templates/#delete-a-template</a>
+        /// </summary>
+        DeleteComposableIndexTemplateResponse DeleteComposableTemplate(
+            IDeleteComposableIndexTemplateRequest request
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>indices.delete_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/#delete-a-template">https://opensearch.org/docs/latest/im-plugin/index-templates/#delete-a-template</a>
+        /// </summary>
+        Task<DeleteComposableIndexTemplateResponse> DeleteComposableTemplateAsync(
+            IDeleteComposableIndexTemplateRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>HEAD</c> request to the <c>indices.exists_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/">https://opensearch.org/docs/latest/im-plugin/index-templates/</a>
+        /// </summary>
+        ExistsResponse ComposableTemplateExists(
+            Name name,
+            Func<
+                ComposableIndexTemplateExistsDescriptor,
+                IComposableIndexTemplateExistsRequest
+            > selector = null
+        );
+
+        /// <summary>
+        /// <c>HEAD</c> request to the <c>indices.exists_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/">https://opensearch.org/docs/latest/im-plugin/index-templates/</a>
+        /// </summary>
+        Task<ExistsResponse> ComposableTemplateExistsAsync(
+            Name name,
+            Func<
+                ComposableIndexTemplateExistsDescriptor,
+                IComposableIndexTemplateExistsRequest
+            > selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>HEAD</c> request to the <c>indices.exists_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/">https://opensearch.org/docs/latest/im-plugin/index-templates/</a>
+        /// </summary>
+        ExistsResponse ComposableTemplateExists(IComposableIndexTemplateExistsRequest request);
+
+        /// <summary>
+        /// <c>HEAD</c> request to the <c>indices.exists_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/">https://opensearch.org/docs/latest/im-plugin/index-templates/</a>
+        /// </summary>
+        Task<ExistsResponse> ComposableTemplateExistsAsync(
+            IComposableIndexTemplateExistsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>indices.get_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/">https://opensearch.org/docs/latest/im-plugin/index-templates/</a>
+        /// </summary>
+        GetComposableIndexTemplateResponse GetComposableTemplate(
+            Name name = null,
+            Func<
+                GetComposableIndexTemplateDescriptor,
+                IGetComposableIndexTemplateRequest
+            > selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>indices.get_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/">https://opensearch.org/docs/latest/im-plugin/index-templates/</a>
+        /// </summary>
+        Task<GetComposableIndexTemplateResponse> GetComposableTemplateAsync(
+            Name name = null,
+            Func<
+                GetComposableIndexTemplateDescriptor,
+                IGetComposableIndexTemplateRequest
+            > selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>indices.get_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/">https://opensearch.org/docs/latest/im-plugin/index-templates/</a>
+        /// </summary>
+        GetComposableIndexTemplateResponse GetComposableTemplate(
+            IGetComposableIndexTemplateRequest request
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>indices.get_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/im-plugin/index-templates/">https://opensearch.org/docs/latest/im-plugin/index-templates/</a>
+        /// </summary>
+        Task<GetComposableIndexTemplateResponse> GetComposableTemplateAsync(
+            IGetComposableIndexTemplateRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>indices.put_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        PutComposableIndexTemplateResponse PutComposableTemplate(
+            Name name,
+            Func<PutComposableIndexTemplateDescriptor, IPutComposableIndexTemplateRequest> selector
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>indices.put_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        Task<PutComposableIndexTemplateResponse> PutComposableTemplateAsync(
+            Name name,
+            Func<PutComposableIndexTemplateDescriptor, IPutComposableIndexTemplateRequest> selector,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>indices.put_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        PutComposableIndexTemplateResponse PutComposableTemplate(
+            IPutComposableIndexTemplateRequest request
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>indices.put_index_template</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        Task<PutComposableIndexTemplateResponse> PutComposableTemplateAsync(
+            IPutComposableIndexTemplateRequest request,
+            CancellationToken ct = default
+        );
+    }
+
+    /// <summary>
+    /// Indices implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Indices"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class IndicesNamespace : NamespacedClientProxy
+    public partial class IndicesNamespace : NamespacedClientProxy, IIndicesNamespace
     {
         internal IndicesNamespace(OpenSearchClient client)
             : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Ingest.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Ingest.cs
@@ -53,11 +53,202 @@ namespace OpenSearch.Client.Specification.IngestApi
 {
     /// <summary>
     /// Ingest APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.Ingest"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface IIngestNamespace
+    {
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>ingest.delete_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</a>
+        /// </summary>
+        DeletePipelineResponse DeletePipeline(
+            Id id,
+            Func<DeletePipelineDescriptor, IDeletePipelineRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>ingest.delete_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</a>
+        /// </summary>
+        Task<DeletePipelineResponse> DeletePipelineAsync(
+            Id id,
+            Func<DeletePipelineDescriptor, IDeletePipelineRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>ingest.delete_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</a>
+        /// </summary>
+        DeletePipelineResponse DeletePipeline(IDeletePipelineRequest request);
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>ingest.delete_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/</a>
+        /// </summary>
+        Task<DeletePipelineResponse> DeletePipelineAsync(
+            IDeletePipelineRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>ingest.get_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</a>
+        /// </summary>
+        GetPipelineResponse GetPipeline(
+            Func<GetPipelineDescriptor, IGetPipelineRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>ingest.get_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</a>
+        /// </summary>
+        Task<GetPipelineResponse> GetPipelineAsync(
+            Func<GetPipelineDescriptor, IGetPipelineRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>ingest.get_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</a>
+        /// </summary>
+        GetPipelineResponse GetPipeline(IGetPipelineRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>ingest.get_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/</a>
+        /// </summary>
+        Task<GetPipelineResponse> GetPipelineAsync(
+            IGetPipelineRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>ingest.processor_grok</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        GrokProcessorPatternsResponse GrokProcessorPatterns(
+            Func<GrokProcessorPatternsDescriptor, IGrokProcessorPatternsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>ingest.processor_grok</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<GrokProcessorPatternsResponse> GrokProcessorPatternsAsync(
+            Func<GrokProcessorPatternsDescriptor, IGrokProcessorPatternsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>ingest.processor_grok</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        GrokProcessorPatternsResponse GrokProcessorPatterns(IGrokProcessorPatternsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>ingest.processor_grok</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<GrokProcessorPatternsResponse> GrokProcessorPatternsAsync(
+            IGrokProcessorPatternsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>ingest.put_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</a>
+        /// </summary>
+        PutPipelineResponse PutPipeline(
+            Id id,
+            Func<PutPipelineDescriptor, IPutPipelineRequest> selector
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>ingest.put_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</a>
+        /// </summary>
+        Task<PutPipelineResponse> PutPipelineAsync(
+            Id id,
+            Func<PutPipelineDescriptor, IPutPipelineRequest> selector,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>ingest.put_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</a>
+        /// </summary>
+        PutPipelineResponse PutPipeline(IPutPipelineRequest request);
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>ingest.put_pipeline</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/</a>
+        /// </summary>
+        Task<PutPipelineResponse> PutPipelineAsync(
+            IPutPipelineRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>ingest.simulate</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</a>
+        /// </summary>
+        SimulatePipelineResponse SimulatePipeline(
+            Func<SimulatePipelineDescriptor, ISimulatePipelineRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>ingest.simulate</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</a>
+        /// </summary>
+        Task<SimulatePipelineResponse> SimulatePipelineAsync(
+            Func<SimulatePipelineDescriptor, ISimulatePipelineRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>ingest.simulate</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</a>
+        /// </summary>
+        SimulatePipelineResponse SimulatePipeline(ISimulatePipelineRequest request);
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>ingest.simulate</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/">https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/</a>
+        /// </summary>
+        Task<SimulatePipelineResponse> SimulatePipelineAsync(
+            ISimulatePipelineRequest request,
+            CancellationToken ct = default
+        );
+    }
+
+    /// <summary>
+    /// Ingest implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Ingest"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class IngestNamespace : NamespacedClientProxy
+    public partial class IngestNamespace : NamespacedClientProxy, IIngestNamespace
     {
         internal IngestNamespace(OpenSearchClient client)
             : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Nodes.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Nodes.cs
@@ -53,11 +53,192 @@ namespace OpenSearch.Client.Specification.NodesApi
 {
     /// <summary>
     /// Nodes APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.Nodes"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface INodesNamespace
+    {
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.hot_threads</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</a>
+        /// </summary>
+        NodesHotThreadsResponse HotThreads(
+            Func<NodesHotThreadsDescriptor, INodesHotThreadsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.hot_threads</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</a>
+        /// </summary>
+        Task<NodesHotThreadsResponse> HotThreadsAsync(
+            Func<NodesHotThreadsDescriptor, INodesHotThreadsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.hot_threads</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</a>
+        /// </summary>
+        NodesHotThreadsResponse HotThreads(INodesHotThreadsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.hot_threads</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/</a>
+        /// </summary>
+        Task<NodesHotThreadsResponse> HotThreadsAsync(
+            INodesHotThreadsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.info</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</a>
+        /// </summary>
+        NodesInfoResponse Info(Func<NodesInfoDescriptor, INodesInfoRequest> selector = null);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.info</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</a>
+        /// </summary>
+        Task<NodesInfoResponse> InfoAsync(
+            Func<NodesInfoDescriptor, INodesInfoRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.info</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</a>
+        /// </summary>
+        NodesInfoResponse Info(INodesInfoRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.info</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/</a>
+        /// </summary>
+        Task<NodesInfoResponse> InfoAsync(
+            INodesInfoRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>nodes.reload_secure_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</a>
+        /// </summary>
+        ReloadSecureSettingsResponse ReloadSecureSettings(
+            Func<ReloadSecureSettingsDescriptor, IReloadSecureSettingsRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>nodes.reload_secure_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</a>
+        /// </summary>
+        Task<ReloadSecureSettingsResponse> ReloadSecureSettingsAsync(
+            Func<ReloadSecureSettingsDescriptor, IReloadSecureSettingsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>nodes.reload_secure_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</a>
+        /// </summary>
+        ReloadSecureSettingsResponse ReloadSecureSettings(IReloadSecureSettingsRequest request);
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>nodes.reload_secure_settings</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/</a>
+        /// </summary>
+        Task<ReloadSecureSettingsResponse> ReloadSecureSettingsAsync(
+            IReloadSecureSettingsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.stats</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</a>
+        /// </summary>
+        NodesStatsResponse Stats(Func<NodesStatsDescriptor, INodesStatsRequest> selector = null);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.stats</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</a>
+        /// </summary>
+        Task<NodesStatsResponse> StatsAsync(
+            Func<NodesStatsDescriptor, INodesStatsRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.stats</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</a>
+        /// </summary>
+        NodesStatsResponse Stats(INodesStatsRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.stats</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/">https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/</a>
+        /// </summary>
+        Task<NodesStatsResponse> StatsAsync(
+            INodesStatsRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.usage</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        NodesUsageResponse Usage(Func<NodesUsageDescriptor, INodesUsageRequest> selector = null);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.usage</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<NodesUsageResponse> UsageAsync(
+            Func<NodesUsageDescriptor, INodesUsageRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.usage</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        NodesUsageResponse Usage(INodesUsageRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>nodes.usage</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<NodesUsageResponse> UsageAsync(
+            INodesUsageRequest request,
+            CancellationToken ct = default
+        );
+    }
+
+    /// <summary>
+    /// Nodes implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Nodes"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class NodesNamespace : NamespacedClientProxy
+    public partial class NodesNamespace : NamespacedClientProxy, INodesNamespace
     {
         internal NodesNamespace(OpenSearchClient client)
             : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Snapshot.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Snapshot.cs
@@ -53,11 +53,441 @@ namespace OpenSearch.Client.Specification.SnapshotApi
 {
     /// <summary>
     /// Snapshot APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.Snapshot"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface ISnapshotNamespace
+    {
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.cleanup_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        CleanupRepositoryResponse CleanupRepository(
+            Name repository,
+            Func<CleanupRepositoryDescriptor, ICleanupRepositoryRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.cleanup_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<CleanupRepositoryResponse> CleanupRepositoryAsync(
+            Name repository,
+            Func<CleanupRepositoryDescriptor, ICleanupRepositoryRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.cleanup_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        CleanupRepositoryResponse CleanupRepository(ICleanupRepositoryRequest request);
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.cleanup_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<CleanupRepositoryResponse> CleanupRepositoryAsync(
+            ICleanupRepositoryRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.clone</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        CloneSnapshotResponse Clone(
+            Name repository,
+            Name snapshot,
+            Name targetSnapshot,
+            Func<CloneSnapshotDescriptor, ICloneSnapshotRequest> selector
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.clone</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<CloneSnapshotResponse> CloneAsync(
+            Name repository,
+            Name snapshot,
+            Name targetSnapshot,
+            Func<CloneSnapshotDescriptor, ICloneSnapshotRequest> selector,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.clone</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        CloneSnapshotResponse Clone(ICloneSnapshotRequest request);
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.clone</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<CloneSnapshotResponse> CloneAsync(
+            ICloneSnapshotRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.create</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        SnapshotResponse Snapshot(
+            Name repository,
+            Name snapshot,
+            Func<SnapshotDescriptor, ISnapshotRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.create</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        Task<SnapshotResponse> SnapshotAsync(
+            Name repository,
+            Name snapshot,
+            Func<SnapshotDescriptor, ISnapshotRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.create</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        SnapshotResponse Snapshot(ISnapshotRequest request);
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.create</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        Task<SnapshotResponse> SnapshotAsync(
+            ISnapshotRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.create_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        CreateRepositoryResponse CreateRepository(
+            Name repository,
+            Func<CreateRepositoryDescriptor, ICreateRepositoryRequest> selector
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.create_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        Task<CreateRepositoryResponse> CreateRepositoryAsync(
+            Name repository,
+            Func<CreateRepositoryDescriptor, ICreateRepositoryRequest> selector,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.create_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        CreateRepositoryResponse CreateRepository(ICreateRepositoryRequest request);
+
+        /// <summary>
+        /// <c>PUT</c> request to the <c>snapshot.create_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a></a>
+        /// </summary>
+        Task<CreateRepositoryResponse> CreateRepositoryAsync(
+            ICreateRepositoryRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>snapshot.delete</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/">https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</a>
+        /// </summary>
+        DeleteSnapshotResponse Delete(
+            Name repository,
+            Name snapshot,
+            Func<DeleteSnapshotDescriptor, IDeleteSnapshotRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>snapshot.delete</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/">https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</a>
+        /// </summary>
+        Task<DeleteSnapshotResponse> DeleteAsync(
+            Name repository,
+            Name snapshot,
+            Func<DeleteSnapshotDescriptor, IDeleteSnapshotRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>snapshot.delete</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/">https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</a>
+        /// </summary>
+        DeleteSnapshotResponse Delete(IDeleteSnapshotRequest request);
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>snapshot.delete</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/">https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot/</a>
+        /// </summary>
+        Task<DeleteSnapshotResponse> DeleteAsync(
+            IDeleteSnapshotRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>snapshot.delete_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</a>
+        /// </summary>
+        DeleteRepositoryResponse DeleteRepository(
+            Names repository,
+            Func<DeleteRepositoryDescriptor, IDeleteRepositoryRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>snapshot.delete_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</a>
+        /// </summary>
+        Task<DeleteRepositoryResponse> DeleteRepositoryAsync(
+            Names repository,
+            Func<DeleteRepositoryDescriptor, IDeleteRepositoryRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>snapshot.delete_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</a>
+        /// </summary>
+        DeleteRepositoryResponse DeleteRepository(IDeleteRepositoryRequest request);
+
+        /// <summary>
+        /// <c>DELETE</c> request to the <c>snapshot.delete_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/delete-snapshot-repository/</a>
+        /// </summary>
+        Task<DeleteRepositoryResponse> DeleteRepositoryAsync(
+            IDeleteRepositoryRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.get</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        GetSnapshotResponse Get(
+            Name repository,
+            Names snapshot,
+            Func<GetSnapshotDescriptor, IGetSnapshotRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.get</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<GetSnapshotResponse> GetAsync(
+            Name repository,
+            Names snapshot,
+            Func<GetSnapshotDescriptor, IGetSnapshotRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.get</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        GetSnapshotResponse Get(IGetSnapshotRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.get</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest">https://opensearch.org/docs/latest</a>
+        /// </summary>
+        Task<GetSnapshotResponse> GetAsync(
+            IGetSnapshotRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.get_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</a>
+        /// </summary>
+        GetRepositoryResponse GetRepository(
+            Func<GetRepositoryDescriptor, IGetRepositoryRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.get_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</a>
+        /// </summary>
+        Task<GetRepositoryResponse> GetRepositoryAsync(
+            Func<GetRepositoryDescriptor, IGetRepositoryRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.get_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</a>
+        /// </summary>
+        GetRepositoryResponse GetRepository(IGetRepositoryRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.get_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-repository/</a>
+        /// </summary>
+        Task<GetRepositoryResponse> GetRepositoryAsync(
+            IGetRepositoryRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.restore</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/">https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</a>
+        /// </summary>
+        RestoreResponse Restore(
+            Name repository,
+            Name snapshot,
+            Func<RestoreDescriptor, IRestoreRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.restore</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/">https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</a>
+        /// </summary>
+        Task<RestoreResponse> RestoreAsync(
+            Name repository,
+            Name snapshot,
+            Func<RestoreDescriptor, IRestoreRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.restore</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/">https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</a>
+        /// </summary>
+        RestoreResponse Restore(IRestoreRequest request);
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.restore</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/">https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/</a>
+        /// </summary>
+        Task<RestoreResponse> RestoreAsync(IRestoreRequest request, CancellationToken ct = default);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.status</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/">https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</a>
+        /// </summary>
+        SnapshotStatusResponse Status(
+            Func<SnapshotStatusDescriptor, ISnapshotStatusRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.status</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/">https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</a>
+        /// </summary>
+        Task<SnapshotStatusResponse> StatusAsync(
+            Func<SnapshotStatusDescriptor, ISnapshotStatusRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.status</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/">https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</a>
+        /// </summary>
+        SnapshotStatusResponse Status(ISnapshotStatusRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>snapshot.status</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/">https://opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/</a>
+        /// </summary>
+        Task<SnapshotStatusResponse> StatusAsync(
+            ISnapshotStatusRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.verify_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</a>
+        /// </summary>
+        VerifyRepositoryResponse VerifyRepository(
+            Name repository,
+            Func<VerifyRepositoryDescriptor, IVerifyRepositoryRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.verify_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</a>
+        /// </summary>
+        Task<VerifyRepositoryResponse> VerifyRepositoryAsync(
+            Name repository,
+            Func<VerifyRepositoryDescriptor, IVerifyRepositoryRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.verify_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</a>
+        /// </summary>
+        VerifyRepositoryResponse VerifyRepository(IVerifyRepositoryRequest request);
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>snapshot.verify_repository</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/">https://opensearch.org/docs/latest/api-reference/snapshots/verify-snapshot-repository/</a>
+        /// </summary>
+        Task<VerifyRepositoryResponse> VerifyRepositoryAsync(
+            IVerifyRepositoryRequest request,
+            CancellationToken ct = default
+        );
+    }
+
+    /// <summary>
+    /// Snapshot implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Snapshot"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class SnapshotNamespace : NamespacedClientProxy
+    public partial class SnapshotNamespace : NamespacedClientProxy, ISnapshotNamespace
     {
         internal SnapshotNamespace(OpenSearchClient client)
             : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.Tasks.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.Tasks.cs
@@ -53,11 +53,123 @@ namespace OpenSearch.Client.Specification.TasksApi
 {
     /// <summary>
     /// Tasks APIs.
+    /// <para>Use the <see cref="IOpenSearchClient.Tasks"/> property on <see cref="IOpenSearchClient"/>.</para>
+    /// </summary>
+    public partial interface ITasksNamespace
+    {
+        /// <summary>
+        /// <c>POST</c> request to the <c>tasks.cancel</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling">https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</a>
+        /// </summary>
+        CancelTasksResponse Cancel(
+            Func<CancelTasksDescriptor, ICancelTasksRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>tasks.cancel</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling">https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</a>
+        /// </summary>
+        Task<CancelTasksResponse> CancelAsync(
+            Func<CancelTasksDescriptor, ICancelTasksRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>tasks.cancel</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling">https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</a>
+        /// </summary>
+        CancelTasksResponse Cancel(ICancelTasksRequest request);
+
+        /// <summary>
+        /// <c>POST</c> request to the <c>tasks.cancel</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling">https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling</a>
+        /// </summary>
+        Task<CancelTasksResponse> CancelAsync(
+            ICancelTasksRequest request,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>tasks.get</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/">https://opensearch.org/docs/latest/api-reference/tasks/</a>
+        /// </summary>
+        GetTaskResponse GetTask(
+            TaskId taskId,
+            Func<GetTaskDescriptor, IGetTaskRequest> selector = null
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>tasks.get</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/">https://opensearch.org/docs/latest/api-reference/tasks/</a>
+        /// </summary>
+        Task<GetTaskResponse> GetTaskAsync(
+            TaskId taskId,
+            Func<GetTaskDescriptor, IGetTaskRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>tasks.get</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/">https://opensearch.org/docs/latest/api-reference/tasks/</a>
+        /// </summary>
+        GetTaskResponse GetTask(IGetTaskRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>tasks.get</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/">https://opensearch.org/docs/latest/api-reference/tasks/</a>
+        /// </summary>
+        Task<GetTaskResponse> GetTaskAsync(IGetTaskRequest request, CancellationToken ct = default);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>tasks.list</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/">https://opensearch.org/docs/latest/api-reference/tasks/</a>
+        /// </summary>
+        ListTasksResponse List(Func<ListTasksDescriptor, IListTasksRequest> selector = null);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>tasks.list</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/">https://opensearch.org/docs/latest/api-reference/tasks/</a>
+        /// </summary>
+        Task<ListTasksResponse> ListAsync(
+            Func<ListTasksDescriptor, IListTasksRequest> selector = null,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>tasks.list</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/">https://opensearch.org/docs/latest/api-reference/tasks/</a>
+        /// </summary>
+        ListTasksResponse List(IListTasksRequest request);
+
+        /// <summary>
+        /// <c>GET</c> request to the <c>tasks.list</c> API, read more about this API online:
+        /// <para></para>
+        /// <a href="https://opensearch.org/docs/latest/api-reference/tasks/">https://opensearch.org/docs/latest/api-reference/tasks/</a>
+        /// </summary>
+        Task<ListTasksResponse> ListAsync(
+            IListTasksRequest request,
+            CancellationToken ct = default
+        );
+    }
+
+    /// <summary>
+    /// Tasks implementation.
     /// <para>Not intended to be instantiated directly. Use the <see cref="IOpenSearchClient.Tasks"/> property
     /// on <see cref="IOpenSearchClient"/>.
     /// </para>
     /// </summary>
-    public partial class TasksNamespace : NamespacedClientProxy
+    public partial class TasksNamespace : NamespacedClientProxy, ITasksNamespace
     {
         internal TasksNamespace(OpenSearchClient client)
             : base(client) { }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.cs
@@ -83,7 +83,7 @@ namespace OpenSearch.Client
         public INodesNamespace Nodes { get; private set; }
 
         /// <summary>Http APIs</summary>
-        public HttpNamespace Http { get; private set; }
+        public IHttpNamespace Http { get; private set; }
 
         /// <summary>Snapshot APIs</summary>
         public ISnapshotNamespace Snapshot { get; private set; }

--- a/src/OpenSearch.Client/_Generated/OpenSearchClient.cs
+++ b/src/OpenSearch.Client/_Generated/OpenSearchClient.cs
@@ -65,31 +65,31 @@ namespace OpenSearch.Client
     public partial class OpenSearchClient : IOpenSearchClient
     {
         /// <summary>Cat APIs</summary>
-        public CatNamespace Cat { get; private set; }
+        public ICatNamespace Cat { get; private set; }
 
         /// <summary>Cluster APIs</summary>
-        public ClusterNamespace Cluster { get; private set; }
+        public IClusterNamespace Cluster { get; private set; }
 
         /// <summary>Dangling Indices APIs</summary>
-        public DanglingIndicesNamespace DanglingIndices { get; private set; }
+        public IDanglingIndicesNamespace DanglingIndices { get; private set; }
 
         /// <summary>Indices APIs</summary>
-        public IndicesNamespace Indices { get; private set; }
+        public IIndicesNamespace Indices { get; private set; }
 
         /// <summary>Ingest APIs</summary>
-        public IngestNamespace Ingest { get; private set; }
+        public IIngestNamespace Ingest { get; private set; }
 
         /// <summary>Nodes APIs</summary>
-        public NodesNamespace Nodes { get; private set; }
+        public INodesNamespace Nodes { get; private set; }
 
         /// <summary>Http APIs</summary>
         public HttpNamespace Http { get; private set; }
 
         /// <summary>Snapshot APIs</summary>
-        public SnapshotNamespace Snapshot { get; private set; }
+        public ISnapshotNamespace Snapshot { get; private set; }
 
         /// <summary>Tasks APIs</summary>
-        public TasksNamespace Tasks { get; private set; }
+        public ITasksNamespace Tasks { get; private set; }
 
         partial void SetupGeneratedNamespaces()
         {


### PR DESCRIPTION
### Description
Say you created a method using IOpenSearchClient:
```
public void CreateIndex(IOpenSearchClient client, string name) {
	client.Indices.Create(name);
}
```

Then you want to write a unit test for it. Since you don't want unit tests to depend on external services, you would likely mock out the IOpenSearchClient.  So, you might write:
```
public void CreateIndex_Always_CreatesAnIndex() {
	// arrange
	var clientMock = new Moq.Mock<IOpenSearchClient>();
	clientMock.Setup(i => i.Indices.Create(name, null));
	var name = "Name";

	// act
	_instance.CreateIndex(client, name)

	// assert
	clientMock.Verify(i => i.Indices.Create(name, null), Times.Once);
}
```

But this doesn't work. IOpenSearchClient is an interface and can be mocked, but IOpenSearchClient.Indices is IndicesNamespace, a concrete class, and concrete classes are not mockable unless they have a public constructor and have visual methods - neither which apply to IndicesNamespace or any other class under OpenSearch.Client.Specification. As such, you get an error on running this test or any test that references or calls code that references any of the namespaced API endpoints.

This PR adds interfaces to all of the auto-generated classes under OpenSearch.Client.Specification, and adjusts IOpenSearchClient and OpenSearchClient to return these interfaces instead of the concrete classes. This allows mocking to work for these classes, so that users of this library can unit test methods using them.

### Issues Resolved
#423 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
