### PR TITLE
[Backport 1.x] Bump CSharpier.Core from 0.29.0 to 0.29.1 (#767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `xunit` from 2.7.1 to 2.8.0
 - Bumps `FSharp.Core` from 8.0.100 to 8.0.400
 - Bumps `xunit.runner.visualstudio` from 2.5.8 to 2.8.2
-- Bumps `CSharpier.Core` from 0.27.3 to 0.29.0
+- Bumps `CSharpier.Core` from 0.27.3 to 0.29.1
 - Bumps `Spectre.Console` from 0.48.0 to 0.49.1
 - Bumps `Nullean.VsTest.Pretty.TestLogger` from 0.3.0 to 0.4.0
 - Bumps `Microsoft.NET.Test.Sdk` from 17.9.0 to 17.10.0

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -9,7 +9,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CSharpier.Core" Version="0.29.0" />
+    <PackageReference Include="CSharpier.Core" Version="0.29.1" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSwag.Core" Version="14.1.0" />


### PR DESCRIPTION
### Description
Backport #767 via 8aa8e7797bfab66893dacb4ce3a4c0bdc88cdc70

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
