### PR TITLE
Pin actions/github-script to exact commit SHA

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -12,7 +12,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             github.rest.issues.addLabels({


### PR DESCRIPTION
## Summary
- Pin `actions/github-script` from `v6` tag to exact commit SHA (`3a2844b7e9c422d3c10d287c895573f7108da1b3`).

## Context
Mutable tags can be overwritten. Pinning to a specific commit SHA ensures the action code cannot change without a corresponding PR update.
