### PR TITLE
Move dblock to emeritus maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @anirudha @dblock @joshuali925 @Xtansia @VachaShah @MaxKsyunz @Yury-Fridlyand
+*   @anirudha @joshuali925 @Xtansia @VachaShah @MaxKsyunz @Yury-Fridlyand

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,12 +4,17 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer         | GitHub ID                                           | Affiliation |
-| ------------------ | --------------------------------------------------- | ----------- |
-| Anirudha Jadhav    | [anirudha](https://github.com/anirudha)             | Amazon      |
-| Daniel Doubrovkine | [dblock](https://github.com/dblock)                 | Independent |
-| Joshua Li          | [joshuali925](https://github.com/joshuali925)       | Amazon      |
-| Thomas Farr        | [Xtansia](https://github.com/Xtansia)               | Amazon      |
-| Vacha Shah         | [VachaShah](https://github.com/VachaShah)           | Amazon      |
-| Max Ksyunz         | [MaxKsyunz](https://github.com/MaxKsyunz)           | Bit Quill   |
-| Yury Fridlyand     | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Bit Quill   |
+| Maintainer      | GitHub ID                                           | Affiliation |
+| --------------- | --------------------------------------------------- | ----------- |
+| Anirudha Jadhav | [anirudha](https://github.com/anirudha)             | Amazon      |
+| Joshua Li       | [joshuali925](https://github.com/joshuali925)       | Amazon      |
+| Thomas Farr     | [Xtansia](https://github.com/Xtansia)               | Amazon      |
+| Vacha Shah      | [VachaShah](https://github.com/VachaShah)           | Amazon      |
+| Max Ksyunz      | [MaxKsyunz](https://github.com/MaxKsyunz)           | Bit Quill   |
+| Yury Fridlyand  | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Bit Quill   |
+
+## Emeritus
+
+| Maintainer         | GitHub ID                               | Affiliation |
+| ------------------ | --------------------------------------- | ----------- |
+| Daniel Doubrovkine | [dblock](https://github.com/dblock)     | Independent |


### PR DESCRIPTION
## Summary
- Moved dblock to emeritus maintainers section
- Added emeritus maintainers section to MAINTAINERS.md
- Removed dblock from CODEOWNERS

🤖 Generated with [Claude Code](https://claude.com/claude-code)