### PR TITLE
[Backport 1.x] Bump System.Text.Json from 8.0.3 to 8.0.4 in /abstractions/src/OpenSearch.Stack.ArtifactsApi (#702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `Octokit` from 11.0.0 to 13.0.1
 - Bumps `System.Reactive` from 6.0.0 to 6.0.1
 - Bumps `Argu` from 6.2.3 to 6.2.4
+- Bumps `System.Text.Json` from 8.0.3 to 8.0.4
 
 ## [1.7.1]
 ### Fixed

--- a/abstractions/src/OpenSearch.Stack.ArtifactsApi/OpenSearch.Stack.ArtifactsApi.csproj
+++ b/abstractions/src/OpenSearch.Stack.ArtifactsApi/OpenSearch.Stack.ArtifactsApi.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="SemanticVersioning" Version="2.0.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description
Backports e76175c44204fe67160b12b0ddb7e43c86f01530 from #702 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
