### PR TITLE
Fix building of OpenSearch 3.0.0-SNAPSHOT/main by installing JDK 21

### DIFF
--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -14,12 +14,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Install Java
-      uses: actions/setup-java@v3
-      with:
-        distribution: zulu
-        java-version: 11
-
     - name: Start OpenSearch
       id: opensearch
       shell: bash -eo pipefail {0}
@@ -27,6 +21,7 @@ runs:
         if [[ "$RUNNER_OS" == "macOS" ]]; then
           brew install -q coreutils
         fi
+        unset JAVA_HOME
         OPENSEARCH_HOME=$(realpath ./opensearch-[1-9]*)
         CONFIG_DIR=$OPENSEARCH_HOME/config
         CONFIG_FILE=$CONFIG_DIR/opensearch.yml
@@ -48,7 +43,7 @@ runs:
             SECURITY_MINOR="${SECURITY_VERSION_COMPONENTS[1]}"
         
             if (( $SECURITY_MAJOR > 2 || ( $SECURITY_MAJOR == 2 && $SECURITY_MINOR >= 12 ) )); then
-              export OPENSEARCH_INITIAL_ADMIN_PASSWORD=$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 16)
+              export OPENSEARCH_INITIAL_ADMIN_PASSWORD="myStrongPassword123!"
             fi
         
             bash "$SECURITY_DIR/tools/install_demo_configuration.sh" -y -i -s

--- a/.github/workflows/integration-yaml-tests.yml
+++ b/.github/workflows/integration-yaml-tests.yml
@@ -104,6 +104,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
       - name: Restore or Build OpenSearch
         id: opensearch_build
         uses: ./client/.github/actions/build-opensearch


### PR DESCRIPTION
### Description
Fix building of OpenSearch 3.0.0-SNAPSHOT/main for unreleased YAML tests by installing JDK 21. Also hard code "secure" password in start script, as attempt at random generation occasionally failed password requirements or /dev/urandom having no data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
