### PR TITLE
Add SamuelCox nomination

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @anirudha @joshuali925 @Xtansia @VachaShah @MaxKsyunz @Yury-Fridlyand
+*   @anirudha @joshuali925 @Xtansia @VachaShah @MaxKsyunz @Yury-Fridlyand @SamuelCox

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Vacha Shah      | [VachaShah](https://github.com/VachaShah)           | Amazon      |
 | Max Ksyunz      | [MaxKsyunz](https://github.com/MaxKsyunz)           | Bit Quill   |
 | Yury Fridlyand  | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Bit Quill   |
+| Samuel Cox      | [SamuelCox](https://github.com/SamuelCox)           | Independent |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
I’d like to nominate Samuel Cox(@samuelcox) as a maintainer of the opensearch-net repository.
Samuel has a number of small contributions already merged, and is interested in seeing the evolution of this language client.

He worked with Charlie Hull (@flaxsearch) in a project using OpenSearch and the client and both Charlie and I think he will be a great maintainer for this repo.


### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
