### PR TITLE
[Backport 1.x] Update Jenkins release docker image (#784)

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -4,7 +4,7 @@ lib = library(identifier: 'jenkins@2.1.2', retriever: modernSCM([
 ]))
 
 standardReleasePipelineWithGenericTrigger(
-    overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v2.3',
+    overrideDockerImage: 'opensearchstaging/ci-runner:release-almalinux8-clients-v1.1',
     tokenIdCredential: 'jenkins-opensearch-net-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-net repository causing this workflow to run',
     publishRelease: true) {


### PR DESCRIPTION
### Description
Backport #784 via e883c8a87c2d0720904dbee753cd54d50fa18ec5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
