### PR TITLE
fix: consult transport verdict in DeleteByQuery/UpdateByQuery IsValid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fixed `MaxTimeoutReached`, `MaxRetriesReached`, and `FailedOverAllNodes` audit events having `Ended` stuck at `default(DateTime)` due to undisposed `Auditable` instances in `RequestPipeline.CreateClientException` ([#998](https://github.com/opensearch-project/opensearch-net/issues/998))
+- Fixed `DeleteByQueryResponse.IsValid` and `UpdateByQueryResponse.IsValid` returning `true` on transport-level failures (no HTTP response) by restoring the `ApiCall.Success` check that the overrides had dropped ([#997](https://github.com/opensearch-project/opensearch-net/issues/997))
 ### Dependencies
 
 ## [2.0.0]

--- a/src/OpenSearch.Client/Document/Multiple/DeleteByQuery/DeleteByQueryResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/DeleteByQuery/DeleteByQueryResponse.cs
@@ -34,7 +34,7 @@ namespace OpenSearch.Client
 {
 	public class DeleteByQueryResponse : ResponseBase
 	{
-		public override bool IsValid => ApiCall?.HttpStatusCode == 200 || !Failures.HasAny();
+		public override bool IsValid => (ApiCall?.Success ?? false) && (ApiCall.HttpStatusCode == 200 || !Failures.HasAny());
 
 		[DataMember(Name ="batches")]
 		public long Batches { get; internal set; }

--- a/src/OpenSearch.Client/Document/Multiple/UpdateByQuery/UpdateByQueryResponse.cs
+++ b/src/OpenSearch.Client/Document/Multiple/UpdateByQuery/UpdateByQueryResponse.cs
@@ -34,7 +34,7 @@ namespace OpenSearch.Client
 {
 	public class UpdateByQueryResponse : ResponseBase
 	{
-		public override bool IsValid => ApiCall?.HttpStatusCode == 200 && !Failures.HasAny();
+		public override bool IsValid => (ApiCall?.Success ?? false) && ApiCall.HttpStatusCode == 200 && !Failures.HasAny();
 
 		[DataMember(Name ="batches")]
 		public long Batches { get; internal set; }

--- a/tests/Tests.Reproduce/GitHubIssue997.cs
+++ b/tests/Tests.Reproduce/GitHubIssue997.cs
@@ -4,27 +4,6 @@
 * this file be licensed under the Apache-2.0 license or a
 * compatible open source license.
 */
-/*
-* Modifications Copyright OpenSearch Contributors. See
-* GitHub history for details.
-*
-*  Licensed to Elasticsearch B.V. under one or more contributor
-*  license agreements. See the NOTICE file distributed with
-*  this work for additional information regarding copyright
-*  ownership. Elasticsearch B.V. licenses this file to you under
-*  the Apache License, Version 2.0 (the "License"); you may
-*  not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
-*
-* 	http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
-*/
 
 using System;
 using System.IO;

--- a/tests/Tests.Reproduce/GitHubIssue997.cs
+++ b/tests/Tests.Reproduce/GitHubIssue997.cs
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+/*
+* Modifications Copyright OpenSearch Contributors. See
+* GitHub history for details.
+*
+*  Licensed to Elasticsearch B.V. under one or more contributor
+*  license agreements. See the NOTICE file distributed with
+*  this work for additional information regarding copyright
+*  ownership. Elasticsearch B.V. licenses this file to you under
+*  the Apache License, Version 2.0 (the "License"); you may
+*  not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+* 	http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using OpenSearch.Client;
+using OpenSearch.Net;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue997
+	{
+		[U]
+		public void DeleteByQueryIsNotValidOnTransportFailure()
+		{
+			var client = TransportFailureClient();
+
+			var response = client.DeleteByQuery<object>(d => d.Index("test-index").Query(q => q.MatchAll()));
+
+			response.ApiCall.Success.Should().BeFalse();
+			response.ApiCall.HttpStatusCode.Should().BeNull();
+			response.IsValid.Should().BeFalse();
+		}
+
+		[U]
+		public void UpdateByQueryIsNotValidOnTransportFailure()
+		{
+			var client = TransportFailureClient();
+
+			var response = client.UpdateByQuery<object>(d => d.Index("test-index").Query(q => q.MatchAll()));
+
+			response.ApiCall.Success.Should().BeFalse();
+			response.ApiCall.HttpStatusCode.Should().BeNull();
+			response.IsValid.Should().BeFalse();
+		}
+
+		private static OpenSearchClient TransportFailureClient()
+		{
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var settings = new ConnectionSettings(pool, new TransportFailureConnection()).DisablePing();
+			return new OpenSearchClient(settings);
+		}
+
+		private sealed class TransportFailureConnection : IConnection
+		{
+			public TResponse Request<TResponse>(RequestData requestData)
+				where TResponse : class, IOpenSearchResponse, new() =>
+				ResponseBuilder.ToResponse<TResponse>(requestData, new HttpRequestException("simulated transport failure"), null, null,
+					Stream.Null, RequestData.MimeType);
+
+			public Task<TResponse> RequestAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+				where TResponse : class, IOpenSearchResponse, new() =>
+				Task.FromResult(Request<TResponse>(requestData));
+
+			public void Dispose() { }
+		}
+	}
+}


### PR DESCRIPTION
### Description

`DeleteByQueryResponse.IsValid` and `UpdateByQueryResponse.IsValid` reimplemented the transport-level check as `ApiCall?.HttpStatusCode == 200`. On a transport failure (connection error, overall request timeout, retries exhausted) no HTTP response is received, so `HttpStatusCode` is `null`.

- `DeleteByQuery` then fell back to `!Failures.HasAny()`. Since no body was deserialized, `Failures` is the default empty collection and `IsValid` returned `true` — a failed call looked like a successful `delete_by_query` that deleted nothing (`Deleted == 0`). With the default `ThrowExceptions == false`, `IsValid` is the primary error signal for callers, so the failure was invisible.
- `UpdateByQuery` used `&&`, so it did not return `true` on transport failure, but it had the same root cause: it bypassed the transport verdict instead of consulting `ApiCall.Success` / `ServerError` like `ResponseBase.IsValid`.

The base implementation catches this:

```csharp
public virtual bool IsValid => (ApiCall?.Success ?? false) && ServerError == null;
```

This restores the `ApiCall.Success` check in both overrides while keeping each response's per-document failure semantics (`DeleteByQuery`: a 200 with per-document failures stays valid; `UpdateByQuery`: failures invalidate).

Added a regression test (`GitHubIssue997`) that reproduces a transport failure via a custom `IConnection` and asserts `IsValid == false` for both responses.

### Issues Resolved

Fixes #997

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.