### PR TITLE
Fix StackOverflowException when serializing KnnVectorProperty via AutoMap visitor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fixed naming of `ClusterManagerTimeout` and `MasterTimeout` properties from `*TimeSpanout` in the low-level client ([#332](https://github.com/opensearch-project/opensearch-net/pull/332))
+- Fixed `StackOverflowException` when serializing a `KnnVectorProperty` returned from a custom `IPropertyVisitor` via `AutoMap` ([#963](https://github.com/opensearch-project/opensearch-net/pull/963))
 
 ### Dependencies
 - Bumps `System.Diagnostics.DiagnosticSource` from 6.0.1 to 8.0.1

--- a/src/OpenSearch.Client/Mapping/Types/PropertyFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertyFormatter.cs
@@ -218,6 +218,9 @@ namespace OpenSearch.Client
 				case IRankFeaturesProperty rankFeaturesProperty:
 					Serialize(ref writer, rankFeaturesProperty, formatterResolver);
 					break;
+				case IKnnVectorProperty knnVectorProperty:
+					Serialize(ref writer, knnVectorProperty, formatterResolver);
+					break;
 				case IGenericProperty genericProperty:
 					Serialize(ref writer, genericProperty, formatterResolver);
 					break;

--- a/tests/Tests/Mapping/Types/Specialized/Knn/KnnVectorVisitorTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Knn/KnnVectorVisitorTests.cs
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Reflection;
+using FluentAssertions;
+using OpenSearch.Client;
+using OpenSearch.Net;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
+using Tests.Core.Client;
+
+namespace Tests.Mapping.Types.Specialized.Knn;
+
+/// <summary>
+/// Regression tests for <see cref="IKnnVectorProperty"/> serialization through the
+/// <see cref="IPropertyVisitor"/> extension point.
+///
+/// Before the corresponding <c>PropertyFormatter</c> fix, the switch in
+/// <c>PropertyFormatter.Serialize</c> had no <c>case IKnnVectorProperty</c> arm, so
+/// any <see cref="KnnVectorProperty"/> produced from <c>AutoMap(visitor)</c> fell
+/// into the reflection-based catch-all and walked
+/// <c>PropertyName.Property</c> → <c>PropertyInfo</c> → <c>Module</c> →
+/// <c>Assembly</c> → <c>Type[]</c> → <c>ConstructorInfo[]</c> forever, terminating
+/// the process with a <see cref="System.StackOverflowException"/>.
+/// </summary>
+public class KnnVectorVisitorTests
+{
+    private class DocWithVector
+    {
+        public float[] Vec { get; set; }
+    }
+
+    private class KnnReturningVisitor : NoopPropertyVisitor
+    {
+        public override IProperty Visit(PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute)
+        {
+            if (propertyInfo.PropertyType == typeof(float[]))
+            {
+                return new KnnVectorProperty
+                {
+                    Dimension = 3,
+                    Method = new KnnMethod
+                    {
+                        Name = "hnsw",
+                        Engine = "lucene",
+                        SpaceType = "l2",
+                        Parameters = new KnnMethodParameters { { "m", 24 } },
+                    },
+                };
+            }
+            return null;
+        }
+    }
+
+    [U]
+    public void KnnVectorReturnedFromVisitorSerializesViaTypedFormatter()
+    {
+        var mapping = new TypeMappingDescriptor<DocWithVector>().AutoMap(new KnnReturningVisitor());
+
+        var json = TestClient.DisabledStreaming.RequestResponseSerializer.SerializeToString(mapping);
+
+        json.Should().Contain("\"type\":\"knn_vector\"");
+        json.Should().Contain("\"dimension\":3");
+        json.Should().NotContain("RuntimeConstructorInfo");
+        json.Should().NotContain("DeclaringType");
+    }
+}


### PR DESCRIPTION
### Description

`PropertyFormatter.Serialize` had no `case IKnnVectorProperty` arm, so the value fell into the reflection-based catch-all and recursed until stack exhaustion. Mirrors the `FieldType.KnnVector` case already present on the `Deserialize` side.

Added a regression test that serializes a visitor-returned `KnnVectorProperty` through `RequestResponseSerializer`; it crashes the xunit host before the fix.

### Issues Resolved

Closes #962.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
