### PR TITLE
[Backport 1.x] Bump YamlDotNet from 15.1.2 to 15.1.6 (#663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `Octokit` from 11.0.0 to 11.0.1
 - Bumps `System.Reactive` from 6.0.0 to 6.0.1
 - Bumps `Argu` from 6.2.3 to 6.2.4
+- Bumps `YamlDotNet` from 15.1.2 to 15.1.6
 
 ## [1.7.1]
 ### Fixed

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -12,7 +12,8 @@
     <PackageReference Include="CSharpier.Core" Version="0.28.2" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NSwag.Core.Yaml" Version="14.0.7" />
+    <PackageReference Include="NSwag.Core" Version="14.0.7" />
+    <PackageReference Include="YamlDotNet" Version="15.1.6" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />


### PR DESCRIPTION
### Description
Backport #663 from 26a619cc255932ea20cd0fc0c8382895a4b15c25

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
