### PR TITLE
Bump versions of deprecated Node.js version based actions

### DIFF
--- a/.github/actions/cached-git-build/action.yml
+++ b/.github/actions/cached-git-build/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Clone Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
@@ -32,7 +32,7 @@ runs:
     
     - name: Restore from cache
       id: restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.cached_paths }}
         key: ${{ inputs.repository }}-${{ steps.get-sha.outputs.sha }}${{ inputs.cache_key_suffix }}
@@ -45,7 +45,7 @@ runs:
 
     - name: Save to cache
       if: steps.restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ${{ inputs.cached_paths }}
         key: ${{ inputs.repository }}-${{ steps.get-sha.outputs.sha }}${{ inputs.cache_key_suffix }}

--- a/.github/actions/run-released-opensearch/action.yml
+++ b/.github/actions/run-released-opensearch/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Restore cached OpenSearch distro
       id: cache-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: opensearch-*
         key: opensearch-${{ inputs.version }}-${{ runner.os }}
@@ -40,7 +40,7 @@ runs:
 
     - name: Save cached OpenSearch distro
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: opensearch-*
         key: opensearch-${{ inputs.version }}-${{ runner.os }}

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -8,7 +8,7 @@ jobs:
     name: Auto Label
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: banyan/auto-label@1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_deploy_docs.yml
+++ b/.github/workflows/build_deploy_docs.yml
@@ -11,14 +11,14 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
             6.0.x
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -8,7 +8,7 @@ jobs:
   verify-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           5.0.x
           6.0.x
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -25,7 +25,7 @@ jobs:
           installation_id: 22958780
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ steps.github_app_token.outputs.token }}
 

--- a/.github/workflows/integration-yaml-tests.yml
+++ b/.github/workflows/integration-yaml-tests.yml
@@ -26,17 +26,17 @@ jobs:
           - 1.1.0
     steps:
       - name: Checkout Client
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: client
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
             6.0.x
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}
@@ -87,17 +87,17 @@ jobs:
         opensearch_ref: ['1.x', '2.x', 'main']
     steps:
       - name: Checkout Client
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: client
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
             6.0.x
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,17 +30,17 @@ jobs:
 
     steps:
       - name: Checkout Client
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: client
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
             6.0.x
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Client
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: client
 
@@ -81,13 +81,13 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
             6.0.x
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Check license headers
       run: |

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: lychee Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: get_approvers
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           5.0.x
           6.0.x
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}

--- a/.github/workflows/test-jobs.yml
+++ b/.github/workflows/test-jobs.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
             6.0.x
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}
@@ -53,7 +53,7 @@ jobs:
           name: unit-test-report
           path: build/output/*
 
-          
+
   # Packages nuget packages first and then uses the nuget packages to test
   # Also builds versioned nuget packages
   canary-tests:
@@ -61,13 +61,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
             6.0.x
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.?sproj') }}


### PR DESCRIPTION
### Description
Bump versions of deprecated Node.js version based actions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
