### PR TITLE
Fix undisposed Auditable in CreateClientException leaving Audit.Ended at default(DateTime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Removed
 ### Fixed
+- Fixed `MaxTimeoutReached`, `MaxRetriesReached`, and `FailedOverAllNodes` audit events having `Ended` stuck at `default(DateTime)` due to undisposed `Auditable` instances in `RequestPipeline.CreateClientException` ([#998](https://github.com/opensearch-project/opensearch-net/issues/998))
 ### Dependencies
 
 ## [2.0.0]

--- a/src/OpenSearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/OpenSearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -249,20 +249,20 @@ namespace OpenSearch.Net
 			if (IsTakingTooLong)
 			{
 				pipelineFailure = PipelineFailure.MaxTimeoutReached;
-				Audit(MaxTimeoutReached);
+				Audit(MaxTimeoutReached).Dispose();
 				exceptionMessage = "Maximum timeout reached while retrying request";
 			}
 			else if (Retried >= MaxRetries && MaxRetries > 0)
 			{
 				pipelineFailure = PipelineFailure.MaxRetriesReached;
-				Audit(MaxRetriesReached);
+				Audit(MaxRetriesReached).Dispose();
 				exceptionMessage = "Maximum number of retries reached";
 
 				var now = _dateTimeProvider.Now();
 				var activeNodes = _connectionPool.Nodes.Count(n => n.IsAlive || n.DeadUntil <= now);
 				if (Retried >= activeNodes)
 				{
-					Audit(FailedOverAllNodes);
+					Audit(FailedOverAllNodes).Dispose();
 					exceptionMessage += ", failed over to all the known alive nodes before failing";
 				}
 			}

--- a/tests/Tests.Reproduce/GitHubIssue998.cs
+++ b/tests/Tests.Reproduce/GitHubIssue998.cs
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
+using OpenSearch.Net;
+using FluentAssertions;
+
+namespace Tests.Reproduce;
+
+public class GitHubIssue998
+{
+	/// <summary>
+	/// MaxRetriesReached and FailedOverAllNodes audit events should have a valid Ended timestamp.
+	/// Previously the Auditable returned by Audit() was discarded without Dispose(), leaving
+	/// Ended at default(DateTime).
+	/// </summary>
+	[U]
+	public void MaxRetriesReachedAuditShouldHaveValidEndedTimestamp()
+	{
+		var pool = new StaticConnectionPool(new[] { new Uri("http://node1:9200"), new Uri("http://node2:9200") });
+		var settings = new ConnectionConfiguration(pool, new AlwaysFailsConnection())
+			.DisablePing()
+			.MaximumRetries(1);
+		var client = new OpenSearchLowLevelClient(settings);
+
+		var response = client.Search<StringResponse>("test-index",
+			PostData.Serializable(new { query = new { match_all = new { } } }));
+
+		var trail = response.ApiCall.AuditTrail;
+		trail.Should().NotBeNullOrEmpty();
+
+		foreach (var audit in trail)
+		{
+			audit.Ended.Should().NotBe(default(DateTime),
+				$"audit event {audit.Event} should have a valid Ended timestamp");
+			audit.Ended.Should().BeOnOrAfter(audit.Started,
+				$"audit event {audit.Event} Ended should be >= Started");
+		}
+
+		var maxRetries = trail.FirstOrDefault(a => a.Event == AuditEvent.MaxRetriesReached);
+		maxRetries.Should().NotBeNull("expected MaxRetriesReached in audit trail");
+		maxRetries!.Ended.Should().NotBe(default(DateTime));
+
+		var failedOverAll = trail.FirstOrDefault(a => a.Event == AuditEvent.FailedOverAllNodes);
+		failedOverAll.Should().NotBeNull("expected FailedOverAllNodes in audit trail");
+		failedOverAll!.Ended.Should().NotBe(default(DateTime));
+	}
+
+	/// <summary>
+	/// MaxTimeoutReached audit event should have a valid Ended timestamp.
+	/// </summary>
+	[U]
+	public void MaxTimeoutReachedAuditShouldHaveValidEndedTimestamp()
+	{
+		var pool = new StaticConnectionPool(new[] { new Uri("http://node1:9200"), new Uri("http://node2:9200") });
+		var settings = new ConnectionConfiguration(pool, new SlowConnection(TimeSpan.FromSeconds(10)))
+			.DisablePing()
+			.RequestTimeout(TimeSpan.FromSeconds(1))
+			.MaxRetryTimeout(TimeSpan.FromSeconds(2));
+		var client = new OpenSearchLowLevelClient(settings);
+
+		var response = client.Search<StringResponse>("test-index",
+			PostData.Serializable(new { query = new { match_all = new { } } }));
+
+		var trail = response.ApiCall.AuditTrail;
+		trail.Should().NotBeNullOrEmpty();
+
+		var maxTimeout = trail.FirstOrDefault(a => a.Event == AuditEvent.MaxTimeoutReached);
+		maxTimeout.Should().NotBeNull("expected MaxTimeoutReached in audit trail");
+		maxTimeout!.Ended.Should().NotBe(default(DateTime),
+			"MaxTimeoutReached audit event should have a valid Ended timestamp");
+		maxTimeout.Ended.Should().BeOnOrAfter(maxTimeout.Started);
+	}
+
+	private sealed class AlwaysFailsConnection : IConnection
+	{
+		public TResponse Request<TResponse>(RequestData requestData)
+			where TResponse : class, IOpenSearchResponse, new() =>
+			ResponseBuilder.ToResponse<TResponse>(requestData, new HttpRequestException("simulated failure"), null, null, Stream.Null, RequestData.MimeType);
+
+		public Task<TResponse> RequestAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+			where TResponse : class, IOpenSearchResponse, new() =>
+			Task.FromResult(Request<TResponse>(requestData));
+
+		public void Dispose() { }
+	}
+
+	private sealed class SlowConnection : IConnection
+	{
+		private readonly TimeSpan _delay;
+		public SlowConnection(TimeSpan delay) => _delay = delay;
+
+		public TResponse Request<TResponse>(RequestData requestData)
+			where TResponse : class, IOpenSearchResponse, new()
+		{
+			Thread.Sleep(_delay);
+			return ResponseBuilder.ToResponse<TResponse>(requestData, new HttpRequestException("timeout"), null, null, Stream.Null, RequestData.MimeType);
+		}
+
+		public Task<TResponse> RequestAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+			where TResponse : class, IOpenSearchResponse, new() =>
+			Task.FromResult(Request<TResponse>(requestData));
+
+		public void Dispose() { }
+	}
+}


### PR DESCRIPTION
### Description

Fixes #998.

`RequestPipeline.CreateClientException` calls `Audit(MaxTimeoutReached)`, `Audit(MaxRetriesReached)`, and `Audit(FailedOverAllNodes)` but discards the returned `Auditable` without calling `Dispose()`. Since `Dispose()` is the only thing that sets `Audit.Ended`, these events are left with `Ended == default(DateTime)` (year 0001).

Any consumer computing duration from the audit trail (e.g. `AuditTrail.Last().Ended - AuditTrail.First().Started`) gets a wildly negative value (~-2026 years) on timeout/retry-exhaustion failures — the exact scenarios operators most need to diagnose.

### Fix

Call `.Dispose()` immediately on the returned `Auditable`, matching the existing `AuditCancellationRequested` pattern (line 158). These are point-in-time markers with no work between start and end.

### Testing

- Added `GitHubIssue998.cs` with 2 unit tests verifying `Ended != default` for all three audit events
- Tests **fail** without the fix, **pass** with it
- Ran the exact repro from the issue — duration now reports `12.85ms` instead of `-63920134953159.78ms`

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented in the CHANGELOG
- [x] Commits are signed off