### PR TITLE
Bump `Microsoft.Extensions.Caching.Memory` from 6.0.0 to 8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `JunitXml.TestLogger` from 4.0.254 to 4.1.0
 - Bumps `FSharp.Core` from 8.0.400 to 8.0.401
 - Bumps `JetBrains.Annotations` from 2024.2.0 to 2024.3.0
+- Bumps `Microsoft.Extensions.Caching.Memory` from 6.0.0 to 8.0.1
 
 ## [1.8.0]
 ### Added

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CSharpier.Core" Version="0.29.2" />
     <PackageReference Include="Glob" Version="1.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSwag.Core" Version="14.1.0" />
     <PackageReference Include="YamlDotNet" Version="16.1.3" />


### PR DESCRIPTION
### Description
Bumps `Microsoft.Extensions.Caching.Memory` from 6.0.0 to 8.0.1, to resolve a CVE
This only affects the code generator, so is not relevant to users of the library.

### Issues Resolved
Fixes #843 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
