### PR TITLE
Use intermediate env var instead of interpolating directly in inline shell scripts

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -33,7 +33,9 @@ jobs:
           token: ${{steps.github_app_token.outputs.token}}
 
       - name: Bump Version
-        run: bash .github/bump-version.sh "${{github.event.inputs.version}}"
+        run: bash .github/bump-version.sh "$VERSION"
+        env:
+          VERSION: ${{github.event.inputs.version}}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
@@ -121,7 +123,7 @@ jobs:
           token: ${{steps.github_app_token.outputs.token}}
 
       - name: Bump Patch Version
-        run: bash .github/bump-version.sh "${{env.NEXT_PATCH}}"
+        run: bash .github/bump-version.sh "$NEXT_PATCH"
 
       - name: Create Patch Version Pull Request
         uses: peter-evans/create-pull-request@v5
@@ -146,7 +148,7 @@ jobs:
 
       - name: Bump Minor Version
         if: env.IS_MINOR_BUMP == 'true'
-        run: bash .github/bump-version.sh "${{env.NEXT_MINOR}}"
+        run: bash .github/bump-version.sh "$NEXT_MINOR"
 
       - name: Create Minor Version Pull Request
         if: env.IS_MINOR_BUMP == 'true'
@@ -172,7 +174,7 @@ jobs:
 
       - name: Bump Major Version
         if: env.IS_MAJOR_BUMP == 'true'
-        run: bash .github/bump-version.sh "${{env.NEXT_MAJOR}}"
+        run: bash .github/bump-version.sh "$NEXT_MAJOR"
 
       - name: Create Major Version Pull Request
         if: env.IS_MAJOR_BUMP == 'true'

--- a/.github/workflows/integration-yaml-tests.yml
+++ b/.github/workflows/integration-yaml-tests.yml
@@ -121,8 +121,10 @@ jobs:
 
       - name: Unpack OpenSearch
         run: |
-          tar -xzf ${{ steps.opensearch_build.outputs.distribution }} \
+          tar -xzf "$DISTRIBUTION" \
           && ./opensearch-*/bin/opensearch-plugin install --batch file://$(realpath ./opensearch-security/build/distributions/opensearch-security-*-SNAPSHOT.zip)
+        env:
+          DISTRIBUTION: ${{ steps.opensearch_build.outputs.distribution }}
 
       - name: Start OpenSearch
         id: opensearch

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,9 +48,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      - run: "./build.sh integrate ${{ matrix.version }} readonly,replicatedreadonly,writable random:test_only_one --report"
+      - run: "./build.sh integrate $VERSION readonly,replicatedreadonly,writable random:test_only_one --report"
         name: Integration Tests
         working-directory: client
+        env:
+          VERSION: ${{ matrix.version }}
 
       - name: Upload test report
         if: failure()

--- a/.github/workflows/test-jobs.yml
+++ b/.github/workflows/test-jobs.yml
@@ -1,6 +1,5 @@
 name: Tests
 
-
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
### Description
Follow [best practices](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) for interpolating in inline scripts in GitHub Actions by using intermediate env vars. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
