### PR TITLE
[BUG] Deadlock prone code in HttpConnection.cs #689

### DIFF
--- a/src/OpenSearch.Net/Connection/HttpConnection.cs
+++ b/src/OpenSearch.Net/Connection/HttpConnection.cs
@@ -107,8 +107,9 @@ namespace OpenSearch.Net
 
 					if (requestData.ThreadPoolStats)
 						threadPoolStats = ThreadPoolStats.GetStats();
-
-					responseMessage = client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
+                    var task = Task.Run(() => client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead));
+                    task.Wait();
+					responseMessage = task.Result;
 					statusCode = (int)responseMessage.StatusCode;
 					d.EndState = statusCode;
 				}
@@ -120,7 +121,9 @@ namespace OpenSearch.Net
 				if (responseMessage.Content != null)
 				{
 					receive = DiagnosticSource.Diagnose(DiagnosticSources.HttpConnection.ReceiveBody, requestData, statusCode);
-					responseStream = responseMessage.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+                    var task = Task.Run(() => responseMessage.Content.ReadAsStreamAsync());
+                    task.Wait();
+					responseStream = task.Result;
 				}
 			}
 			catch (TaskCanceledException e)


### PR DESCRIPTION
### Description
Fixes deadlock prone code in HttpConnection.cs. Changed synchronous methods in HttpConnection.cs to use Task.Run/Task.Wait to avoid deadlocks in accordance with: https://learn.microsoft.com/en-us/archive/blogs/jpsanders/asp-net-do-not-use-task-result-in-main-context

### Issues Resolved
#689

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
