### PR TITLE
Update unreleased integration matrix to use specific branch versions

### DIFF
--- a/.github/workflows/integration-yaml-tests.yml
+++ b/.github/workflows/integration-yaml-tests.yml
@@ -88,8 +88,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { opensearch_ref: '1.x', java_version: '11' }
-          - { opensearch_ref: '2.x', java_version: '21' }
+          - { opensearch_ref: '1.3', java_version: '11' }
+          - { opensearch_ref: '2.19', java_version: '21' }
           - { opensearch_ref: 'main', java_version: '21' }
     steps:
       - name: Checkout Client

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,8 +75,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { opensearch_ref: '1.x', java_version: '11' }
-          - { opensearch_ref: '2.x', java_version: '17' }
+          - { opensearch_ref: '1.3', java_version: '11' }
+          - { opensearch_ref: '2.19', java_version: '17' }
           - { opensearch_ref: 'main', java_version: '21' }
 
     steps:
@@ -114,7 +114,7 @@ jobs:
         uses: ./client/.github/actions/build-opensearch
         with:
           ref: ${{ matrix.opensearch_ref }}
-          security_plugin: ${{ matrix.opensearch_ref == '1.x' }}
+          security_plugin: ${{ matrix.opensearch_ref == '1.3' }}
           knn_plugin: true
           plugins_output_directory: ${{ env.OPENSEARCH_PLUGINS_DIRECTORY }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Changed the namespace client properties on `IOpenSearchClient` to return corresponding interfaces to better enable mocking & unit testing ([#646](https://github.com/opensearch-project/opensearch-net/pull/646))
 - Changed `NeuralQuery`'s `ModelId` to be optional ([#917](https://github.com/opensearch-project/opensearch-net/pull/917))
+- Changed unreleased integration test matrix to use specific branch versions `1.3` and `2.19` ([#984](https://github.com/opensearch-project/opensearch-net/pull/984))
 
 ### Added
 - Added conditions to the Microsoft.CSharp, System.Buffers & System.Diagnostics.DiagnosticSource dependencies so that they are not included on net 6+ as the newer framework's natively provides those dependencies. ([#930](https://github.com/opensearch-project/opensearch-net/pull/930))


### PR DESCRIPTION
## Summary
- Replace `1.x` with `1.3` and `2.x` with `2.19` in the unreleased integration test matrices, maintenance work based on 2.19 now for 2.x
- Updates both `integration.yml` and `integration-yaml-tests.yml`
- Updates the security_plugin condition to match the new `1.3` ref

## Test plan
- [x] Verify CI integration tests trigger correctly against the `1.3` and `2.19` branches