### PR TITLE
Fix Indices.BulkAsync summary

### DIFF
--- a/src/OpenSearch.Client/OpenSearchClient.Indices.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Indices.cs
@@ -1623,7 +1623,7 @@ namespace OpenSearch.Client.Specification.IndicesApi
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/stats-api/">https://opensearch.org/docs/latest/opensearch/stats-api/</a>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
 		/// </summary>
 		public BulkAliasResponse BulkAlias(Func<BulkAliasDescriptor, IBulkAliasRequest> selector) => BulkAlias(selector.InvokeOrDefault(new BulkAliasDescriptor()));
 		/// <summary>

--- a/src/OpenSearch.Client/OpenSearchClient.Indices.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Indices.cs
@@ -811,7 +811,7 @@ namespace OpenSearch.Client.Specification.IndicesApi
 		/// </summary>
 		Task<SplitIndexResponse> SplitAsync(ISplitIndexRequest request, CancellationToken ct = default);
 		/// <summary>
-		/// <c>GET</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
+		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
 		/// </summary>

--- a/src/OpenSearch.Client/OpenSearchClient.Indices.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Indices.cs
@@ -811,7 +811,7 @@ namespace OpenSearch.Client.Specification.IndicesApi
 		/// </summary>
 		Task<SplitIndexResponse> SplitAsync(ISplitIndexRequest request, CancellationToken ct = default);
 		/// <summary>
-		/// <c>GET</c> request to the <c>indices.stats</c> API, read more about this API online:
+		/// <c>GET</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://opensearch.org/docs/latest/opensearch/stats-api/">https://opensearch.org/docs/latest/opensearch/stats-api/</a>
 		/// </summary>
@@ -1621,7 +1621,7 @@ namespace OpenSearch.Client.Specification.IndicesApi
 		/// </summary>
 		public Task<SplitIndexResponse> SplitAsync(ISplitIndexRequest request, CancellationToken ct = default) => DoRequestAsync<ISplitIndexRequest, SplitIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
-		/// <c>GET</c> request to the <c>indices.stats</c> API, read more about this API online:
+		/// <c>GET</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://opensearch.org/docs/latest/opensearch/stats-api/">https://opensearch.org/docs/latest/opensearch/stats-api/</a>
 		/// </summary>

--- a/src/OpenSearch.Client/OpenSearchClient.Indices.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Indices.cs
@@ -1621,7 +1621,7 @@ namespace OpenSearch.Client.Specification.IndicesApi
 		/// </summary>
 		public Task<SplitIndexResponse> SplitAsync(ISplitIndexRequest request, CancellationToken ct = default) => DoRequestAsync<ISplitIndexRequest, SplitIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
-		/// <c>GET</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
+		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
 		/// </summary>

--- a/src/OpenSearch.Client/OpenSearchClient.Indices.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Indices.cs
@@ -813,7 +813,7 @@ namespace OpenSearch.Client.Specification.IndicesApi
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/stats-api/">https://opensearch.org/docs/latest/opensearch/stats-api/</a>
+		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/alias/">https://opensearch.org/docs/latest/opensearch/rest-api/alias/</a>
 		/// </summary>
 		BulkAliasResponse BulkAlias(Func<BulkAliasDescriptor, IBulkAliasRequest> selector);
 		/// <summary>


### PR DESCRIPTION
### Description
Update `Indices.BulkAsync` summary with the correct API name

### Issues Resolved
Closes [#715].

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
