### PR TITLE
Fix release workflows to use pre-releases and update releasing.md with new process

### DIFF
--- a/.github/actions/cached-git-build/action.yml
+++ b/.github/actions/cached-git-build/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Clone Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
@@ -32,7 +32,7 @@ runs:
     
     - name: Restore from cache
       id: restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ inputs.cached_paths }}
         key: ${{ inputs.repository }}-${{ steps.get-sha.outputs.sha }}${{ inputs.cache_key_suffix }}
@@ -45,7 +45,7 @@ runs:
 
     - name: Save to cache
       if: steps.restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ inputs.cached_paths }}
         key: ${{ inputs.repository }}-${{ steps.get-sha.outputs.sha }}${{ inputs.cache_key_suffix }}

--- a/.github/actions/create-version-bump-pr/action.yml
+++ b/.github/actions/create-version-bump-pr/action.yml
@@ -18,7 +18,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout ${{ inputs.branch }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.branch }}
         path: client
@@ -31,7 +31,7 @@ runs:
         VERSION: ${{ inputs.version }}
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
       with:
         token: ${{ inputs.token }}
         path: client

--- a/.github/actions/run-released-opensearch/action.yml
+++ b/.github/actions/run-released-opensearch/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Restore cached OpenSearch distro
       id: cache-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@5b7a9f8ae54e16fe74b141e0cd16a8aa366217c4 #v5
       with:
         path: opensearch-*
         key: opensearch-${{ inputs.version }}-${{ runner.os }}
@@ -43,7 +43,7 @@ runs:
 
     - name: Save cached OpenSearch distro
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@5b7a9f8ae54e16fe74b141e0cd16a8aa366217c4 #v5
       with:
         path: opensearch-*
         key: opensearch-${{ inputs.version }}-${{ runner.os }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -31,7 +31,8 @@ jobs:
           exclude-workflow-initiator-as-approver: true
 
       - name: Draft a release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
-          draft: true
-          generate_release_notes: true
+          immutableCreate: true
+          generateReleaseNotes: true
+          prerelease: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,9 +33,14 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
 
-1. Create a tag, e.g. 1.0.0, and push it to this GitHub repository.
-2. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and is responsible for drafting a new release on GitHub.
-3. Before creating a draft release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). See sample [issue](https://github.com/gaiksaya/opensearch-net/issues/10). The maintainers need to approve in order to continue the workflow run.
-4. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-net-release) as a result of which the client is released on [Nuget.org](https://www.nuget.org/profiles/opensearchproject). Please note that the release workflow is triggered only if created release is in draft state.
-5. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. Identify the commit to release and create a tag on it, pushing to the upstream repo:
+```
+git fetch origin
+git tag <tag-name> <commit-sha>
+git push origin <tag-name>
+```
+2. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off. Before creating a release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). The maintainers need to approve in order to continue the workflow run.
+3. Once approved, a pre-release will be created.
+4. This pre-release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-net-release) as a result of which the client is released on [Nuget.org](https://www.nuget.org/profiles/opensearchproject). Please note that the release workflow is triggered only if created release is in pre-release state.
+5. Once the above release workflow is successful, it creates a GitHub issue requesting maintainers to manually publish the pre-release to release on GitHub.
 6. Increment the version to next iteration. See [example](https://github.com/opensearch-project/opensearch-net/pull/93).

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@12.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.0.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -6,8 +6,7 @@ lib = library(identifier: 'jenkins@12.0.0', retriever: modernSCM([
 standardReleasePipelineWithGenericTrigger(
     overrideDockerImage: 'opensearchstaging/ci-runner:release-almalinux8-clients-v1.1',
     tokenIdCredential: 'jenkins-opensearch-net-generic-webhook-token',
-    causeString: 'A tag was cut on opensearch-project/opensearch-net repository causing this workflow to run',
-    publishRelease: true) {
+    causeString: 'A tag was cut on opensearch-project/opensearch-net repository causing this workflow to run') {
         publishToNuget(
             repository: 'https://github.com/opensearch-project/opensearch-net',
             tag: "$tag",


### PR DESCRIPTION
### Description
Recently we removed bot access to the repository. Due to which it is now unable to read draft releases or publish releases on GitHub. This PR fixes it by creating pre-release first, trigger jenkins workflow and then once successful creates GH issue requesting maintainers to publish the release on the GitHub.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6255

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
