### PR TITLE
Add support for wildcard field type

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @anirudha @joshuali925 @Xtansia @VachaShah @MaxKsyunz @Yury-Fridlyand @SamuelCox
+*   @anirudha @joshuali925 @Xtansia @VachaShah @MaxKsyunz @Yury-Fridlyand @SamuelCox @Hailong-am

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @anirudha @joshuali925 @Xtansia @VachaShah @MaxKsyunz @Yury-Fridlyand @SamuelCox @Hailong-am
+* @Hailong-am @tony-cui

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,6 +1,6 @@
 name: Compile
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   compile:

--- a/.github/workflows/integration-yaml-tests.yml
+++ b/.github/workflows/integration-yaml-tests.yml
@@ -1,9 +1,6 @@
 name: YAML Tests
 
 on:
-  push:
-    branches-ignore:
-      - 'dependabot/**'
   pull_request: {}
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,6 @@
 name: Integration tests
 
 on:
-  push:
-    branches-ignore:
-      - 'dependabot/**'
   pull_request: {}
 
 env:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,5 +1,5 @@
 name: Link Checker
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   linkchecker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Create Release Candidate
 
-on: [pull_request, push]
+on: [pull_request]
 jobs:
   create-release-artifacts:
     name: Create Release Artifacts

--- a/.github/workflows/test-jobs.yml
+++ b/.github/workflows/test-jobs.yml
@@ -5,16 +5,6 @@ on:
     paths-ignore:
       - 'README.md'
       - '.editorconfig'
-  push:
-    paths-ignore:
-      - 'README.md'
-      - '.editorconfig'
-    branches:
-      - main
-      - master
-      - '[0-9]+.[0-9]+'
-      - '[0-9]+.x'
-      - 'dev-*'
 
 permissions:
   checks: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added conditions to the Microsoft.CSharp, System.Buffers & System.Diagnostics.DiagnosticSource dependencies so that they are not included on net 6+ as the newer framework's natively provides those dependencies. ([#930](https://github.com/opensearch-project/opensearch-net/pull/930))
 - Added support for Hybrid query ([#917](https://github.com/opensearch-project/opensearch-net/pull/917))
 - Added support for `MaxDistance` and `MinScore` to `KnnQuery` ([#917](https://github.com/opensearch-project/opensearch-net/pull/917))
+- Added System.Text.Json serialization infrastructure to OpenSearch.Net as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 
 ### Removed
 - Removed support for the `net461` target ([#256](https://github.com/opensearch-project/opensearch-net/pull/256))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added System.Text.Json serialization infrastructure to OpenSearch.Net as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 - Added System.Text.Json converters for core inference types and the Document domain as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 - Added System.Text.Json converters for the QueryDsl and Aggregations domains as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
+- Added System.Text.Json converters for the Mapping, Analysis, Ingest, and Search domains as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 
 ### Removed
 - Removed support for the `net461` target ([#256](https://github.com/opensearch-project/opensearch-net/pull/256))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for Hybrid query ([#917](https://github.com/opensearch-project/opensearch-net/pull/917))
 - Added support for `MaxDistance` and `MinScore` to `KnnQuery` ([#917](https://github.com/opensearch-project/opensearch-net/pull/917))
 - Added System.Text.Json serialization infrastructure to OpenSearch.Net as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
+- Added System.Text.Json converters for core inference types and the Document domain as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 
 ### Removed
 - Removed support for the `net461` target ([#256](https://github.com/opensearch-project/opensearch-net/pull/256))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### ⚠️ Breaking Changes ⚠️
 - As part of [efforts to re-generate the client](https://github.com/opensearch-project/opensearch-net/pulls?q=is%3Apr+label%3Acode-gen+is%3Aclosed) from our [OpenAPI specification](https://github.com/opensearch-project/opensearch-api-specification) there have been numerous corrections and changes that resulted in breaking changes. Please refer to [UPGRADING.md](UPGRADING.md) for a complete list of these breakages and any relevant guidance for upgrading to this version of the client.
+- Changed the default high-level client serialization engine from the vendored Utf8Json to `System.Text.Json` ([#388](https://github.com/opensearch-project/opensearch-net/issues/388)). Call `.UseUtf8Json()` on `ConnectionSettings`, or set the `OSC_USE_UTF8JSON` environment variable, to roll back to the legacy engine.
 
 ### Changed
 - Changed the namespace client properties on `IOpenSearchClient` to return corresponding interfaces to better enable mocking & unit testing ([#646](https://github.com/opensearch-project/opensearch-net/pull/646))
@@ -17,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added System.Text.Json converters for core inference types and the Document domain as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 - Added System.Text.Json converters for the QueryDsl and Aggregations domains as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 - Added System.Text.Json converters for the Mapping, Analysis, Ingest, and Search domains as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
+- Added System.Text.Json converters for the Indices, Snapshot, Cluster, and Nodes domains, completing the Utf8Json to System.Text.Json migration ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 
 ### Removed
 - Removed support for the `net461` target ([#256](https://github.com/opensearch-project/opensearch-net/pull/256))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for `MaxDistance` and `MinScore` to `KnnQuery` ([#917](https://github.com/opensearch-project/opensearch-net/pull/917))
 - Added System.Text.Json serialization infrastructure to OpenSearch.Net as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 - Added System.Text.Json converters for core inference types and the Document domain as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
+- Added System.Text.Json converters for the QueryDsl and Aggregations domains as part of the ongoing Utf8Json to System.Text.Json migration; the default serialization engine is unchanged ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
 
 ### Removed
 - Removed support for the `net461` target ([#256](https://github.com/opensearch-project/opensearch-net/pull/256))

--- a/src/OpenSearch.Client/Aggregations/AggregateConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregateConverter.cs
@@ -1,0 +1,1048 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// STJ converter for <see cref="IAggregate"/> that uses heuristic-based parsing
+	/// to determine the concrete aggregate type from the JSON structure.
+	/// Replaces the Utf8Json-based <c>AggregateFormatter</c>.
+	/// </summary>
+	internal sealed class AggregateConverter : JsonConverter<IAggregate>
+	{
+		public static string[] AllReservedAggregationNames { get; }
+		public static string UsingReservedAggNameFormat { get; }
+
+		private const string AsStringSuffix = "_as_string";
+
+		static AggregateConverter()
+		{
+			AllReservedAggregationNames = new[]
+			{
+				"after_key", "_as_string", "bg_count", "bottom_right",
+				"bounds", "buckets", "count", "doc_count",
+				"doc_count_error_upper_bound", "fields", "from", "top",
+				"type", "from_as_string", "hits", "key", "key_as_string",
+				"keys", "location", "max_score", "meta", "min",
+				"min_length", "score", "sum_other_doc_count", "to",
+				"to_as_string", "top_left", "total", "value",
+				"value_as_string", "values", "geometry", "properties"
+			};
+
+			var allKeys = string.Join(", ", AllReservedAggregationNames);
+			UsingReservedAggNameFormat =
+				"'{0}' is one of the reserved aggregation keywords"
+				+ " we use a heuristics based response parser and using these reserved keywords"
+				+ " could throw its heuristics off course. We are working on a solution in OpenSearch itself to make"
+				+ " the response parseable. For now these are all the reserved keywords: "
+				+ allKeys;
+		}
+
+		public override IAggregate Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+			ReadAggregate(ref reader, options);
+
+		public override void Write(Utf8JsonWriter writer, IAggregate value, JsonSerializerOptions options) =>
+			throw new NotSupportedException();
+
+		internal IAggregate ReadAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			// Depth of the aggregate object's opening brace. The matching closing brace
+			// is reported at this same depth by Utf8JsonReader. We use it below to reliably
+			// re-synchronise the reader onto this aggregate's own EndObject regardless of
+			// where the per-shape helper left it (helpers may stop on an inner EndObject).
+			var startDepth = reader.CurrentDepth;
+
+			reader.Read(); // Move past StartObject
+
+			if (reader.TokenType == JsonTokenType.EndObject)
+				return null;
+
+			// First property name
+			var propertyName = reader.GetString();
+			reader.Read(); // Move to value
+
+			Dictionary<string, object> meta = null;
+			if (propertyName == "meta")
+			{
+				meta = JsonSerializer.Deserialize<Dictionary<string, object>>(ref reader, options);
+				reader.Read(); // Move past value to next property name
+				if (reader.TokenType == JsonTokenType.EndObject)
+					return null;
+				propertyName = reader.GetString();
+				reader.Read(); // Move to value
+			}
+
+			IAggregate aggregate = null;
+			switch (propertyName)
+			{
+				case "values":
+					aggregate = GetPercentilesAggregate(ref reader, meta);
+					break;
+				case "value":
+					aggregate = GetValueAggregate(ref reader, options, meta);
+					break;
+				case "after_key":
+					aggregate = GetCompositeAggregate(ref reader, options, meta);
+					break;
+				case "buckets":
+				case "doc_count_error_upper_bound":
+					aggregate = GetMultiBucketAggregate(ref reader, options, propertyName, meta);
+					break;
+				case "count":
+					aggregate = GetStatsAggregate(ref reader, options, meta);
+					break;
+				case "doc_count":
+					aggregate = GetSingleBucketAggregate(ref reader, options, meta);
+					break;
+				case "bounds":
+					aggregate = GetGeoBoundsAggregate(ref reader, options, meta);
+					break;
+				case "hits":
+					aggregate = GetTopHitsAggregate(ref reader, options, meta);
+					break;
+				case "location":
+					aggregate = GetGeoCentroidAggregate(ref reader, options, meta);
+					break;
+				case "fields":
+					aggregate = GetMatrixStatsAggregate(ref reader, options, meta);
+					break;
+				case "min":
+					aggregate = GetGeoLineAggregate(ref reader, options, meta);
+					break;
+				case "top":
+				case "type":
+					// Skip unrecognized root fields
+					reader.Skip();
+					break;
+				default:
+					reader.Skip();
+					break;
+			}
+
+			// Re-synchronise the reader onto this aggregate object's own closing brace.
+			// The per-shape helpers above are inconsistent about where they leave the reader:
+			// some stop on the aggregate's own EndObject, others stop on an inner EndObject or
+			// on a scalar value. We advance until we reach the EndObject at the same depth as
+			// the opening brace, skipping any remaining sibling properties/values. This must
+			// leave the reader positioned exactly on the LAST token of the value (the EndObject)
+			// so STJ does not report "read too much or not enough".
+			while (!(reader.TokenType == JsonTokenType.EndObject && reader.CurrentDepth == startDepth))
+			{
+				if (!reader.Read())
+					break;
+			}
+
+			return aggregate;
+		}
+
+		private IAggregate GetPercentilesAggregate(ref Utf8JsonReader reader, IReadOnlyDictionary<string, object> meta)
+		{
+			var metric = new PercentilesAggregate { Meta = meta };
+
+			if (reader.TokenType == JsonTokenType.StartObject)
+			{
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+				{
+					var key = reader.GetString();
+					reader.Read();
+					if (key.Contains(AsStringSuffix))
+					{
+						reader.Skip();
+						continue;
+					}
+					metric.Items.Add(new PercentileItem
+					{
+						Percentile = double.Parse(key, CultureInfo.InvariantCulture),
+						Value = reader.TokenType == JsonTokenType.Null ? (double?)null : reader.GetDouble()
+					});
+				}
+			}
+			else if (reader.TokenType == JsonTokenType.StartArray)
+			{
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+				{
+					// Each item is { "key": N, "value": V }
+					double percentile = 0;
+					double? value = null;
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+					{
+						var prop = reader.GetString();
+						reader.Read();
+						if (prop == "key") percentile = reader.GetDouble();
+						else if (prop == "value") value = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						else reader.Skip();
+					}
+					metric.Items.Add(new PercentileItem { Percentile = percentile, Value = value });
+				}
+			}
+			else
+			{
+				reader.Skip();
+			}
+
+			return metric;
+		}
+
+		private IAggregate GetValueAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta)
+		{
+			if (reader.TokenType == JsonTokenType.Number || reader.TokenType == JsonTokenType.Null)
+			{
+				var value = reader.TokenType == JsonTokenType.Null ? (double?)null : reader.GetDouble();
+				string valueAsString = null;
+				List<string> keys = null;
+
+				// Peek ahead for additional properties within same object
+				// We need to check sibling properties (value_as_string, keys)
+				// They'll be read by the outer loop, but we use a helper approach:
+				// Read remaining properties in the parent object
+				while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+				{
+					var prop = reader.GetString();
+					reader.Read();
+					if (prop == "value_as_string")
+						valueAsString = reader.GetString();
+					else if (prop == "keys")
+						keys = JsonSerializer.Deserialize<List<string>>(ref reader, options);
+					else if (prop == "meta" || prop.EndsWith(AsStringSuffix))
+						reader.Skip();
+					else
+					{
+						// Unknown property - skip
+						reader.Skip();
+					}
+				}
+
+				if (keys != null)
+				{
+					return new KeyedValueAggregate
+					{
+						Value = value,
+						Keys = keys,
+						Meta = meta
+					};
+				}
+
+				return new ValueAggregate
+				{
+					Value = value,
+					ValueAsString = valueAsString,
+					Meta = meta
+				};
+			}
+
+			// Non-numeric value = scripted metric (object or array). Capture it as a LazyDocument so
+			// ScriptedMetricAggregate.Value<T>() can materialize it via the source serializer on demand.
+			var lazyValue = JsonSerializer.Deserialize<LazyDocument>(ref reader, options);
+			return new ScriptedMetricAggregate(lazyValue) { Meta = meta };
+		}
+
+		private IAggregate GetCompositeAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta)
+		{
+			// after_key value is the composite key
+			var afterKeyDict = JsonSerializer.Deserialize<IReadOnlyDictionary<string, object>>(ref reader, options);
+			var afterKey = afterKeyDict != null ? new CompositeKey(afterKeyDict) : null;
+
+			// Next should be "buckets"
+			BucketAggregate bucketAggregate = null;
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				if (prop == "buckets")
+				{
+					bucketAggregate = GetMultiBucketAggregate(ref reader, options, "buckets", meta) as BucketAggregate;
+					break;
+				}
+				else
+					reader.Skip();
+			}
+
+			var result = bucketAggregate ?? new BucketAggregate { Meta = meta };
+			result.AfterKey = afterKey;
+			return result;
+		}
+
+		private IAggregate GetSingleBucketAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta)
+		{
+			var docCount = reader.TokenType == JsonTokenType.Null ? 0L : reader.GetInt64();
+			Dictionary<string, IAggregate> subAggregates = null;
+			long bgCount = 0;
+
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+
+				if (prop == "bg_count")
+				{
+					// Aggregate-level bg_count for a top-level significant_terms/significant_text aggregate.
+					bgCount = reader.TokenType == JsonTokenType.Null ? 0L : reader.GetInt64();
+					continue;
+				}
+				if (prop == "fields")
+				{
+					var fields = JsonSerializer.Deserialize<List<MatrixStatsField>>(ref reader, options);
+					return new MatrixStatsAggregate { DocCount = docCount, Fields = fields, Meta = meta };
+				}
+				if (prop == "buckets")
+				{
+					var b = GetMultiBucketAggregate(ref reader, options, "buckets", meta) as BucketAggregate;
+					return new BucketAggregate
+					{
+						BgCount = bgCount,
+						DocCount = docCount,
+						Items = b?.Items ?? EmptyReadOnly<IBucket>.Collection,
+						Meta = meta
+					};
+				}
+
+				// Sub-aggregation
+				if (subAggregates == null)
+					subAggregates = new Dictionary<string, IAggregate>();
+				var subAgg = ReadAggregate(ref reader, options);
+				subAggregates[prop] = subAgg;
+			}
+
+			return new SingleBucketAggregate(subAggregates ?? new Dictionary<string, IAggregate>())
+			{
+				DocCount = docCount,
+				Meta = meta
+			};
+		}
+
+		private IAggregate GetStatsAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta)
+		{
+			var count = reader.TokenType == JsonTokenType.Null ? 0L : reader.GetInt64();
+
+			// Check if this might just be a GeoCentroidAggregate (only "count" with no stats fields)
+			if (!reader.Read() || reader.TokenType == JsonTokenType.EndObject)
+				return new GeoCentroidAggregate { Count = count, Meta = meta };
+
+			// Read remaining stats fields
+			double? min = null, max = null, average = null;
+			double sum = 0;
+			double? sumOfSquares = null, variance = null, stdDeviation = null;
+			double? variancePopulation = null, varianceSampling = null;
+			double? stdDeviationPopulation = null, stdDeviationSampling = null;
+			StandardDeviationBounds stdDeviationBounds = null;
+			bool isExtended = false;
+
+			while (reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+
+				switch (prop)
+				{
+					case "min":
+						min = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						break;
+					case "max":
+						max = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						break;
+					case "avg":
+						average = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						break;
+					case "sum":
+						sum = reader.TokenType == JsonTokenType.Null ? 0 : reader.GetDouble();
+						break;
+					case "sum_of_squares":
+						isExtended = true;
+						sumOfSquares = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						break;
+					case "variance":
+						isExtended = true;
+						variance = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						break;
+					case "std_deviation":
+						isExtended = true;
+						stdDeviation = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						break;
+					case "std_deviation_bounds":
+						isExtended = true;
+						stdDeviationBounds = JsonSerializer.Deserialize<StandardDeviationBounds>(ref reader, options);
+						break;
+					case "variance_population":
+						isExtended = true;
+						variancePopulation = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						break;
+					case "variance_sampling":
+						isExtended = true;
+						varianceSampling = ReadNullableDoubleOrString(ref reader);
+						break;
+					case "std_deviation_population":
+						isExtended = true;
+						stdDeviationPopulation = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+						break;
+					case "std_deviation_sampling":
+						isExtended = true;
+						stdDeviationSampling = ReadNullableDoubleOrString(ref reader);
+						break;
+					default:
+						if (prop.EndsWith(AsStringSuffix))
+							reader.Skip();
+						else
+							reader.Skip();
+						break;
+				}
+
+				if (!reader.Read() || reader.TokenType == JsonTokenType.EndObject)
+					break;
+			}
+
+			if (isExtended)
+			{
+				return new ExtendedStatsAggregate
+				{
+					Count = count,
+					Min = min,
+					Max = max,
+					Average = average,
+					Sum = sum,
+					SumOfSquares = sumOfSquares,
+					Variance = variance,
+					StdDeviation = stdDeviation,
+					StdDeviationBounds = stdDeviationBounds,
+					VariancePopulation = variancePopulation,
+					VarianceSampling = varianceSampling,
+					StdDeviationPopulation = stdDeviationPopulation,
+					StdDeviationSampling = stdDeviationSampling,
+					Meta = meta
+				};
+			}
+
+			return new StatsAggregate
+			{
+				Count = count,
+				Min = min,
+				Max = max,
+				Average = average,
+				Sum = sum,
+				Meta = meta
+			};
+		}
+
+		private static double? ReadNullableDoubleOrString(ref Utf8JsonReader reader)
+		{
+			if (reader.TokenType == JsonTokenType.Null) return null;
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var s = reader.GetString();
+				return double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) ? d : null;
+			}
+			return reader.GetDouble();
+		}
+
+		private IAggregate GetGeoBoundsAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var geoBounds = new GeoBoundsAggregate { Meta = meta };
+
+			if (reader.TokenType == JsonTokenType.StartObject)
+			{
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+				{
+					var prop = reader.GetString();
+					reader.Read();
+					switch (prop)
+					{
+						case "top_left":
+							geoBounds.Bounds.TopLeft = JsonSerializer.Deserialize<LatLon>(ref reader, options);
+							break;
+						case "bottom_right":
+							geoBounds.Bounds.BottomRight = JsonSerializer.Deserialize<LatLon>(ref reader, options);
+							break;
+						default:
+							reader.Skip();
+							break;
+					}
+				}
+			}
+			else
+				reader.Skip();
+
+			return geoBounds;
+		}
+
+		private IAggregate GetGeoCentroidAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta)
+		{
+			var geoCentroid = new GeoCentroidAggregate
+			{
+				Location = JsonSerializer.Deserialize<GeoLocation>(ref reader, options),
+				Meta = meta
+			};
+
+			// Check for "count" property next
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				if (prop == "count")
+					geoCentroid.Count = reader.GetInt64();
+				else
+					reader.Skip();
+			}
+
+			return geoCentroid;
+		}
+
+		private IAggregate GetTopHitsAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta)
+		{
+			// "hits" value is an object with total, max_score, hits
+			TotalHits total = null;
+			double? maxScore = null;
+			List<LazyDocument> hits = null;
+
+			if (reader.TokenType == JsonTokenType.StartObject)
+			{
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+				{
+					var prop = reader.GetString();
+					reader.Read();
+					switch (prop)
+					{
+						case "total":
+							total = JsonSerializer.Deserialize<TotalHits>(ref reader, options);
+							break;
+						case "max_score":
+							maxScore = reader.TokenType == JsonTokenType.Null ? null : reader.GetDouble();
+							break;
+						case "hits":
+							// Capture each hit as a LazyDocument so TopHitsAggregate.Hits<T>()/Documents<T>()
+							// can materialize the typed documents on demand via the source serializer.
+							hits = JsonSerializer.Deserialize<List<LazyDocument>>(ref reader, options);
+							break;
+						default:
+							reader.Skip();
+							break;
+					}
+				}
+			}
+			else
+				reader.Skip();
+
+			return new TopHitsAggregate(hits, options)
+			{
+				Total = total,
+				MaxScore = maxScore,
+				Meta = meta
+			};
+		}
+
+		private IAggregate GetMatrixStatsAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta, long? docCount = null)
+		{
+			var fields = JsonSerializer.Deserialize<List<MatrixStatsField>>(ref reader, options);
+			return new MatrixStatsAggregate
+			{
+				DocCount = docCount.GetValueOrDefault(),
+				Fields = fields,
+				Meta = meta
+			};
+		}
+
+		private IAggregate GetGeoLineAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options, IReadOnlyDictionary<string, object> meta)
+		{
+			var geoLine = new GeoLineAggregate { Meta = meta };
+
+			if (reader.TokenType == JsonTokenType.Null)
+				return geoLine;
+
+			// "min" is actually the "type" field for geo_line, read string
+			geoLine.Type = reader.TokenType == JsonTokenType.String ? reader.GetString() : null;
+			if (reader.TokenType != JsonTokenType.String)
+				reader.Skip();
+
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				switch (prop)
+				{
+					case "geometry":
+						geoLine.Geometry = JsonSerializer.Deserialize<LineStringGeoShape>(ref reader, options);
+						break;
+					case "properties":
+						geoLine.Properties = JsonSerializer.Deserialize<GeoLineProperties>(ref reader, options);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			return geoLine;
+		}
+
+		private IAggregate GetMultiBucketAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options,
+			string initialProperty, IReadOnlyDictionary<string, object> meta)
+		{
+			var bucket = new BucketAggregate { Meta = meta };
+
+			var propertyName = initialProperty;
+
+			if (propertyName == "doc_count_error_upper_bound")
+			{
+				bucket.DocCountErrorUpperBound = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt64();
+				if (!reader.Read() || reader.TokenType == JsonTokenType.EndObject)
+					return bucket;
+				propertyName = reader.GetString();
+				reader.Read();
+			}
+
+			if (propertyName == "sum_other_doc_count")
+			{
+				bucket.SumOtherDocCount = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt64();
+				if (!reader.Read() || reader.TokenType == JsonTokenType.EndObject)
+					return bucket;
+				propertyName = reader.GetString();
+				reader.Read(); // Move to value of "buckets"
+			}
+
+			// Now we should be at the "buckets" value
+			if (propertyName != "buckets")
+			{
+				reader.Skip();
+				return bucket;
+			}
+
+			var items = new List<IBucket>();
+			bucket.Items = items;
+
+			if (reader.TokenType == JsonTokenType.StartObject)
+			{
+				// Named buckets (filters aggregation with named filters)
+				var filterAggregates = new Dictionary<string, IAggregate>();
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+				{
+					var name = reader.GetString();
+					reader.Read();
+					var innerAgg = ReadAggregate(ref reader, options);
+					filterAggregates[name] = innerAgg;
+				}
+				return new FiltersAggregate(filterAggregates) { Meta = meta };
+			}
+
+			if (reader.TokenType == JsonTokenType.StartArray)
+			{
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+				{
+					var item = ReadBucket(ref reader, options);
+					if (item != null)
+						items.Add(item);
+				}
+			}
+			else
+			{
+				reader.Skip();
+			}
+
+			// Check for additional properties after buckets (e.g., "interval")
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				if (prop == "interval")
+				{
+					// AutoInterval for auto_date_histogram
+					bucket.AutoInterval = JsonSerializer.Deserialize<DateMathTime>(ref reader, options);
+				}
+				else
+					reader.Skip();
+			}
+
+			return bucket;
+		}
+
+		private IBucket ReadBucket(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+				return null;
+
+			reader.Read(); // Move past StartObject
+			if (reader.TokenType == JsonTokenType.EndObject)
+				return null;
+
+			var property = reader.GetString();
+			reader.Read(); // Move to value
+
+			switch (property)
+			{
+				case "key":
+					return GetKeyedBucket(ref reader, options);
+				case "from":
+				case "to":
+					return GetRangeBucket(ref reader, options, null, property);
+				case "key_as_string":
+					return GetDateHistogramBucket(ref reader, options);
+				case "doc_count":
+					return GetFiltersBucket(ref reader, options);
+				case "min":
+					return GetVariableWidthHistogramBucket(ref reader, options);
+				default:
+					// Skip unknown bucket shapes
+					SkipToEndOfCurrentObject(ref reader);
+					return null;
+			}
+		}
+
+		private IBucket GetKeyedBucket(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			// "key" value - could be string, number, array, or object (composite)
+			if (reader.TokenType == JsonTokenType.StartObject)
+				return GetCompositeBucket(ref reader, options);
+
+			object key;
+			if (reader.TokenType == JsonTokenType.String)
+				key = reader.GetString();
+			else if (reader.TokenType == JsonTokenType.StartArray)
+			{
+				// multi-terms bucket
+				var keys = new List<object>();
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+				{
+					if (reader.TokenType == JsonTokenType.String)
+						keys.Add(reader.GetString());
+					else if (reader.TokenType == JsonTokenType.Number)
+					{
+						if (reader.TryGetInt64(out var l)) keys.Add(l);
+						else keys.Add(reader.GetDouble());
+					}
+					else reader.Skip();
+				}
+				key = keys;
+			}
+			else if (reader.TokenType == JsonTokenType.Number)
+			{
+				if (reader.TryGetInt64(out var l)) key = l;
+				else key = reader.GetDouble();
+			}
+			else
+			{
+				key = null;
+				reader.Skip();
+			}
+
+			// Read next property
+			if (!reader.Read() || reader.TokenType == JsonTokenType.EndObject)
+				return new KeyedBucket<object>(null) { Key = key };
+
+			var propertyName = reader.GetString();
+			reader.Read();
+
+			// Check if this is a range bucket
+			if (propertyName == "from" || propertyName == "to")
+			{
+				var rangeKey = key is double d ? d.ToString("#.#") : key?.ToString();
+				return GetRangeBucket(ref reader, options, rangeKey, propertyName);
+			}
+
+			string keyAsString = null;
+			if (propertyName == "key_as_string")
+			{
+				keyAsString = reader.GetString();
+				reader.Read(); // next property name
+				propertyName = reader.GetString();
+				reader.Read(); // "doc_count" value
+			}
+
+			// Should be at doc_count now
+			long docCount = 0;
+			if (propertyName == "doc_count")
+				docCount = reader.TokenType == JsonTokenType.Null ? 0 : reader.GetInt64();
+
+			Dictionary<string, IAggregate> subAggregates = null;
+			long? docCountErrorUpperBound = null;
+
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+
+				switch (prop)
+				{
+					case "score":
+						return GetSignificantTermsBucket(ref reader, options, key, docCount);
+					case "doc_count_error_upper_bound":
+						docCountErrorUpperBound = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt64();
+						break;
+					default:
+						if (subAggregates == null)
+							subAggregates = new Dictionary<string, IAggregate>();
+						subAggregates[prop] = ReadAggregate(ref reader, options);
+						break;
+				}
+			}
+
+			return new KeyedBucket<object>(subAggregates)
+			{
+				Key = key,
+				KeyAsString = keyAsString,
+				DocCount = docCount,
+				DocCountErrorUpperBound = docCountErrorUpperBound
+			};
+		}
+
+		private IBucket GetCompositeBucket(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			var keyDict = JsonSerializer.Deserialize<IReadOnlyDictionary<string, object>>(ref reader, options);
+			var key = new CompositeKey(keyDict ?? new Dictionary<string, object>());
+			long? docCount = null;
+			Dictionary<string, IAggregate> nestedAggregates = null;
+
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				if (prop == "doc_count")
+					docCount = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt64();
+				else
+				{
+					if (nestedAggregates == null)
+						nestedAggregates = new Dictionary<string, IAggregate>();
+					nestedAggregates[prop] = ReadAggregate(ref reader, options);
+				}
+			}
+
+			return new CompositeBucket(nestedAggregates, key) { DocCount = docCount };
+		}
+
+		private IBucket GetRangeBucket(ref Utf8JsonReader reader, JsonSerializerOptions options, string key, string initialProperty)
+		{
+			string fromAsString = null, fromString = null;
+			string toAsString = null, toString = null;
+			long? docCount = null;
+			double? toDouble = null, fromDouble = null;
+			Dictionary<string, IAggregate> subAggregates = null;
+
+			var propertyName = initialProperty;
+			var reading = true;
+			while (reading)
+			{
+				switch (propertyName)
+				{
+					case "from":
+						if (reader.TokenType == JsonTokenType.Number)
+							fromDouble = reader.GetDouble();
+						else if (reader.TokenType == JsonTokenType.String)
+							fromString = reader.GetString();
+						else reader.Skip();
+						break;
+					case "to":
+						if (reader.TokenType == JsonTokenType.Number)
+							toDouble = reader.GetDouble();
+						else if (reader.TokenType == JsonTokenType.String)
+							toString = reader.GetString();
+						else reader.Skip();
+						break;
+					case "key":
+						key = reader.GetString();
+						break;
+					case "from_as_string":
+						fromAsString = reader.GetString();
+						break;
+					case "to_as_string":
+						toAsString = reader.GetString();
+						break;
+					case "doc_count":
+						docCount = reader.TokenType == JsonTokenType.Null ? 0 : reader.GetInt64();
+						break;
+					default:
+						// This is a sub-aggregation property
+						if (subAggregates == null)
+							subAggregates = new Dictionary<string, IAggregate>();
+						subAggregates[propertyName] = ReadAggregate(ref reader, options);
+						// Continue reading more sub-aggregates
+						while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+						{
+							var subProp = reader.GetString();
+							reader.Read();
+							subAggregates[subProp] = ReadAggregate(ref reader, options);
+						}
+						reading = false;
+						continue;
+				}
+
+				if (!reader.Read() || reader.TokenType == JsonTokenType.EndObject)
+					break;
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+				propertyName = reader.GetString();
+				reader.Read();
+			}
+
+			if (fromString != null || toString != null)
+				return new IpRangeBucket(subAggregates)
+				{
+					Key = key,
+					DocCount = docCount.GetValueOrDefault(),
+					From = fromString,
+					To = toString,
+				};
+
+			return new RangeBucket(subAggregates)
+			{
+				Key = key,
+				From = fromDouble,
+				To = toDouble,
+				DocCount = docCount.GetValueOrDefault(),
+				FromAsString = fromAsString,
+				ToAsString = toAsString,
+			};
+		}
+
+		private IBucket GetDateHistogramBucket(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			// First property was "key_as_string", value is the current token
+			var keyAsString = reader.GetString();
+
+			// Read remaining properties
+			double key = 0;
+			long docCount = 0;
+			Dictionary<string, IAggregate> subAggregates = null;
+
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				switch (prop)
+				{
+					case "key":
+						key = reader.GetDouble();
+						break;
+					case "doc_count":
+						docCount = reader.GetInt64();
+						break;
+					default:
+						if (subAggregates == null)
+							subAggregates = new Dictionary<string, IAggregate>();
+						subAggregates[prop] = ReadAggregate(ref reader, options);
+						break;
+				}
+			}
+
+			return new DateHistogramBucket(subAggregates)
+			{
+				Key = key,
+				KeyAsString = keyAsString,
+				DocCount = docCount,
+			};
+		}
+
+		private IBucket GetVariableWidthHistogramBucket(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			// First property was "min", value is the current token
+			var min = reader.GetDouble();
+			double key = 0, max = 0;
+			long docCount = 0;
+			Dictionary<string, IAggregate> subAggregates = null;
+
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				switch (prop)
+				{
+					case "key": key = reader.GetDouble(); break;
+					case "max": max = reader.GetDouble(); break;
+					case "doc_count": docCount = reader.GetInt64(); break;
+					default:
+						if (subAggregates == null) subAggregates = new Dictionary<string, IAggregate>();
+						subAggregates[prop] = ReadAggregate(ref reader, options);
+						break;
+				}
+			}
+
+			return new VariableWidthHistogramBucket(subAggregates)
+			{
+				Key = key,
+				Minimum = min,
+				Maximum = max,
+				DocCount = docCount,
+			};
+		}
+
+		private IBucket GetSignificantTermsBucket(ref Utf8JsonReader reader, JsonSerializerOptions options, object key, long docCount)
+		{
+			// Current value is the "score" value
+			var score = reader.GetDouble();
+			long bgCount = 0;
+			Dictionary<string, IAggregate> subAggregates = null;
+
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				switch (prop)
+				{
+					case "bg_count":
+						bgCount = reader.GetInt64();
+						break;
+					default:
+						if (subAggregates == null) subAggregates = new Dictionary<string, IAggregate>();
+						subAggregates[prop] = ReadAggregate(ref reader, options);
+						break;
+				}
+			}
+
+			return new SignificantTermsBucket<object>(subAggregates)
+			{
+				Key = key,
+				DocCount = docCount,
+				BgCount = bgCount,
+				Score = score
+			};
+		}
+
+		private IBucket GetFiltersBucket(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			// First property was "doc_count", value is current token
+			var docCount = reader.TokenType == JsonTokenType.Null ? 0L : reader.GetInt64();
+			Dictionary<string, IAggregate> subAggregates = null;
+
+			while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				var prop = reader.GetString();
+				reader.Read();
+				if (subAggregates == null)
+					subAggregates = new Dictionary<string, IAggregate>();
+				subAggregates[prop] = ReadAggregate(ref reader, options);
+			}
+
+			return new FiltersBucketItem(subAggregates ?? EmptyReadOnly<string, IAggregate>.Dictionary)
+			{
+				DocCount = docCount
+			};
+		}
+
+		private static void SkipToEndOfCurrentObject(ref Utf8JsonReader reader)
+		{
+			int depth = 1;
+			while (depth > 0 && reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.StartObject) depth++;
+				else if (reader.TokenType == JsonTokenType.EndObject) depth--;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/AggregateDictionaryConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregateDictionaryConverter.cs
@@ -1,0 +1,101 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// STJ converter for <see cref="AggregateDictionary"/> that handles the dynamic keying
+	/// pattern where aggregation names in the response map to aggregation result types.
+	/// Replaces the Utf8Json-based <c>AggregateDictionaryFormatter</c>.
+	/// </summary>
+	/// <remarks>
+	/// Aggregation responses use user-defined property names as keys. Each value is
+	/// an aggregate object that is parsed heuristically by <see cref="AggregateConverter"/>.
+	/// When typed_keys is enabled, the property name format is "type#name" which is split
+	/// to determine the concrete type.
+	/// </remarks>
+	internal sealed class AggregateDictionaryResponseConverter : JsonConverter<AggregateDictionary>
+	{
+		private static readonly AggregateConverter Converter = new();
+
+		public override AggregateDictionary Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var dictionary = new Dictionary<string, IAggregate>();
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return new AggregateDictionary(dictionary);
+			}
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var typedProperty = reader.GetString();
+				reader.Read(); // Move to value
+
+				if (string.IsNullOrEmpty(typedProperty))
+				{
+					reader.Skip();
+					continue;
+				}
+
+				var tokens = AggregateDictionary.TypedKeyTokens(typedProperty);
+				if (tokens.Length == 1)
+				{
+					ParseAggregate(ref reader, options, tokens[0], dictionary);
+				}
+				else
+				{
+					ReadTypedAggregate(ref reader, options, tokens, dictionary);
+				}
+			}
+
+			return new AggregateDictionary(dictionary);
+		}
+
+		public override void Write(Utf8JsonWriter writer, AggregateDictionary value, JsonSerializerOptions options) =>
+			throw new NotSupportedException();
+
+		private static void ReadTypedAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options,
+			string[] tokens, Dictionary<string, IAggregate> dictionary)
+		{
+			var name = tokens[1];
+			var type = tokens[0];
+
+			switch (type)
+			{
+				case "geo_centroid":
+					var geoCentroid = JsonSerializer.Deserialize<GeoCentroidAggregate>(ref reader, options);
+					dictionary.Add(name, geoCentroid);
+					break;
+				case "geo_line":
+					var geoLine = JsonSerializer.Deserialize<GeoLineAggregate>(ref reader, options);
+					dictionary.Add(name, geoLine);
+					break;
+				default:
+					// Fall back to heuristic-based parsing
+					ParseAggregate(ref reader, options, name, dictionary);
+					break;
+			}
+		}
+
+		private static void ParseAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options,
+			string name, Dictionary<string, IAggregate> dictionary)
+		{
+			var aggregate = Converter.ReadAggregate(ref reader, options);
+			dictionary.Add(name, aggregate);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/AggregationContainer.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregationContainer.cs
@@ -84,25 +84,14 @@ namespace OpenSearch.Client
 
 		protected override string ValidateKey(string key)
 		{
-			if (AggregateFormatter.AllReservedAggregationNames.Contains(key))
+			if (AggregateConverter.AllReservedAggregationNames.Contains(key))
 				throw new ArgumentException(
-					string.Format(AggregateFormatter.UsingReservedAggNameFormat, key), nameof(key));
+					string.Format(AggregateConverter.UsingReservedAggNameFormat, key), nameof(key));
 
 			return key;
 		}
 	}
 
-	internal class AggregationDictionaryFormatter : IJsonFormatter<AggregationDictionary>
-	{
-		private static readonly VerbatimDictionaryInterfaceKeysFormatter<string, IAggregationContainer> DictionaryKeysFormatter =
-			new VerbatimDictionaryInterfaceKeysFormatter<string, IAggregationContainer>();
-
-		public AggregationDictionary Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver) =>
-			new AggregationDictionary(DictionaryKeysFormatter.Deserialize(ref reader, formatterResolver));
-
-		public void Serialize(ref JsonWriter writer, AggregationDictionary value, IJsonFormatterResolver formatterResolver) =>
-			DictionaryKeysFormatter.Serialize(ref writer, value, formatterResolver);
-	}
 
 	[InterfaceDataContract]
 	[ReadAs(typeof(AggregationContainer))]
@@ -955,4 +944,17 @@ namespace OpenSearch.Client
 			return d;
 		}
 	}
+	internal class AggregationDictionaryFormatter : IJsonFormatter<AggregationDictionary>
+	{
+		private static readonly VerbatimDictionaryInterfaceKeysFormatter<string, IAggregationContainer> DictionaryKeysFormatter =
+			new VerbatimDictionaryInterfaceKeysFormatter<string, IAggregationContainer>();
+
+		public AggregationDictionary Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver) =>
+			new AggregationDictionary(DictionaryKeysFormatter.Deserialize(ref reader, formatterResolver));
+
+		public void Serialize(ref JsonWriter writer, AggregationDictionary value, IJsonFormatterResolver formatterResolver) =>
+			DictionaryKeysFormatter.Serialize(ref writer, value, formatterResolver);
+	}
+
+
 }

--- a/src/OpenSearch.Client/Aggregations/AggregationContainerConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/AggregationContainerConverter.cs
@@ -1,0 +1,812 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="AggregationContainer"/> that handles
+	/// the polymorphic aggregation dispatch pattern used by OpenSearch.
+	/// Each aggregation container holds one aggregation type property (e.g. "terms", "avg"),
+	/// optionally "meta" metadata, and optionally nested "aggs" sub-aggregations.
+	/// </summary>
+	internal sealed class AggregationContainerConverter : JsonConverter<AggregationContainer>
+	{
+		// Pre-computed property names for aggregation types
+		private static readonly JsonEncodedText AggsProp = JsonEncodedText.Encode("aggs");
+		private static readonly JsonEncodedText AggregationsProp = JsonEncodedText.Encode("aggregations");
+		private static readonly JsonEncodedText MetaProp = JsonEncodedText.Encode("meta");
+		private static readonly JsonEncodedText AdjacencyMatrixProp = JsonEncodedText.Encode("adjacency_matrix");
+		private static readonly JsonEncodedText AvgProp = JsonEncodedText.Encode("avg");
+		private static readonly JsonEncodedText AvgBucketProp = JsonEncodedText.Encode("avg_bucket");
+		private static readonly JsonEncodedText BucketScriptProp = JsonEncodedText.Encode("bucket_script");
+		private static readonly JsonEncodedText BucketSelectorProp = JsonEncodedText.Encode("bucket_selector");
+		private static readonly JsonEncodedText BucketSortProp = JsonEncodedText.Encode("bucket_sort");
+		private static readonly JsonEncodedText CardinalityProp = JsonEncodedText.Encode("cardinality");
+		private static readonly JsonEncodedText ChildrenProp = JsonEncodedText.Encode("children");
+		private static readonly JsonEncodedText CompositeProp = JsonEncodedText.Encode("composite");
+		private static readonly JsonEncodedText CumulativeSumProp = JsonEncodedText.Encode("cumulative_sum");
+		private static readonly JsonEncodedText DateHistogramProp = JsonEncodedText.Encode("date_histogram");
+		private static readonly JsonEncodedText AutoDateHistogramProp = JsonEncodedText.Encode("auto_date_histogram");
+		private static readonly JsonEncodedText DateRangeProp = JsonEncodedText.Encode("date_range");
+		private static readonly JsonEncodedText DerivativeProp = JsonEncodedText.Encode("derivative");
+		private static readonly JsonEncodedText DiversifiedSamplerProp = JsonEncodedText.Encode("diversified_sampler");
+		private static readonly JsonEncodedText ExtendedStatsProp = JsonEncodedText.Encode("extended_stats");
+		private static readonly JsonEncodedText ExtendedStatsBucketProp = JsonEncodedText.Encode("extended_stats_bucket");
+		private static readonly JsonEncodedText FilterProp = JsonEncodedText.Encode("filter");
+		private static readonly JsonEncodedText FiltersProp = JsonEncodedText.Encode("filters");
+		private static readonly JsonEncodedText GeoBoundsProp = JsonEncodedText.Encode("geo_bounds");
+		private static readonly JsonEncodedText GeoCentroidProp = JsonEncodedText.Encode("geo_centroid");
+		private static readonly JsonEncodedText GeoDistanceProp = JsonEncodedText.Encode("geo_distance");
+		private static readonly JsonEncodedText GeoHashGridProp = JsonEncodedText.Encode("geohash_grid");
+		private static readonly JsonEncodedText GeoLineProp = JsonEncodedText.Encode("geo_line");
+		private static readonly JsonEncodedText GeoTileGridProp = JsonEncodedText.Encode("geotile_grid");
+		private static readonly JsonEncodedText GlobalProp = JsonEncodedText.Encode("global");
+		private static readonly JsonEncodedText HistogramProp = JsonEncodedText.Encode("histogram");
+		private static readonly JsonEncodedText IpRangeProp = JsonEncodedText.Encode("ip_range");
+		private static readonly JsonEncodedText MatrixStatsProp = JsonEncodedText.Encode("matrix_stats");
+		private static readonly JsonEncodedText MaxProp = JsonEncodedText.Encode("max");
+		private static readonly JsonEncodedText MaxBucketProp = JsonEncodedText.Encode("max_bucket");
+		private static readonly JsonEncodedText MinProp = JsonEncodedText.Encode("min");
+		private static readonly JsonEncodedText MinBucketProp = JsonEncodedText.Encode("min_bucket");
+		private static readonly JsonEncodedText MissingProp = JsonEncodedText.Encode("missing");
+		private static readonly JsonEncodedText MovingAvgProp = JsonEncodedText.Encode("moving_avg");
+		private static readonly JsonEncodedText MovingFnProp = JsonEncodedText.Encode("moving_fn");
+		private static readonly JsonEncodedText NestedProp = JsonEncodedText.Encode("nested");
+		private static readonly JsonEncodedText ParentProp = JsonEncodedText.Encode("parent");
+		private static readonly JsonEncodedText PercentileRanksProp = JsonEncodedText.Encode("percentile_ranks");
+		private static readonly JsonEncodedText PercentilesProp = JsonEncodedText.Encode("percentiles");
+		private static readonly JsonEncodedText PercentilesBucketProp = JsonEncodedText.Encode("percentiles_bucket");
+		private static readonly JsonEncodedText RangeProp = JsonEncodedText.Encode("range");
+		private static readonly JsonEncodedText RareTermsProp = JsonEncodedText.Encode("rare_terms");
+		private static readonly JsonEncodedText ReverseNestedProp = JsonEncodedText.Encode("reverse_nested");
+		private static readonly JsonEncodedText SamplerProp = JsonEncodedText.Encode("sampler");
+		private static readonly JsonEncodedText ScriptedMetricProp = JsonEncodedText.Encode("scripted_metric");
+		private static readonly JsonEncodedText SerialDiffProp = JsonEncodedText.Encode("serial_diff");
+		private static readonly JsonEncodedText SignificantTermsProp = JsonEncodedText.Encode("significant_terms");
+		private static readonly JsonEncodedText SignificantTextProp = JsonEncodedText.Encode("significant_text");
+		private static readonly JsonEncodedText StatsProp = JsonEncodedText.Encode("stats");
+		private static readonly JsonEncodedText StatsBucketProp = JsonEncodedText.Encode("stats_bucket");
+		private static readonly JsonEncodedText SumProp = JsonEncodedText.Encode("sum");
+		private static readonly JsonEncodedText SumBucketProp = JsonEncodedText.Encode("sum_bucket");
+		private static readonly JsonEncodedText TermsProp = JsonEncodedText.Encode("terms");
+		private static readonly JsonEncodedText TopHitsProp = JsonEncodedText.Encode("top_hits");
+		private static readonly JsonEncodedText ValueCountProp = JsonEncodedText.Encode("value_count");
+		private static readonly JsonEncodedText WeightedAvgProp = JsonEncodedText.Encode("weighted_avg");
+		private static readonly JsonEncodedText MedianAbsoluteDeviationProp = JsonEncodedText.Encode("median_absolute_deviation");
+		private static readonly JsonEncodedText MultiTermsProp = JsonEncodedText.Encode("multi_terms");
+		private static readonly JsonEncodedText VariableWidthHistogramProp = JsonEncodedText.Encode("variable_width_histogram");
+
+		public override AggregationContainer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var container = new AggregationContainer();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to the value
+
+				ReadAggregationProperty(container, propertyName, ref reader, options);
+			}
+
+			return container;
+		}
+
+		private static void ReadAggregationProperty(
+			AggregationContainer container,
+			string propertyName,
+			ref Utf8JsonReader reader,
+			JsonSerializerOptions options)
+		{
+			switch (propertyName)
+			{
+				case "aggs":
+				case "aggregations":
+					container.Aggregations = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+					break;
+				case "meta":
+					container.Meta = JsonSerializer.Deserialize<IDictionary<string, object>>(ref reader, options);
+					break;
+				case "adjacency_matrix":
+					container.AdjacencyMatrix = JsonSerializer.Deserialize<IAdjacencyMatrixAggregation>(ref reader, options);
+					break;
+				case "avg":
+					container.Average = JsonSerializer.Deserialize<IAverageAggregation>(ref reader, options);
+					break;
+				case "avg_bucket":
+					container.AverageBucket = JsonSerializer.Deserialize<IAverageBucketAggregation>(ref reader, options);
+					break;
+				case "bucket_script":
+					container.BucketScript = JsonSerializer.Deserialize<IBucketScriptAggregation>(ref reader, options);
+					break;
+				case "bucket_selector":
+					container.BucketSelector = JsonSerializer.Deserialize<IBucketSelectorAggregation>(ref reader, options);
+					break;
+				case "bucket_sort":
+					container.BucketSort = JsonSerializer.Deserialize<IBucketSortAggregation>(ref reader, options);
+					break;
+				case "cardinality":
+					container.Cardinality = JsonSerializer.Deserialize<ICardinalityAggregation>(ref reader, options);
+					break;
+				case "children":
+					container.Children = JsonSerializer.Deserialize<IChildrenAggregation>(ref reader, options);
+					break;
+				case "composite":
+					container.Composite = JsonSerializer.Deserialize<ICompositeAggregation>(ref reader, options);
+					break;
+				case "cumulative_sum":
+					container.CumulativeSum = JsonSerializer.Deserialize<ICumulativeSumAggregation>(ref reader, options);
+					break;
+				case "date_histogram":
+					container.DateHistogram = JsonSerializer.Deserialize<IDateHistogramAggregation>(ref reader, options);
+					break;
+				case "auto_date_histogram":
+					container.AutoDateHistogram = JsonSerializer.Deserialize<IAutoDateHistogramAggregation>(ref reader, options);
+					break;
+				case "date_range":
+					container.DateRange = JsonSerializer.Deserialize<IDateRangeAggregation>(ref reader, options);
+					break;
+				case "derivative":
+					container.Derivative = JsonSerializer.Deserialize<IDerivativeAggregation>(ref reader, options);
+					break;
+				case "diversified_sampler":
+					container.DiversifiedSampler = JsonSerializer.Deserialize<IDiversifiedSamplerAggregation>(ref reader, options);
+					break;
+				case "extended_stats":
+					container.ExtendedStats = JsonSerializer.Deserialize<IExtendedStatsAggregation>(ref reader, options);
+					break;
+				case "extended_stats_bucket":
+					container.ExtendedStatsBucket = JsonSerializer.Deserialize<IExtendedStatsBucketAggregation>(ref reader, options);
+					break;
+				case "filter":
+					container.Filter = JsonSerializer.Deserialize<IFilterAggregation>(ref reader, options);
+					break;
+				case "filters":
+					container.Filters = JsonSerializer.Deserialize<IFiltersAggregation>(ref reader, options);
+					break;
+				case "geo_bounds":
+					container.GeoBounds = JsonSerializer.Deserialize<IGeoBoundsAggregation>(ref reader, options);
+					break;
+				case "geo_centroid":
+					container.GeoCentroid = JsonSerializer.Deserialize<IGeoCentroidAggregation>(ref reader, options);
+					break;
+				case "geo_distance":
+					container.GeoDistance = JsonSerializer.Deserialize<IGeoDistanceAggregation>(ref reader, options);
+					break;
+				case "geohash_grid":
+					container.GeoHash = JsonSerializer.Deserialize<IGeoHashGridAggregation>(ref reader, options);
+					break;
+				case "geo_line":
+					container.GeoLine = JsonSerializer.Deserialize<IGeoLineAggregation>(ref reader, options);
+					break;
+				case "geotile_grid":
+					container.GeoTile = JsonSerializer.Deserialize<IGeoTileGridAggregation>(ref reader, options);
+					break;
+				case "global":
+					container.Global = JsonSerializer.Deserialize<IGlobalAggregation>(ref reader, options);
+					break;
+				case "histogram":
+					container.Histogram = JsonSerializer.Deserialize<IHistogramAggregation>(ref reader, options);
+					break;
+				case "ip_range":
+					container.IpRange = JsonSerializer.Deserialize<IIpRangeAggregation>(ref reader, options);
+					break;
+				case "matrix_stats":
+					container.MatrixStats = JsonSerializer.Deserialize<IMatrixStatsAggregation>(ref reader, options);
+					break;
+				case "max":
+					container.Max = JsonSerializer.Deserialize<IMaxAggregation>(ref reader, options);
+					break;
+				case "max_bucket":
+					container.MaxBucket = JsonSerializer.Deserialize<IMaxBucketAggregation>(ref reader, options);
+					break;
+				case "min":
+					container.Min = JsonSerializer.Deserialize<IMinAggregation>(ref reader, options);
+					break;
+				case "min_bucket":
+					container.MinBucket = JsonSerializer.Deserialize<IMinBucketAggregation>(ref reader, options);
+					break;
+				case "missing":
+					container.Missing = JsonSerializer.Deserialize<IMissingAggregation>(ref reader, options);
+					break;
+				case "moving_avg":
+					container.MovingAverage = JsonSerializer.Deserialize<IMovingAverageAggregation>(ref reader, options);
+					break;
+				case "moving_fn":
+					container.MovingFunction = JsonSerializer.Deserialize<IMovingFunctionAggregation>(ref reader, options);
+					break;
+				case "nested":
+					container.Nested = JsonSerializer.Deserialize<INestedAggregation>(ref reader, options);
+					break;
+				case "parent":
+					container.Parent = JsonSerializer.Deserialize<IParentAggregation>(ref reader, options);
+					break;
+				case "percentile_ranks":
+					container.PercentileRanks = JsonSerializer.Deserialize<IPercentileRanksAggregation>(ref reader, options);
+					break;
+				case "percentiles":
+					container.Percentiles = JsonSerializer.Deserialize<IPercentilesAggregation>(ref reader, options);
+					break;
+				case "percentiles_bucket":
+					container.PercentilesBucket = JsonSerializer.Deserialize<IPercentilesBucketAggregation>(ref reader, options);
+					break;
+				case "range":
+					container.Range = JsonSerializer.Deserialize<IRangeAggregation>(ref reader, options);
+					break;
+				case "rare_terms":
+					container.RareTerms = JsonSerializer.Deserialize<IRareTermsAggregation>(ref reader, options);
+					break;
+				case "reverse_nested":
+					container.ReverseNested = JsonSerializer.Deserialize<IReverseNestedAggregation>(ref reader, options);
+					break;
+				case "sampler":
+					container.Sampler = JsonSerializer.Deserialize<ISamplerAggregation>(ref reader, options);
+					break;
+				case "scripted_metric":
+					container.ScriptedMetric = JsonSerializer.Deserialize<IScriptedMetricAggregation>(ref reader, options);
+					break;
+				case "serial_diff":
+					container.SerialDifferencing = JsonSerializer.Deserialize<ISerialDifferencingAggregation>(ref reader, options);
+					break;
+				case "significant_terms":
+					container.SignificantTerms = JsonSerializer.Deserialize<ISignificantTermsAggregation>(ref reader, options);
+					break;
+				case "significant_text":
+					container.SignificantText = JsonSerializer.Deserialize<ISignificantTextAggregation>(ref reader, options);
+					break;
+				case "stats":
+					container.Stats = JsonSerializer.Deserialize<IStatsAggregation>(ref reader, options);
+					break;
+				case "stats_bucket":
+					container.StatsBucket = JsonSerializer.Deserialize<IStatsBucketAggregation>(ref reader, options);
+					break;
+				case "sum":
+					container.Sum = JsonSerializer.Deserialize<ISumAggregation>(ref reader, options);
+					break;
+				case "sum_bucket":
+					container.SumBucket = JsonSerializer.Deserialize<ISumBucketAggregation>(ref reader, options);
+					break;
+				case "terms":
+					container.Terms = JsonSerializer.Deserialize<ITermsAggregation>(ref reader, options);
+					break;
+				case "top_hits":
+					container.TopHits = JsonSerializer.Deserialize<ITopHitsAggregation>(ref reader, options);
+					break;
+				case "value_count":
+					container.ValueCount = JsonSerializer.Deserialize<IValueCountAggregation>(ref reader, options);
+					break;
+				case "weighted_avg":
+					container.WeightedAverage = JsonSerializer.Deserialize<IWeightedAverageAggregation>(ref reader, options);
+					break;
+				case "median_absolute_deviation":
+					container.MedianAbsoluteDeviation = JsonSerializer.Deserialize<IMedianAbsoluteDeviationAggregation>(ref reader, options);
+					break;
+				case "multi_terms":
+					container.MultiTerms = JsonSerializer.Deserialize<IMultiTermsAggregation>(ref reader, options);
+					break;
+				case "variable_width_histogram":
+					container.VariableWidthHistogram = JsonSerializer.Deserialize<IVariableWidthHistogramAggregation>(ref reader, options);
+					break;
+				default:
+					// Unknown aggregation type — skip the value to maintain forward compatibility
+					reader.Skip();
+					break;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, AggregationContainer value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			// Write the aggregation type property (only one should be non-null)
+			WriteAggregationType(writer, value, options);
+
+			// Write meta if present
+			if (value.Meta != null && value.Meta.Count > 0)
+			{
+				writer.WritePropertyName(MetaProp);
+				JsonSerializer.Serialize(writer, value.Meta, options);
+			}
+
+			// Write nested aggregations if present
+			if (value.Aggregations != null && ((IDictionary<string, IAggregationContainer>)value.Aggregations).Count > 0)
+			{
+				writer.WritePropertyName(AggsProp);
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static void WriteAggregationType(Utf8JsonWriter writer, AggregationContainer value, JsonSerializerOptions options)
+		{
+			if (value.AdjacencyMatrix != null)
+			{
+				writer.WritePropertyName(AdjacencyMatrixProp);
+				JsonSerializer.Serialize(writer, value.AdjacencyMatrix, options);
+			}
+			else if (value.Average != null)
+			{
+				writer.WritePropertyName(AvgProp);
+				JsonSerializer.Serialize(writer, value.Average, options);
+			}
+			else if (value.AverageBucket != null)
+			{
+				writer.WritePropertyName(AvgBucketProp);
+				JsonSerializer.Serialize(writer, value.AverageBucket, options);
+			}
+			else if (value.BucketScript != null)
+			{
+				writer.WritePropertyName(BucketScriptProp);
+				JsonSerializer.Serialize(writer, value.BucketScript, options);
+			}
+			else if (value.BucketSelector != null)
+			{
+				writer.WritePropertyName(BucketSelectorProp);
+				JsonSerializer.Serialize(writer, value.BucketSelector, options);
+			}
+			else if (value.BucketSort != null)
+			{
+				writer.WritePropertyName(BucketSortProp);
+				JsonSerializer.Serialize(writer, value.BucketSort, options);
+			}
+			else if (value.Cardinality != null)
+			{
+				writer.WritePropertyName(CardinalityProp);
+				JsonSerializer.Serialize(writer, value.Cardinality, options);
+			}
+			else if (value.Children != null)
+			{
+				writer.WritePropertyName(ChildrenProp);
+				JsonSerializer.Serialize(writer, value.Children, options);
+			}
+			else if (value.Composite != null)
+			{
+				writer.WritePropertyName(CompositeProp);
+				JsonSerializer.Serialize(writer, value.Composite, options);
+			}
+			else if (value.CumulativeSum != null)
+			{
+				writer.WritePropertyName(CumulativeSumProp);
+				JsonSerializer.Serialize(writer, value.CumulativeSum, options);
+			}
+			else if (value.DateHistogram != null)
+			{
+				writer.WritePropertyName(DateHistogramProp);
+				JsonSerializer.Serialize(writer, value.DateHistogram, options);
+			}
+			else if (value.AutoDateHistogram != null)
+			{
+				writer.WritePropertyName(AutoDateHistogramProp);
+				JsonSerializer.Serialize(writer, value.AutoDateHistogram, options);
+			}
+			else if (value.DateRange != null)
+			{
+				writer.WritePropertyName(DateRangeProp);
+				JsonSerializer.Serialize(writer, value.DateRange, options);
+			}
+			else if (value.Derivative != null)
+			{
+				writer.WritePropertyName(DerivativeProp);
+				JsonSerializer.Serialize(writer, value.Derivative, options);
+			}
+			else if (value.DiversifiedSampler != null)
+			{
+				writer.WritePropertyName(DiversifiedSamplerProp);
+				JsonSerializer.Serialize(writer, value.DiversifiedSampler, options);
+			}
+			else if (value.ExtendedStats != null)
+			{
+				writer.WritePropertyName(ExtendedStatsProp);
+				JsonSerializer.Serialize(writer, value.ExtendedStats, options);
+			}
+			else if (value.ExtendedStatsBucket != null)
+			{
+				writer.WritePropertyName(ExtendedStatsBucketProp);
+				JsonSerializer.Serialize(writer, value.ExtendedStatsBucket, options);
+			}
+			else if (value.Filter != null)
+			{
+				writer.WritePropertyName(FilterProp);
+				JsonSerializer.Serialize(writer, value.Filter, options);
+			}
+			else if (value.Filters != null)
+			{
+				writer.WritePropertyName(FiltersProp);
+				JsonSerializer.Serialize(writer, value.Filters, options);
+			}
+			else if (value.GeoBounds != null)
+			{
+				writer.WritePropertyName(GeoBoundsProp);
+				JsonSerializer.Serialize(writer, value.GeoBounds, options);
+			}
+			else if (value.GeoCentroid != null)
+			{
+				writer.WritePropertyName(GeoCentroidProp);
+				JsonSerializer.Serialize(writer, value.GeoCentroid, options);
+			}
+			else if (value.GeoDistance != null)
+			{
+				writer.WritePropertyName(GeoDistanceProp);
+				JsonSerializer.Serialize(writer, value.GeoDistance, options);
+			}
+			else if (value.GeoHash != null)
+			{
+				writer.WritePropertyName(GeoHashGridProp);
+				JsonSerializer.Serialize(writer, value.GeoHash, options);
+			}
+			else if (value.GeoLine != null)
+			{
+				writer.WritePropertyName(GeoLineProp);
+				JsonSerializer.Serialize(writer, value.GeoLine, options);
+			}
+			else if (value.GeoTile != null)
+			{
+				writer.WritePropertyName(GeoTileGridProp);
+				JsonSerializer.Serialize(writer, value.GeoTile, options);
+			}
+			else if (value.Global != null)
+			{
+				writer.WritePropertyName(GlobalProp);
+				JsonSerializer.Serialize(writer, value.Global, options);
+			}
+			else if (value.Histogram != null)
+			{
+				writer.WritePropertyName(HistogramProp);
+				JsonSerializer.Serialize(writer, value.Histogram, options);
+			}
+			else if (value.IpRange != null)
+			{
+				writer.WritePropertyName(IpRangeProp);
+				JsonSerializer.Serialize(writer, value.IpRange, options);
+			}
+			else if (value.MatrixStats != null)
+			{
+				writer.WritePropertyName(MatrixStatsProp);
+				JsonSerializer.Serialize(writer, value.MatrixStats, options);
+			}
+			else if (value.Max != null)
+			{
+				writer.WritePropertyName(MaxProp);
+				JsonSerializer.Serialize(writer, value.Max, options);
+			}
+			else if (value.MaxBucket != null)
+			{
+				writer.WritePropertyName(MaxBucketProp);
+				JsonSerializer.Serialize(writer, value.MaxBucket, options);
+			}
+			else if (value.Min != null)
+			{
+				writer.WritePropertyName(MinProp);
+				JsonSerializer.Serialize(writer, value.Min, options);
+			}
+			else if (value.MinBucket != null)
+			{
+				writer.WritePropertyName(MinBucketProp);
+				JsonSerializer.Serialize(writer, value.MinBucket, options);
+			}
+			else if (value.Missing != null)
+			{
+				writer.WritePropertyName(MissingProp);
+				JsonSerializer.Serialize(writer, value.Missing, options);
+			}
+			else if (value.MovingAverage != null)
+			{
+				writer.WritePropertyName(MovingAvgProp);
+				JsonSerializer.Serialize(writer, value.MovingAverage, options);
+			}
+			else if (value.MovingFunction != null)
+			{
+				writer.WritePropertyName(MovingFnProp);
+				JsonSerializer.Serialize(writer, value.MovingFunction, options);
+			}
+			else if (value.Nested != null)
+			{
+				writer.WritePropertyName(NestedProp);
+				JsonSerializer.Serialize(writer, value.Nested, options);
+			}
+			else if (value.Parent != null)
+			{
+				writer.WritePropertyName(ParentProp);
+				JsonSerializer.Serialize(writer, value.Parent, options);
+			}
+			else if (value.PercentileRanks != null)
+			{
+				writer.WritePropertyName(PercentileRanksProp);
+				JsonSerializer.Serialize(writer, value.PercentileRanks, options);
+			}
+			else if (value.Percentiles != null)
+			{
+				writer.WritePropertyName(PercentilesProp);
+				JsonSerializer.Serialize(writer, value.Percentiles, options);
+			}
+			else if (value.PercentilesBucket != null)
+			{
+				writer.WritePropertyName(PercentilesBucketProp);
+				JsonSerializer.Serialize(writer, value.PercentilesBucket, options);
+			}
+			else if (value.Range != null)
+			{
+				writer.WritePropertyName(RangeProp);
+				JsonSerializer.Serialize(writer, value.Range, options);
+			}
+			else if (value.RareTerms != null)
+			{
+				writer.WritePropertyName(RareTermsProp);
+				JsonSerializer.Serialize(writer, value.RareTerms, options);
+			}
+			else if (value.ReverseNested != null)
+			{
+				writer.WritePropertyName(ReverseNestedProp);
+				JsonSerializer.Serialize(writer, value.ReverseNested, options);
+			}
+			else if (value.Sampler != null)
+			{
+				writer.WritePropertyName(SamplerProp);
+				JsonSerializer.Serialize(writer, value.Sampler, options);
+			}
+			else if (value.ScriptedMetric != null)
+			{
+				writer.WritePropertyName(ScriptedMetricProp);
+				JsonSerializer.Serialize(writer, value.ScriptedMetric, options);
+			}
+			else if (value.SerialDifferencing != null)
+			{
+				writer.WritePropertyName(SerialDiffProp);
+				JsonSerializer.Serialize(writer, value.SerialDifferencing, options);
+			}
+			else if (value.SignificantTerms != null)
+			{
+				writer.WritePropertyName(SignificantTermsProp);
+				JsonSerializer.Serialize(writer, value.SignificantTerms, options);
+			}
+			else if (value.SignificantText != null)
+			{
+				writer.WritePropertyName(SignificantTextProp);
+				JsonSerializer.Serialize(writer, value.SignificantText, options);
+			}
+			else if (value.Stats != null)
+			{
+				writer.WritePropertyName(StatsProp);
+				JsonSerializer.Serialize(writer, value.Stats, options);
+			}
+			else if (value.StatsBucket != null)
+			{
+				writer.WritePropertyName(StatsBucketProp);
+				JsonSerializer.Serialize(writer, value.StatsBucket, options);
+			}
+			else if (value.Sum != null)
+			{
+				writer.WritePropertyName(SumProp);
+				JsonSerializer.Serialize(writer, value.Sum, options);
+			}
+			else if (value.SumBucket != null)
+			{
+				writer.WritePropertyName(SumBucketProp);
+				JsonSerializer.Serialize(writer, value.SumBucket, options);
+			}
+			else if (value.Terms != null)
+			{
+				writer.WritePropertyName(TermsProp);
+				JsonSerializer.Serialize(writer, value.Terms, options);
+			}
+			else if (value.TopHits != null)
+			{
+				writer.WritePropertyName(TopHitsProp);
+				JsonSerializer.Serialize(writer, value.TopHits, options);
+			}
+			else if (value.ValueCount != null)
+			{
+				writer.WritePropertyName(ValueCountProp);
+				JsonSerializer.Serialize(writer, value.ValueCount, options);
+			}
+			else if (value.WeightedAverage != null)
+			{
+				writer.WritePropertyName(WeightedAvgProp);
+				JsonSerializer.Serialize(writer, value.WeightedAverage, options);
+			}
+			else if (value.MedianAbsoluteDeviation != null)
+			{
+				writer.WritePropertyName(MedianAbsoluteDeviationProp);
+				JsonSerializer.Serialize(writer, value.MedianAbsoluteDeviation, options);
+			}
+			else if (value.MultiTerms != null)
+			{
+				writer.WritePropertyName(MultiTermsProp);
+				JsonSerializer.Serialize(writer, value.MultiTerms, options);
+			}
+			else if (value.VariableWidthHistogram != null)
+			{
+				writer.WritePropertyName(VariableWidthHistogramProp);
+				JsonSerializer.Serialize(writer, value.VariableWidthHistogram, options);
+			}
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IAggregationContainer"/> that delegates
+	/// to <see cref="AggregationContainerConverter"/> for interface-based serialization.
+	/// </summary>
+	internal sealed class AggregationContainerInterfaceConverter : JsonConverter<IAggregationContainer>
+	{
+		private static readonly AggregationContainerConverter ConcreteConverter = new();
+
+		public override IAggregationContainer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+			ConcreteConverter.Read(ref reader, typeof(AggregationContainer), options);
+
+		public override void Write(Utf8JsonWriter writer, IAggregationContainer value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Cast to concrete type for serialization
+			if (value is AggregationContainer concrete)
+				ConcreteConverter.Write(writer, concrete, options);
+			else
+			{
+				// Fallback: create an AggregationContainer from the interface
+				var container = new AggregationContainer
+				{
+					AdjacencyMatrix = value.AdjacencyMatrix,
+					Aggregations = value.Aggregations,
+					Average = value.Average,
+					AverageBucket = value.AverageBucket,
+					BucketScript = value.BucketScript,
+					BucketSelector = value.BucketSelector,
+					BucketSort = value.BucketSort,
+					Cardinality = value.Cardinality,
+					Children = value.Children,
+					Composite = value.Composite,
+					CumulativeSum = value.CumulativeSum,
+					DateHistogram = value.DateHistogram,
+					AutoDateHistogram = value.AutoDateHistogram,
+					DateRange = value.DateRange,
+					Derivative = value.Derivative,
+					DiversifiedSampler = value.DiversifiedSampler,
+					ExtendedStats = value.ExtendedStats,
+					ExtendedStatsBucket = value.ExtendedStatsBucket,
+					Filter = value.Filter,
+					Filters = value.Filters,
+					GeoBounds = value.GeoBounds,
+					GeoCentroid = value.GeoCentroid,
+					GeoDistance = value.GeoDistance,
+					GeoHash = value.GeoHash,
+					GeoLine = value.GeoLine,
+					GeoTile = value.GeoTile,
+					Global = value.Global,
+					Histogram = value.Histogram,
+					IpRange = value.IpRange,
+					MatrixStats = value.MatrixStats,
+					Max = value.Max,
+					MaxBucket = value.MaxBucket,
+					Meta = value.Meta,
+					Min = value.Min,
+					MinBucket = value.MinBucket,
+					Missing = value.Missing,
+					MovingAverage = value.MovingAverage,
+					MovingFunction = value.MovingFunction,
+					Nested = value.Nested,
+					Parent = value.Parent,
+					PercentileRanks = value.PercentileRanks,
+					Percentiles = value.Percentiles,
+					PercentilesBucket = value.PercentilesBucket,
+					Range = value.Range,
+					RareTerms = value.RareTerms,
+					ReverseNested = value.ReverseNested,
+					Sampler = value.Sampler,
+					ScriptedMetric = value.ScriptedMetric,
+					SerialDifferencing = value.SerialDifferencing,
+					SignificantTerms = value.SignificantTerms,
+					SignificantText = value.SignificantText,
+					Stats = value.Stats,
+					StatsBucket = value.StatsBucket,
+					Sum = value.Sum,
+					SumBucket = value.SumBucket,
+					Terms = value.Terms,
+					TopHits = value.TopHits,
+					ValueCount = value.ValueCount,
+					WeightedAverage = value.WeightedAverage,
+					MedianAbsoluteDeviation = value.MedianAbsoluteDeviation,
+					MultiTerms = value.MultiTerms,
+					VariableWidthHistogram = value.VariableWidthHistogram
+				};
+				ConcreteConverter.Write(writer, container, options);
+			}
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="AggregationDictionary"/> that handles
+	/// it as a dictionary of string keys to <see cref="IAggregationContainer"/> values.
+	/// </summary>
+	internal sealed class AggregationDictionaryConverter : JsonConverter<AggregationDictionary>
+	{
+		public override AggregationDictionary Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var dictionary = new Dictionary<string, IAggregationContainer>();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var key = reader.GetString();
+				reader.Read();
+
+				var container = JsonSerializer.Deserialize<AggregationContainer>(ref reader, options);
+				if (container != null)
+					dictionary[key] = container;
+			}
+
+			return new AggregationDictionary(dictionary);
+		}
+
+		public override void Write(Utf8JsonWriter writer, AggregationDictionary value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var backing = (IDictionary<string, IAggregationContainer>)value;
+
+			writer.WriteStartObject();
+
+			foreach (var kvp in backing)
+			{
+				if (kvp.Value == null)
+					continue;
+
+				writer.WritePropertyName(kvp.Key);
+				JsonSerializer.Serialize(writer, kvp.Value, kvp.Value.GetType(), options);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeAggregationSource.cs
@@ -30,9 +30,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net;
 using OpenSearch.Net.Extensions;
-using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
 using OpenSearch.Net.Utf8Json.Resolvers;
 
@@ -42,6 +43,8 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A values source for <see cref="ICompositeAggregation" />
 	/// </summary>
+	[InterfaceDataContract]
+	[JsonConverter(typeof(CompositeAggregationSourceConverter))]
 	[JsonFormatter(typeof(CompositeAggregationSourceFormatter))]
 	public interface ICompositeAggregationSource
 	{
@@ -264,4 +267,6 @@ namespace OpenSearch.Client
 			return compositeAggregationSource;
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeAggregationSourceConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeAggregationSourceConverter.cs
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes an <see cref="ICompositeAggregationSource"/> as
+	/// <c>{ "&lt;name&gt;": { "&lt;source_type&gt;": { ...body } } }</c>. The body is written using the
+	/// concrete runtime type's own interface-data-contract, so this converter is only applied via the
+	/// interface attribute channel to avoid infinite recursion. Replaces the Utf8Json
+	/// <c>CompositeAggregationSourceFormatter</c>.
+	/// </summary>
+	internal sealed class CompositeAggregationSourceConverter : JsonConverter<ICompositeAggregationSource>
+	{
+		public override ICompositeAggregationSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			// { name: { source_type: { body } } }
+			reader.Read(); // property name (name)
+			var name = reader.GetString();
+			reader.Read(); // start object (source wrapper)
+			reader.Read(); // property name (source type)
+			var sourceType = reader.GetString();
+			reader.Read(); // start object (body)
+
+			ICompositeAggregationSource source = sourceType switch
+			{
+				"terms" => JsonSerializer.Deserialize<TermsCompositeAggregationSource>(ref reader, options),
+				"date_histogram" => JsonSerializer.Deserialize<DateHistogramCompositeAggregationSource>(ref reader, options),
+				"histogram" => JsonSerializer.Deserialize<HistogramCompositeAggregationSource>(ref reader, options),
+				"geotile_grid" => JsonSerializer.Deserialize<GeoTileGridCompositeAggregationSource>(ref reader, options),
+				_ => throw new JsonException($"Unknown {nameof(ICompositeAggregationSource)}: {sourceType}")
+			};
+
+			// After deserializing the body the reader is on the body's EndObject. Advance past the
+			// source-wrapper EndObject and onto this value's own outer EndObject, where a converter
+			// must leave the reader positioned.
+			reader.Read(); // end object (source wrapper)
+			reader.Read(); // end object (outer)
+
+			if (source != null)
+				source.Name = name;
+
+			return source;
+		}
+
+		public override void Write(Utf8JsonWriter writer, ICompositeAggregationSource value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(value.Name);
+			writer.WriteStartObject();
+			writer.WritePropertyName(value.SourceType);
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+			writer.WriteEndObject();
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeBucket.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/CompositeBucket.cs
@@ -112,7 +112,7 @@ namespace OpenSearch.Client
 				return false;
 			}
 
-			value = DateTimeUtil.UnixEpoch.AddMilliseconds(l);
+			value = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddMilliseconds(l);
 			return true;
 		}
 
@@ -154,4 +154,6 @@ namespace OpenSearch.Client
 			return new CompositeKey(dictionary);
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -36,6 +37,7 @@ namespace OpenSearch.Client
 	/// The interval parameter defines a date/time expression that determines how values should be transformed.
 	/// For instance an interval set to month will translate any values to its closest month interval..
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IDateHistogramCompositeAggregationSource : ICompositeAggregationSource
 	{
 		/// <summary>
@@ -68,6 +70,8 @@ namespace OpenSearch.Client
 	/// <inheritdoc cref="IDateHistogramCompositeAggregationSource" />
 	public class DateHistogramCompositeAggregationSource : CompositeAggregationSourceBase, IDateHistogramCompositeAggregationSource
 	{
+		internal DateHistogramCompositeAggregationSource() { }
+
 		public DateHistogramCompositeAggregationSource(string name) : base(name) { }
 
 		/// <inheritdoc />

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/GeoTileGridCompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/GeoTileGridCompositeAggregationSource.cs
@@ -27,12 +27,14 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A values source that is equivalent to a simple Geo aggregation.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IGeoTileGridCompositeAggregationSource : ICompositeAggregationSource
 	{
 		/// <summary>
@@ -45,6 +47,8 @@ namespace OpenSearch.Client
 	/// <inheritdoc cref="IGeoTileGridCompositeAggregationSource" />
 	public class GeoTileGridCompositeAggregationSource : CompositeAggregationSourceBase, IGeoTileGridCompositeAggregationSource
 	{
+		internal GeoTileGridCompositeAggregationSource() { }
+
 		public GeoTileGridCompositeAggregationSource(string name) : base(name) { }
 
 		/// <inheritdoc />

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/HistogramCompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/HistogramCompositeAggregationSource.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// For instance an interval set to 5 will translate any numeric values to its closest interval,
 	/// a value of 101 would be translated to 100 which is the key for the interval between 100 and 105.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IHistogramCompositeAggregationSource : ICompositeAggregationSource
 	{
 		/// <summary>
@@ -55,6 +57,8 @@ namespace OpenSearch.Client
 	/// <inheritdoc cref="IHistogramCompositeAggregationSource" />
 	public class HistogramCompositeAggregationSource : CompositeAggregationSourceBase, IHistogramCompositeAggregationSource
 	{
+		internal HistogramCompositeAggregationSource() { }
+
 		public HistogramCompositeAggregationSource(string name) : base(name) { }
 
 		/// <inheritdoc />

--- a/src/OpenSearch.Client/Aggregations/Bucket/Composite/TermsCompositeAggregationSource.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Composite/TermsCompositeAggregationSource.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// A values source that is equivalent to a simple terms aggregation.
 	/// The values are extracted from a field or a script exactly like the terms aggregation.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ITermsCompositeAggregationSource : ICompositeAggregationSource
 	{
 		/// <summary>
@@ -47,6 +49,8 @@ namespace OpenSearch.Client
 	/// <inheritdoc cref="ITermsCompositeAggregationSource" />
 	public class TermsCompositeAggregationSource : CompositeAggregationSourceBase, ITermsCompositeAggregationSource
 	{
+		internal TermsCompositeAggregationSource() { }
+
 		public TermsCompositeAggregationSource(string name) : base(name) { }
 
 		/// <inheritdoc />

--- a/src/OpenSearch.Client/Aggregations/Bucket/DateRange/DateRangeExpression.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/DateRange/DateRangeExpression.cs
@@ -27,10 +27,12 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(DateRangeExpression))]
+	[InterfaceDataContract]
 	public interface IDateRangeExpression
 	{
 		[DataMember(Name ="from")]

--- a/src/OpenSearch.Client/Aggregations/Bucket/Filter/FilterAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Filter/FilterAggregation.cs
@@ -28,11 +28,13 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[JsonConverter(typeof(FilterAggregationConverter))]
 	[JsonFormatter(typeof(FilterAggregationFormatter))]
 	public interface IFilterAggregation : IBucketAggregation
 	{

--- a/src/OpenSearch.Client/Aggregations/Bucket/Filter/FilterAggregationConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Filter/FilterAggregationConverter.cs
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class FilterAggregationConverter : JsonConverter<IFilterAggregation>
+	{
+		public override IFilterAggregation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var container = JsonSerializer.Deserialize<QueryContainer>(ref reader, options);
+			return new FilterAggregation { Filter = container };
+		}
+
+		public override void Write(Utf8JsonWriter writer, IFilterAggregation value, JsonSerializerOptions options)
+		{
+			if (value?.Filter == null || !value.Filter.IsWritable)
+			{
+				writer.WriteStartObject();
+				writer.WriteEndObject();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value.Filter, options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/Bucket/Histogram/HistogramOrder.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Histogram/HistogramOrder.cs
@@ -26,8 +26,11 @@
 *  under the License.
 */
 
-using OpenSearch.Net;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
@@ -38,6 +41,51 @@ namespace OpenSearch.Client
 		SortOrder Order { get; set; }
 	}
 
+	/// <summary>
+	/// Serializes an <see cref="ISortOrder"/> as a single-key object <c>{ "&lt;key&gt;": &lt;order&gt; }</c>.
+	/// Replaces the Utf8Json <c>SortOrderFormatter</c>. Declared via <c>[JsonConverter]</c> on the concrete
+	/// order types so it is honored in every context (including list elements).
+	/// </summary>
+	internal sealed class SortOrderConverter<TSortOrder> : JsonConverter<TSortOrder>
+		where TSortOrder : class, ISortOrder, new()
+	{
+		public override TSortOrder Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var sortOrder = new TSortOrder();
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+				sortOrder.Key = reader.GetString();
+				reader.Read();
+				sortOrder.Order = System.Text.Json.JsonSerializer.Deserialize<SortOrder>(ref reader, options);
+			}
+
+			return sortOrder;
+		}
+
+		public override void Write(Utf8JsonWriter writer, TSortOrder value, JsonSerializerOptions options)
+		{
+			if (value?.Key == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(value.Key);
+			System.Text.Json.JsonSerializer.Serialize(writer, value.Order, options);
+			writer.WriteEndObject();
+		}
+	}
+
+	[JsonConverter(typeof(SortOrderConverter<HistogramOrder>))]
 	[JsonFormatter(typeof(SortOrderFormatter<HistogramOrder>))]
 	public class HistogramOrder : ISortOrder
 	{

--- a/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/Term.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/MultiTerms/Term.cs
@@ -29,10 +29,12 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(Term))]
+	[InterfaceDataContract]
 	public interface ITerm
 	{
 		Field Field { get; set; }

--- a/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/IncludeExclude.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/SignificantTerms/IncludeExclude.cs
@@ -29,10 +29,13 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(IncludeExcludeConverter))]
 	[JsonFormatter(typeof(IncludeExcludeFormatter))]
 	public class IncludeExclude
 	{
@@ -47,6 +50,35 @@ namespace OpenSearch.Client
 		public IEnumerable<string> Values { get; set; }
 	}
 
+	internal sealed class IncludeExcludeConverter : JsonConverter<IncludeExclude>
+	{
+		public override IncludeExclude Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					reader.Skip();
+					return null;
+				case JsonTokenType.StartArray:
+					var values = System.Text.Json.JsonSerializer.Deserialize<IEnumerable<string>>(ref reader, options);
+					return new IncludeExclude(values);
+				case JsonTokenType.String:
+					return new IncludeExclude(reader.GetString());
+				default:
+					throw new JsonException($"Unexpected token {reader.TokenType} when deserializing {nameof(IncludeExclude)}");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, IncludeExclude value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else if (value.Values != null)
+				System.Text.Json.JsonSerializer.Serialize(writer, value.Values, options);
+			else
+				writer.WriteStringValue(value.Pattern);
+		}
+	}
 	internal class IncludeExcludeFormatter : IJsonFormatter<IncludeExclude>
 	{
 		public void Serialize(ref JsonWriter writer, IncludeExclude value, IJsonFormatterResolver formatterResolver)
@@ -90,4 +122,6 @@ namespace OpenSearch.Client
 			return termsInclude;
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsExclude.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsExclude.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -34,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Filters which terms to exclude from the response
 	/// </summary>
+	[JsonConverter(typeof(TermsExcludeConverter))]
 	[JsonFormatter(typeof(TermsExcludeFormatter))]
 	public class TermsExclude
 	{

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsExcludeConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsExcludeConverter.cs
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class TermsExcludeConverter : JsonConverter<TermsExclude>
+	{
+		public override TermsExclude Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					reader.Skip();
+					return null;
+				case JsonTokenType.StartArray:
+					var values = JsonSerializer.Deserialize<IEnumerable<string>>(ref reader, options);
+					return new TermsExclude(values);
+				case JsonTokenType.String:
+					return new TermsExclude(reader.GetString());
+				default:
+					throw new JsonException($"Unexpected token {reader.TokenType} when deserializing {nameof(TermsExclude)}");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, TermsExclude value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else if (value.Values != null)
+				JsonSerializer.Serialize(writer, value.Values, options);
+			else
+				writer.WriteStringValue(value.Pattern);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsInclude.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsInclude.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Filters which terms to include in the response
 	/// </summary>
+	[JsonConverter(typeof(TermsIncludeConverter))]
 	[JsonFormatter(typeof(TermsIncludeFormatter))]
 	public class TermsInclude
 	{

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsIncludeConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsIncludeConverter.cs
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class TermsIncludeConverter : JsonConverter<TermsInclude>
+	{
+		public override TermsInclude Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					reader.Skip();
+					return null;
+				case JsonTokenType.StartArray:
+					var values = JsonSerializer.Deserialize<IEnumerable<string>>(ref reader, options);
+					return new TermsInclude(values);
+				case JsonTokenType.StartObject:
+					long partition = 0;
+					long numberOfPartitions = 0;
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+					{
+						if (reader.TokenType != JsonTokenType.PropertyName)
+							continue;
+						var propertyName = reader.GetString();
+						reader.Read();
+						switch (propertyName)
+						{
+							case "partition":
+								partition = reader.GetInt64();
+								break;
+							case "num_partitions":
+								numberOfPartitions = reader.GetInt64();
+								break;
+							default:
+								reader.Skip();
+								break;
+						}
+					}
+					return new TermsInclude(partition, numberOfPartitions);
+				case JsonTokenType.String:
+					return new TermsInclude(reader.GetString());
+				default:
+					throw new JsonException($"Unexpected token {reader.TokenType} when deserializing {nameof(TermsInclude)}");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, TermsInclude value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+			}
+			else if (value.Values != null)
+			{
+				JsonSerializer.Serialize(writer, value.Values, options);
+			}
+			else if (value.Partition.HasValue && value.NumberOfPartitions.HasValue)
+			{
+				writer.WriteStartObject();
+				writer.WriteNumber("partition", value.Partition.Value);
+				writer.WriteNumber("num_partitions", value.NumberOfPartitions.Value);
+				writer.WriteEndObject();
+			}
+			else
+			{
+				writer.WriteStringValue(value.Pattern);
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsOrder.cs
+++ b/src/OpenSearch.Client/Aggregations/Bucket/Terms/TermsOrder.cs
@@ -26,11 +26,13 @@
 *  under the License.
 */
 
-using OpenSearch.Net;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(SortOrderConverter<TermsOrder>))]
 	[JsonFormatter(typeof(SortOrderFormatter<TermsOrder>))]
 	public class TermsOrder : ISortOrder
 	{

--- a/src/OpenSearch.Client/Aggregations/Matrix/MatrixAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Matrix/MatrixAggregation.cs
@@ -29,9 +29,11 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IMatrixAggregation : IAggregation
 	{
 		[DataMember(Name ="fields")]

--- a/src/OpenSearch.Client/Aggregations/Metric/MetricAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/MetricAggregation.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// An aggregation that computes metrics based on values extracted in
 	/// one way or another from the documents that are being aggregated.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IMetricAggregation : IAggregation
 	{
 		/// <summary>
@@ -61,6 +63,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A metric aggregation that can accept a format to use for the output of the aggregation
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IFormattableMetricAggregation : IMetricAggregation
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Aggregations/Metric/PercentileRanks/PercentileRanksAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/PercentileRanks/PercentileRanksAggregation.cs
@@ -28,10 +28,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(PercentileRanksAggregationConverter))]
 	[JsonFormatter(typeof(PercentileRanksAggregationFormatter))]
 	public interface IPercentileRanksAggregation : IFormattableMetricAggregation
 	{

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/HdrHistogramMethod.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/HdrHistogramMethod.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(HDRHistogramMethod))]
 	public interface IHDRHistogramMethod : IPercentilesMethod
 	{
 		[DataMember(Name ="number_of_significant_value_digits")]

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/TDigestMethod.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/Methods/TDigestMethod.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(TDigestMethod))]
 	public interface ITDigestMethod : IPercentilesMethod
 	{
 		[DataMember(Name ="compression")]

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesAggregation.cs
@@ -28,10 +28,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(PercentilesAggregationConverter))]
 	[JsonFormatter(typeof(PercentilesAggregationFormatter))]
 	public interface IPercentilesAggregation : IFormattableMetricAggregation
 	{

--- a/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesAggregationConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/Percentiles/PercentilesAggregationConverter.cs
@@ -1,0 +1,266 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Shared serialization helpers for the <c>percentiles</c> and <c>percentile_ranks</c>
+	/// aggregations, which both wrap the polymorphic <see cref="IPercentilesMethod"/> under
+	/// a <c>hdr</c>/<c>tdigest</c> key and share the metric-aggregation body.
+	/// </summary>
+	internal static class PercentilesMethodJson
+	{
+		public static void WriteMethod(Utf8JsonWriter writer, IPercentilesMethod method, JsonSerializerOptions options)
+		{
+			switch (method)
+			{
+				case ITDigestMethod tdigest:
+					writer.WritePropertyName("tdigest");
+					writer.WriteStartObject();
+					if (tdigest.Compression.HasValue)
+					{
+						writer.WritePropertyName("compression");
+						var doubleConverter = (JsonConverter<double>)options.GetConverter(typeof(double));
+						doubleConverter.Write(writer, tdigest.Compression.Value, options);
+					}
+					writer.WriteEndObject();
+					break;
+				case IHDRHistogramMethod hdr:
+					writer.WritePropertyName("hdr");
+					writer.WriteStartObject();
+					if (hdr.NumberOfSignificantValueDigits.HasValue)
+						writer.WriteNumber("number_of_significant_value_digits", hdr.NumberOfSignificantValueDigits.Value);
+					writer.WriteEndObject();
+					break;
+			}
+		}
+
+		public static void WriteDoubleArray(Utf8JsonWriter writer, IEnumerable<double> values, JsonSerializerOptions options)
+		{
+			var doubleConverter = (JsonConverter<double>)options.GetConverter(typeof(double));
+			writer.WriteStartArray();
+			foreach (var v in values)
+				doubleConverter.Write(writer, v, options);
+			writer.WriteEndArray();
+		}
+
+		public static void WriteMetricBody(
+			Utf8JsonWriter writer,
+			IMetricAggregation value,
+			JsonSerializerOptions options)
+		{
+			if (value.Meta != null && value.Meta.Any())
+			{
+				writer.WritePropertyName("meta");
+				JsonSerializer.Serialize(writer, value.Meta, options);
+			}
+
+			if (value.Field != null)
+			{
+				writer.WritePropertyName("field");
+				JsonSerializer.Serialize(writer, value.Field, options);
+			}
+
+			if (value.Script != null)
+			{
+				writer.WritePropertyName("script");
+				JsonSerializer.Serialize(writer, value.Script, options);
+			}
+
+			if (value.Missing.HasValue)
+			{
+				writer.WritePropertyName("missing");
+				var doubleConverter = (JsonConverter<double>)options.GetConverter(typeof(double));
+				doubleConverter.Write(writer, value.Missing.Value, options);
+			}
+		}
+	}
+
+	internal sealed class PercentilesAggregationConverter : JsonConverter<IPercentilesAggregation>
+	{
+		public override IPercentilesAggregation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var agg = new PercentilesAggregation();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var propertyName = reader.GetString();
+				reader.Read();
+
+				switch (propertyName)
+				{
+					case "hdr":
+						agg.Method = JsonSerializer.Deserialize<HDRHistogramMethod>(ref reader, options);
+						break;
+					case "tdigest":
+						agg.Method = JsonSerializer.Deserialize<TDigestMethod>(ref reader, options);
+						break;
+					case "field":
+						agg.Field = JsonSerializer.Deserialize<Field>(ref reader, options);
+						break;
+					case "script":
+						agg.Script = JsonSerializer.Deserialize<IScript>(ref reader, options);
+						break;
+					case "missing":
+						agg.Missing = reader.GetDouble();
+						break;
+					case "percents":
+						agg.Percents = JsonSerializer.Deserialize<IEnumerable<double>>(ref reader, options);
+						break;
+					case "meta":
+						agg.Meta = JsonSerializer.Deserialize<IDictionary<string, object>>(ref reader, options);
+						break;
+					case "keyed":
+						agg.Keyed = reader.GetBoolean();
+						break;
+					case "format":
+						agg.Format = reader.GetString();
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			return agg;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IPercentilesAggregation value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			PercentilesMethodJson.WriteMetricBody(writer, value, options);
+
+			if (value.Method != null)
+				PercentilesMethodJson.WriteMethod(writer, value.Method, options);
+
+			if (value.Percents != null)
+			{
+				writer.WritePropertyName("percents");
+				PercentilesMethodJson.WriteDoubleArray(writer, value.Percents, options);
+			}
+
+			if (value.Keyed.HasValue)
+				writer.WriteBoolean("keyed", value.Keyed.Value);
+
+			if (!string.IsNullOrEmpty(value.Format))
+				writer.WriteString("format", value.Format);
+
+			writer.WriteEndObject();
+		}
+	}
+
+	internal sealed class PercentileRanksAggregationConverter : JsonConverter<IPercentileRanksAggregation>
+	{
+		public override IPercentileRanksAggregation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var agg = new PercentileRanksAggregation();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var propertyName = reader.GetString();
+				reader.Read();
+
+				switch (propertyName)
+				{
+					case "hdr":
+						agg.Method = JsonSerializer.Deserialize<HDRHistogramMethod>(ref reader, options);
+						break;
+					case "tdigest":
+						agg.Method = JsonSerializer.Deserialize<TDigestMethod>(ref reader, options);
+						break;
+					case "field":
+						agg.Field = JsonSerializer.Deserialize<Field>(ref reader, options);
+						break;
+					case "script":
+						agg.Script = JsonSerializer.Deserialize<IScript>(ref reader, options);
+						break;
+					case "missing":
+						agg.Missing = reader.GetDouble();
+						break;
+					case "values":
+						agg.Values = JsonSerializer.Deserialize<IEnumerable<double>>(ref reader, options);
+						break;
+					case "meta":
+						agg.Meta = JsonSerializer.Deserialize<IDictionary<string, object>>(ref reader, options);
+						break;
+					case "keyed":
+						agg.Keyed = reader.GetBoolean();
+						break;
+					case "format":
+						agg.Format = reader.GetString();
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			return agg;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IPercentileRanksAggregation value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			PercentilesMethodJson.WriteMetricBody(writer, value, options);
+
+			if (value.Method != null)
+				PercentilesMethodJson.WriteMethod(writer, value.Method, options);
+
+			if (value.Values != null && value.Values.Any())
+			{
+				writer.WritePropertyName("values");
+				PercentilesMethodJson.WriteDoubleArray(writer, value.Values, options);
+			}
+
+			if (value.Keyed.HasValue)
+				writer.WriteBoolean("keyed", value.Keyed.Value);
+
+			if (!string.IsNullOrEmpty(value.Format))
+				writer.WriteString("format", value.Format);
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/Metric/TopHits/TopHitsAggregate.cs
+++ b/src/OpenSearch.Client/Aggregations/Metric/TopHits/TopHitsAggregate.cs
@@ -28,17 +28,28 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	public class TopHitsAggregate : MetricAggregateBase
 	{
+		private readonly JsonSerializerOptions _options;
+		// Populated only on the legacy Utf8Json path (see the resolver-based ctor).
 		private readonly IJsonFormatterResolver _formatterResolver;
 		private readonly IList<LazyDocument> _hits;
 
 		public TopHitsAggregate() { }
 
+		internal TopHitsAggregate(IList<LazyDocument> hits, JsonSerializerOptions options)
+		{
+			_hits = hits;
+			_options = options;
+		}
+
+		// Resolver-based overload used by the restored Utf8Json AggregateFormatter.
 		internal TopHitsAggregate(IList<LazyDocument> hits, IJsonFormatterResolver formatterResolver)
 		{
 			_hits = hits;
@@ -52,12 +63,24 @@ namespace OpenSearch.Client
 		private IEnumerable<IHit<TDocument>> ConvertHits<TDocument>()
 			where TDocument : class
 		{
-			var formatter = _formatterResolver.GetFormatter<IHit<TDocument>>();
-			return _hits.Select(h =>
+			if (_hits == null)
+				return Enumerable.Empty<IHit<TDocument>>();
+
+			if (_formatterResolver != null)
 			{
-				var reader = new JsonReader(h.Bytes);
-				return formatter.Deserialize(ref reader, _formatterResolver);
-			});
+				var formatter = _formatterResolver.GetFormatter<IHit<TDocument>>();
+				return _hits.Select(h =>
+				{
+					var reader = new JsonReader(h.Bytes);
+					return formatter.Deserialize(ref reader, _formatterResolver);
+				});
+			}
+
+			if (_options == null)
+				return Enumerable.Empty<IHit<TDocument>>();
+
+			return _hits.Select(h =>
+				System.Text.Json.JsonSerializer.Deserialize<IHit<TDocument>>(h.Bytes, _options));
 		}
 
 		public IReadOnlyCollection<IHit<TDocument>> Hits<TDocument>()

--- a/src/OpenSearch.Client/Aggregations/Pipeline/BucketsPath.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/BucketsPath.cs
@@ -26,11 +26,15 @@
 *  under the License.
 */
 
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(BucketsPathConverter))]
 	[JsonFormatter(typeof(BucketsPathFormatter))]
 	public interface IBucketsPath { }
 
@@ -66,6 +70,50 @@ namespace OpenSearch.Client
 		public MultiBucketsPathDescriptor Add(string name, string bucketsPath) => Assign(name, bucketsPath);
 	}
 
+	/// <summary>
+	/// Dispatches <see cref="IBucketsPath"/> to its string form (<see cref="SingleBucketsPath"/>) or
+	/// object/dictionary form (<see cref="MultiBucketsPath"/>). Declared via <c>[JsonConverter]</c> on the
+	/// interface so it is honored in every context. Replaces the Utf8Json <c>BucketsPathFormatter</c>.
+	/// </summary>
+	internal sealed class BucketsPathConverter : JsonConverter<IBucketsPath>
+	{
+		public override IBucketsPath Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.String:
+					return new SingleBucketsPath(reader.GetString());
+				case JsonTokenType.StartObject:
+					var dict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
+					return new MultiBucketsPath(dict);
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, IBucketsPath value, JsonSerializerOptions options)
+		{
+			switch (value)
+			{
+				case SingleBucketsPath single:
+					writer.WriteStringValue(single.BucketsPath);
+					break;
+				case MultiBucketsPath multi:
+					writer.WriteStartObject();
+					foreach (var kv in (IEnumerable<KeyValuePair<string, string>>)multi)
+					{
+						writer.WritePropertyName(kv.Key);
+						writer.WriteStringValue(kv.Value);
+					}
+					writer.WriteEndObject();
+					break;
+				default:
+					writer.WriteNullValue();
+					break;
+			}
+		}
+	}
 	internal class BucketsPathFormatter : IJsonFormatter<IBucketsPath>
 	{
 		public IBucketsPath Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
@@ -106,4 +154,6 @@ namespace OpenSearch.Client
 				writer.WriteNull();
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/EwmaModel.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/EwmaModel.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(EwmaModel))]
 	public interface IEwmaModel : IMovingAverageModel
 	{
 		[DataMember(Name ="alpha")]

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/SimpleModel.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/Models/SimpleModel.cs
@@ -31,6 +31,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(SimpleModel))]
 	public interface ISimpleModel : IMovingAverageModel { }
 
 	public class SimpleModel : ISimpleModel

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/MovingAverageAggregation.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/MovingAverageAggregation.cs
@@ -28,11 +28,13 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[JsonConverter(typeof(MovingAverageAggregationConverter))]
 	[JsonFormatter(typeof(MovingAverageAggregationFormatter))]
 	public interface IMovingAverageAggregation : IPipelineAggregation
 	{

--- a/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/MovingAverageAggregationConverter.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/MovingAverage/MovingAverageAggregationConverter.cs
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes the <c>moving_avg</c> pipeline aggregation. The polymorphic
+	/// <see cref="IMovingAverageModel"/> is written as a <c>model</c> name string plus a
+	/// <c>settings</c> object holding the model's parameters. Replaces the Utf8Json
+	/// <c>MovingAverageAggregationFormatter</c>.
+	/// </summary>
+	internal sealed class MovingAverageAggregationConverter : JsonConverter<IMovingAverageAggregation>
+	{
+		public override IMovingAverageAggregation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var agg = new MovingAverageAggregation();
+			string modelName = null;
+			JsonElement settings = default;
+			var hasSettings = false;
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var propertyName = reader.GetString();
+				reader.Read();
+
+				switch (propertyName)
+				{
+					case "buckets_path":
+						agg.BucketsPath = JsonSerializer.Deserialize<IBucketsPath>(ref reader, options);
+						break;
+					case "format":
+						agg.Format = reader.GetString();
+						break;
+					case "gap_policy":
+						agg.GapPolicy = JsonSerializer.Deserialize<GapPolicy?>(ref reader, options);
+						break;
+					case "minimize":
+						agg.Minimize = reader.GetBoolean();
+						break;
+					case "predict":
+						agg.Predict = reader.GetInt32();
+						break;
+					case "window":
+						agg.Window = reader.GetInt32();
+						break;
+					case "model":
+						modelName = reader.GetString();
+						break;
+					case "settings":
+						settings = JsonElement.ParseValue(ref reader);
+						hasSettings = true;
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			if (modelName != null)
+			{
+				var json = hasSettings ? settings.GetRawText() : "{}";
+				agg.Model = modelName switch
+				{
+					"linear" => JsonSerializer.Deserialize<LinearModel>(json, options),
+					"simple" => JsonSerializer.Deserialize<SimpleModel>(json, options),
+					"ewma" => JsonSerializer.Deserialize<EwmaModel>(json, options),
+					"holt" => JsonSerializer.Deserialize<HoltLinearModel>(json, options),
+					"holt_winters" => JsonSerializer.Deserialize<HoltWintersModel>(json, options),
+					_ => null
+				};
+			}
+
+			return agg;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IMovingAverageAggregation value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (value.BucketsPath != null)
+			{
+				writer.WritePropertyName("buckets_path");
+				JsonSerializer.Serialize(writer, value.BucketsPath, options);
+			}
+
+			if (value.GapPolicy != null)
+			{
+				writer.WritePropertyName("gap_policy");
+				JsonSerializer.Serialize(writer, value.GapPolicy, options);
+			}
+
+			if (!string.IsNullOrEmpty(value.Format))
+				writer.WriteString("format", value.Format);
+
+			if (value.Window != null)
+				writer.WriteNumber("window", value.Window.Value);
+
+			if (value.Minimize != null)
+				writer.WriteBoolean("minimize", value.Minimize.Value);
+
+			if (value.Predict != null)
+				writer.WriteNumber("predict", value.Predict.Value);
+
+			if (value.Model != null)
+			{
+				writer.WriteString("model", value.Model.Name);
+				writer.WritePropertyName("settings");
+				JsonSerializer.Serialize(writer, value.Model, value.Model.GetType(), options);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Aggregations/Pipeline/PipelineAggregationBase.cs
+++ b/src/OpenSearch.Client/Aggregations/Pipeline/PipelineAggregationBase.cs
@@ -29,9 +29,11 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IPipelineAggregation : IAggregation
 	{
 		[DataMember(Name ="buckets_path")]

--- a/src/OpenSearch.Client/Analysis/Analyzers/AnalyzerBase.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/AnalyzerBase.cs
@@ -27,10 +27,13 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
+	[JsonConverter(typeof(AnalyzerConverter))]
 	[JsonFormatter(typeof(AnalyzerFormatter))]
 	public interface IAnalyzer
 	{

--- a/src/OpenSearch.Client/Analysis/Analyzers/AnalyzerConverter.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/AnalyzerConverter.cs
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Polymorphic converter for <see cref="IAnalyzer"/> that dispatches on the <c>"type"</c>
+	/// discriminator when reading, and serializes the concrete runtime type when writing.
+	/// Replaces the Utf8Json <c>AnalyzerFormatter</c>.
+	/// </summary>
+	/// <remarks>
+	/// When no known <c>"type"</c> is present the analyzer is treated as a <see cref="CustomAnalyzer"/>
+	/// if a <c>"tokenizer"</c> is present, otherwise as a <see cref="LanguageAnalyzer"/> — matching the
+	/// behavior of the original Utf8Json formatter.
+	/// </remarks>
+	internal sealed class AnalyzerConverter : JsonConverter<IAnalyzer>
+	{
+		private static readonly Dictionary<string, Type> TypeMapping = new(StringComparer.Ordinal)
+		{
+			["stop"] = typeof(StopAnalyzer),
+			["standard"] = typeof(StandardAnalyzer),
+			["snowball"] = typeof(SnowballAnalyzer),
+			["pattern"] = typeof(PatternAnalyzer),
+			["keyword"] = typeof(KeywordAnalyzer),
+			["whitespace"] = typeof(WhitespaceAnalyzer),
+			["simple"] = typeof(SimpleAnalyzer),
+			["fingerprint"] = typeof(FingerprintAnalyzer),
+			["kuromoji"] = typeof(KuromojiAnalyzer),
+			["nori"] = typeof(NoriAnalyzer),
+			["icu_analyzer"] = typeof(IcuAnalyzer),
+			["custom"] = typeof(CustomAnalyzer),
+		};
+
+		public override IAnalyzer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			Type concreteType = null;
+			if (root.TryGetProperty("type", out var typeProp) && typeProp.ValueKind == JsonValueKind.String)
+			{
+				var type = typeProp.GetString();
+				if (type != null)
+					TypeMapping.TryGetValue(type, out concreteType);
+			}
+
+			if (concreteType == null)
+			{
+				// No known "type" discriminator: a "tokenizer" implies a custom analyzer, otherwise it is
+				// a language analyzer (mirrors the Utf8Json AnalyzerFormatter default behavior).
+				concreteType = root.TryGetProperty("tokenizer", out _)
+					? typeof(CustomAnalyzer)
+					: typeof(LanguageAnalyzer);
+			}
+
+			return (IAnalyzer)root.Deserialize(concreteType, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, IAnalyzer value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Analysis/Analyzers/CustomAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/CustomAnalyzer.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -41,12 +42,14 @@ namespace OpenSearch.Client
 	/// logical/registered names of token filters.
 	/// </para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ICustomAnalyzer : IAnalyzer
 	{
 		/// <summary>
 		/// The logical / registered name of the tokenizer to use.
 		/// </summary>
 		[DataMember(Name ="char_filter")]
+		[JsonConverter(typeof(SingleOrManyStringConverter))]
 		[JsonFormatter(typeof(SingleOrEnumerableFormatter<string>))]
 		IEnumerable<string> CharFilter { get; set; }
 
@@ -54,6 +57,7 @@ namespace OpenSearch.Client
 		/// An optional list of logical / registered name of token filters.
 		/// </summary>
 		[DataMember(Name ="filter")]
+		[JsonConverter(typeof(SingleOrManyStringConverter))]
 		[JsonFormatter(typeof(SingleOrEnumerableFormatter<string>))]
 		IEnumerable<string> Filter { get; set; }
 

--- a/src/OpenSearch.Client/Analysis/Analyzers/FingerprintAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/FingerprintAnalyzer.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// The fingerprint analyzer implements a fingerprinting algorithm which
 	/// is used by the OpenRefine project to assist in clustering.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IFingerprintAnalyzer : IAnalyzer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Analyzers/LanguageAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/LanguageAnalyzer.cs
@@ -29,12 +29,14 @@
 using System.Collections.Generic;
 using OpenSearch.Net;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A set of analyzers aimed at analyzing specific language text.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ILanguageAnalyzer : IAnalyzer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Analyzers/NoriAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/NoriAnalyzer.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -39,6 +40,7 @@ namespace OpenSearch.Client
 	/// <para> - nori_number token filter</para>
 	/// <para> - lowercase token filter</para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface INoriAnalyzer : IAnalyzer
 	{
 		/// <inheritdoc cref="INoriTokenizer.DecompoundMode" />

--- a/src/OpenSearch.Client/Analysis/Analyzers/PatternAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/PatternAnalyzer.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// An analyzer of type pattern that can flexibly separate text into terms via a regular expression.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IPatternAnalyzer : IAnalyzer
 	{
 		[DataMember(Name ="flags")]

--- a/src/OpenSearch.Client/Analysis/Analyzers/SnowballAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/SnowballAnalyzer.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -38,6 +39,7 @@ namespace OpenSearch.Client
 	/// snowball.tartarus.org.
 	/// </para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ISnowballAnalyzer : IAnalyzer
 	{
 		[DataMember(Name ="language")]

--- a/src/OpenSearch.Client/Analysis/Analyzers/StandardAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/StandardAnalyzer.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// An analyzer of type standard that is built of using Standard Tokenizer, with Standard Token Filter, Lower Case Token Filter, and Stop Token
 	/// Filter.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IStandardAnalyzer : IAnalyzer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Analyzers/StopAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Analyzers/StopAnalyzer.cs
@@ -28,12 +28,14 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// An analyzer of type stop that is built using a Lower Case Tokenizer, with Stop Token Filter.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IStopAnalyzer : IAnalyzer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/CharFilters/CharFilterBase.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/CharFilterBase.cs
@@ -27,10 +27,13 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
+	[JsonConverter(typeof(CharFilterConverter))]
 	[JsonFormatter(typeof(CharFilterFormatter))]
 	public interface ICharFilter
 	{

--- a/src/OpenSearch.Client/Analysis/CharFilters/CharFilterConverter.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/CharFilterConverter.cs
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Polymorphic converter for <see cref="ICharFilter"/> that dispatches on the <c>"type"</c>
+	/// discriminator when reading, and serializes the concrete runtime type when writing.
+	/// Replaces the Utf8Json <c>CharFilterFormatter</c>.
+	/// </summary>
+	internal sealed class CharFilterConverter : JsonConverter<ICharFilter>
+	{
+		private static readonly Dictionary<string, Type> TypeMapping = new(StringComparer.Ordinal)
+		{
+			["html_strip"] = typeof(HtmlStripCharFilter),
+			["mapping"] = typeof(MappingCharFilter),
+			["pattern_replace"] = typeof(PatternReplaceCharFilter),
+			["kuromoji_iteration_mark"] = typeof(KuromojiIterationMarkCharFilter),
+			["icu_normalizer"] = typeof(IcuNormalizationCharFilter),
+		};
+
+		public override ICharFilter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			if (!root.TryGetProperty("type", out var typeProp) || typeProp.ValueKind != JsonValueKind.String)
+				return null;
+
+			var type = typeProp.GetString();
+			if (type == null || !TypeMapping.TryGetValue(type, out var concreteType))
+				return null;
+
+			return (ICharFilter)root.Deserialize(concreteType, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, ICharFilter value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Analysis/CharFilters/MappingCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/MappingCharFilter.cs
@@ -28,12 +28,14 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A char filter of type mapping replacing characters of an analyzed text with given mapping.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IMappingCharFilter : ICharFilter
 	{
 		[DataMember(Name = "mappings")]

--- a/src/OpenSearch.Client/Analysis/CharFilters/PatternReplaceCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/CharFilters/PatternReplaceCharFilter.cs
@@ -27,12 +27,14 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// The pattern_replace char filter allows the use of a regex to manipulate the characters in a string before analysis.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IPatternReplaceCharFilter : ICharFilter
 	{
 		[DataMember(Name ="flags")]

--- a/src/OpenSearch.Client/Analysis/Normalizers/CustomNormalizer.cs
+++ b/src/OpenSearch.Client/Analysis/Normalizers/CustomNormalizer.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -41,12 +42,14 @@ namespace OpenSearch.Client
 	/// <para>OpenSearch does not ship with built-in normalizers so far, so the only way to create one is through composing a custom one</para>
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(CustomNormalizer))]
 	public interface ICustomNormalizer : INormalizer
 	{
 		/// <summary>
 		/// Char filters to normalize the keyword
 		/// </summary>
 		[DataMember(Name ="char_filter")]
+		[JsonConverter(typeof(SingleOrManyStringConverter))]
 		[JsonFormatter(typeof(SingleOrEnumerableFormatter<string>))]
 		IEnumerable<string> CharFilter { get; set; }
 
@@ -54,6 +57,7 @@ namespace OpenSearch.Client
 		/// An optional list of logical / registered name of token filters.
 		/// </summary>
 		[DataMember(Name ="filter")]
+		[JsonConverter(typeof(SingleOrManyStringConverter))]
 		[JsonFormatter(typeof(SingleOrEnumerableFormatter<string>))]
 		IEnumerable<string> Filter { get; set; }
 	}

--- a/src/OpenSearch.Client/Analysis/Normalizers/NormalizerBase.cs
+++ b/src/OpenSearch.Client/Analysis/Normalizers/NormalizerBase.cs
@@ -27,10 +27,13 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
+	[JsonConverter(typeof(NormalizerConverter))]
 	[JsonFormatter(typeof(NormalizerFormatter))]
 	public interface INormalizer
 	{

--- a/src/OpenSearch.Client/Analysis/Normalizers/NormalizerConverter.cs
+++ b/src/OpenSearch.Client/Analysis/Normalizers/NormalizerConverter.cs
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Polymorphic converter for <see cref="INormalizer"/>. OpenSearch only supports custom
+	/// normalizers, so every normalizer is read as a <see cref="CustomNormalizer"/> and written
+	/// via its concrete runtime type. Replaces the Utf8Json <c>NormalizerFormatter</c>.
+	/// </summary>
+	internal sealed class NormalizerConverter : JsonConverter<INormalizer>
+	{
+		public override INormalizer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			return JsonSerializer.Deserialize<CustomNormalizer>(ref reader, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, INormalizer value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuAnalyzer.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -38,6 +39,7 @@ namespace OpenSearch.Client
 	/// <remarks>
 	/// Requires analysis-icu plugin to be installed
 	/// </remarks>
+	[InterfaceDataContract]
 	public interface IIcuAnalyzer : IAnalyzer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuCollationTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuCollationTokenFilter.cs
@@ -39,6 +39,7 @@ namespace OpenSearch.Client
 	/// <remarks>
 	/// Requires analysis-icu plugin to be installed
 	/// </remarks>
+	[InterfaceDataContract]
 	public interface IIcuCollationTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuFoldingTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuFoldingTokenFilter.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -36,6 +37,7 @@ namespace OpenSearch.Client
 	/// <remarks>
 	/// Requires analysis-icu plugin to be installed
 	/// </remarks>
+	[InterfaceDataContract]
 	public interface IIcuFoldingTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuNormalizationCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuNormalizationCharFilter.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -36,6 +37,7 @@ namespace OpenSearch.Client
 	/// <remarks>
 	/// Requires analysis-icu plugin to be installed
 	/// </remarks>
+	[InterfaceDataContract]
 	public interface IIcuNormalizationCharFilter : ICharFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuNormalizationTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuNormalizationTokenFilter.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -36,6 +37,7 @@ namespace OpenSearch.Client
 	/// <remarks>
 	/// Requires analysis-icu plugin to be installed
 	/// </remarks>
+	[InterfaceDataContract]
 	public interface IIcuNormalizationTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuTokenizer.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -39,6 +40,7 @@ namespace OpenSearch.Client
 	/// <remarks>
 	/// Requires analysis-icu plugin to be installed
 	/// </remarks>
+	[InterfaceDataContract]
 	public interface IIcuTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuTransformTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Icu/IcuTransformTokenFilter.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// <remarks>
 	/// Requires analysis-icu plugin to be installed
 	/// </remarks>
+	[InterfaceDataContract]
 	public interface IIcuTransformTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiAnalyzer.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiAnalyzer.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -34,6 +35,7 @@ namespace OpenSearch.Client
 	/// An analyzer tailored for japanese that is bootstrapped with defaults.
 	/// Part of the `analysis-kuromoji` plugin:
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKuromojiAnalyzer : IAnalyzer
 	{
 		[DataMember(Name ="mode")]

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiIterationMarkCharFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiIterationMarkCharFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// The kuromoji_iteration_mark normalizes Japanese horizontal iteration marks (odoriji) to their expanded form.
 	/// Part of the `analysis-kuromoji` plugin:
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKuromojiIterationMarkCharFilter : ICharFilter
 	{
 		[DataMember(Name ="normalize_kana")]

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiPartOfSpeechTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiPartOfSpeechTokenFilter.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// The kuromoji_part_of_speech token filter removes tokens that match a set of part-of-speech tags.
 	/// Part of the `analysis-kuromoji` plugin:
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKuromojiPartOfSpeechTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiReadingFormTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiReadingFormTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// The kuromoji_readingform token filter replaces the token with its reading form in either katakana or romaji.
 	/// Part of the `analysis-kuromoji` plugin:
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKuromojiReadingFormTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiStemmerTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiStemmerTokenFilter.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// long sound character by removing this character (U+30FC). Only full-width katakana characters are supported.
 	/// Part of the `analysis-kuromoji` plugin:
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKuromojiStemmerTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Kuromoji/KuromojiTokenizer.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// A tokenizer of type pattern that can flexibly separate text into terms via a regular expression.
 	/// Part of the `analysis-kuromoji` plugin:
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKuromojiTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/Plugins/Phonetic/PhoneticTokenFilter.cs
@@ -39,6 +39,7 @@ namespace OpenSearch.Client
 	/// <remarks>
 	/// Requires the Phonetic Analysis plugin be installed (analysis-phonetic)
 	/// </remarks>
+	[InterfaceDataContract]
 	public interface IPhoneticTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/SingleOrManyStringConverter.cs
+++ b/src/OpenSearch.Client/Analysis/SingleOrManyStringConverter.cs
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Reads a JSON value that may be either a single string or an array of strings into an
+	/// <see cref="IEnumerable{String}"/>, and always writes an array. Replaces the Utf8Json
+	/// <c>SingleOrEnumerableFormatter&lt;string&gt;</c> used on analysis <c>filter</c> / <c>char_filter</c>
+	/// members, which OpenSearch may return either as a bare string or an array.
+	/// </summary>
+	internal sealed class SingleOrManyStringConverter : JsonConverter<IEnumerable<string>>
+	{
+		public override IEnumerable<string> Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.String:
+					return new[] { reader.GetString() };
+				case JsonTokenType.StartArray:
+				{
+					var list = new List<string>();
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+					{
+						if (reader.TokenType == JsonTokenType.Null)
+							list.Add(null);
+						else
+							list.Add(reader.GetString());
+					}
+					return list;
+				}
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, IEnumerable<string> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach (var s in value)
+			{
+				if (s == null)
+					writer.WriteNullValue();
+				else
+					writer.WriteStringValue(s);
+			}
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Analysis/StopWords.cs
+++ b/src/OpenSearch.Client/Analysis/StopWords.cs
@@ -81,4 +81,6 @@ namespace OpenSearch.Client
 			}
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Analysis/TokenFilters/AsciiFoldingTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/AsciiFoldingTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// A token filter of type asciifolding that converts alphabetic, numeric, and symbolic Unicode characters which are
 	/// <para> not in the first 127 ASCII characters (the “Basic Latin” Unicode block) into their ASCII equivalents, if one exists.</para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IAsciiFoldingTokenFilter : ITokenFilter
 	{
 		[DataMember(Name ="preserve_original")]

--- a/src/OpenSearch.Client/Analysis/TokenFilters/CommonGramsTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/CommonGramsTokenFilter.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -36,12 +37,14 @@ namespace OpenSearch.Client
 	///  Token filter that generates bigrams for frequently occuring terms. Single terms are still indexed.
 	/// <para>Note, common_words or common_words_path field is required.</para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ICommonGramsTokenFilter : ITokenFilter
 	{
 		/// <summary>
 		/// A list of common words to use.
 		/// </summary>
 		[DataMember(Name ="common_words")]
+		[JsonConverter(typeof(SingleOrManyStringConverter))]
 		[JsonFormatter(typeof(SingleOrEnumerableFormatter<string>))]
 		IEnumerable<string> CommonWords { get; set; }
 

--- a/src/OpenSearch.Client/Analysis/TokenFilters/CompoundWord/CompoundWordTokenFilterBase.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/CompoundWord/CompoundWordTokenFilterBase.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Token filters that allow to decompose compound words.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ICompoundWordTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/ConditionTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/ConditionTokenFilter.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -36,6 +37,7 @@ namespace OpenSearch.Client
 	/// The conditional token filter takes a predicate script and a list of subfilters, and
 	/// only applies the subfilters to the current token if it matches the predicate.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IConditionTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/DelimitedPayload/DelimitedPayloadTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/DelimitedPayload/DelimitedPayloadTokenFilter.cs
@@ -27,12 +27,14 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// Splits tokens into tokens and payload whenever a delimiter character is found.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IDelimitedPayloadTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/EdgeNGram/EdgeNGramTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/EdgeNGram/EdgeNGramTokenFilter.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A token filter of type edgeNGram.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IEdgeNGramTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/ElisionTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/ElisionTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A token filter which removes elisions. For example, “l’avion” (the plane) will tokenized as “avion” (plane).
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IElisionTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/FingerprintTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/FingerprintTokenFilter.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// clustered on. It does this by sorting the tokens, deduplicating and
 	/// then concatenating them back into a single token.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IFingerprintTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/HunspellTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/HunspellTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	///  Basic support for hunspell stemming.
 	/// <para> Hunspell dictionaries will be picked up from a dedicated hunspell directory on the filesystem.</para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IHunspellTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/KeepTypesTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/KeepTypesTokenFilter.cs
@@ -29,6 +29,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -45,6 +46,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A token filter of type keep that only keeps tokens with text contained in a predefined set of words.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKeepTypesTokenFilter : ITokenFilter
 	{
 		/// <summary> Whether to include or exclude the types provided on <see cref="Types" /> </summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/KeepWordsTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/KeepWordsTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A token filter of type keep that only keeps tokens with text contained in a predefined set of words.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKeepWordsTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/KeywordMarkerTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/KeywordMarkerTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Protects words from being modified by stemmers. Must be placed before any stemming filters.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKeywordMarkerTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/LengthTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/LengthTokenFilter.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A token filter of type length that removes words that are too long or too short for the stream.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ILengthTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/LimitTokenCountTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/LimitTokenCountTokenFilter.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Limits the number of tokens that are indexed per document and field.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ILimitTokenCountTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/LowercaseTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/LowercaseTokenFilter.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -34,6 +35,7 @@ namespace OpenSearch.Client
 	///  A token filter of type lowercase that normalizes token text to lower case.
 	/// <para> Lowercase token filter supports Greek and Turkish lowercase token filters through the language parameter.</para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ILowercaseTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/MultiplexerTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/MultiplexerTokenFilter.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// A token filter of type multiplexer will emit multiple tokens at the same position, each version of the token having
 	/// been run through a different filter. Identical output tokens at the same position will be removed.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IMultiplexerTokenFilter : ITokenFilter
 	{
 		[DataMember(Name ="filters")]

--- a/src/OpenSearch.Client/Analysis/TokenFilters/NgramTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/NgramTokenFilter.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A token filter of type nGram.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface INGramTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/NoriPartOfSpeechTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/NoriPartOfSpeechTokenFilter.cs
@@ -28,10 +28,12 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary> The nori_part_of_speech token filter removes tokens that match a set of part-of-speech tags. </summary>
+	[InterfaceDataContract]
 	public interface INoriPartOfSpeechTokenFilter : ITokenFilter
 	{
 		/// <summary> An array of part-of-speech tags that should be removed. </summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/PatternCaptureTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/PatternCaptureTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// The pattern_capture token filter, unlike the pattern tokenizer, emits a token for every capture group in the regular expression.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IPatternCaptureTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/PatternReplaceTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/PatternReplaceTokenFilter.cs
@@ -27,12 +27,14 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// The pattern_replace token filter allows to easily handle string replacements based on a regular expression.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IPatternReplaceTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/PredicateTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/PredicateTokenFilter.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// The predicate_token_filter token filter takes a predicate script, and removes tokens that do
 	/// not match the predicate.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IPredicateTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Shingle/ShingleTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Shingle/ShingleTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// A token filter of type shingle that constructs shingles (token n-grams) from a token stream.
 	/// <para>In other words, it creates combinations of tokens as a single token. </para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IShingleTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/SnowballTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/SnowballTokenFilter.cs
@@ -27,12 +27,14 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A filter that stems words using a Snowball-generated stemmer.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ISnowballTokenFilter : ITokenFilter
 	{
 		[DataMember(Name ="language")]

--- a/src/OpenSearch.Client/Analysis/TokenFilters/StemmerOverrideTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/StemmerOverrideTokenFilter.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// Overrides stemming algorithms, by applying a custom mapping, then protecting these terms from being modified by stemmers. Must be placed
 	/// before any stemming filters.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IStemmerOverrideTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/StemmerTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/StemmerTokenFilter.cs
@@ -27,12 +27,14 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A filter that stems words (similar to snowball, but with more options).
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IStemmerTokenFilter : ITokenFilter
 	{
 		[DataMember(Name ="language")]

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Stop/StopTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Stop/StopTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A token filter of type stop that removes stop words from token streams.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IStopTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymGraphTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymGraphTokenFilter.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// The synonym_graph token filter allows to easily handle synonyms,
 	/// including multi-word synonyms correctly during the analysis process.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ISynonymGraphTokenFilter : ITokenFilter
 	{
 		[DataMember(Name ="expand")]

--- a/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/Synonym/SynonymTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// The synonym token filter allows to easily handle synonyms during the analysis process.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ISynonymTokenFilter : ITokenFilter
 	{
 		[DataMember(Name ="expand")]

--- a/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilterBase.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilterBase.cs
@@ -27,10 +27,13 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
+	[JsonConverter(typeof(TokenFilterConverter))]
 	[JsonFormatter(typeof(TokenFilterFormatter))]
 	public interface ITokenFilter
 	{

--- a/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilterConverter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/TokenFilterConverter.cs
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Polymorphic converter for <see cref="ITokenFilter"/> that dispatches on the <c>"type"</c>
+	/// discriminator when reading, and serializes the concrete runtime type when writing.
+	/// Replaces the Utf8Json <c>TokenFilterFormatter</c>.
+	/// </summary>
+	internal sealed class TokenFilterConverter : JsonConverter<ITokenFilter>
+	{
+		private static readonly Dictionary<string, Type> TypeMapping = new(StringComparer.Ordinal)
+		{
+			["asciifolding"] = typeof(AsciiFoldingTokenFilter),
+			["common_grams"] = typeof(CommonGramsTokenFilter),
+			["delimited_payload"] = typeof(DelimitedPayloadTokenFilter),
+			["delimited_payload_filter"] = typeof(DelimitedPayloadTokenFilter),
+			["dictionary_decompounder"] = typeof(DictionaryDecompounderTokenFilter),
+			["edge_ngram"] = typeof(EdgeNGramTokenFilter),
+			["elision"] = typeof(ElisionTokenFilter),
+			["hunspell"] = typeof(HunspellTokenFilter),
+			["hyphenation_decompounder"] = typeof(HyphenationDecompounderTokenFilter),
+			["keep_types"] = typeof(KeepTypesTokenFilter),
+			["keep"] = typeof(KeepWordsTokenFilter),
+			["keyword_marker"] = typeof(KeywordMarkerTokenFilter),
+			["kstem"] = typeof(KStemTokenFilter),
+			["length"] = typeof(LengthTokenFilter),
+			["limit"] = typeof(LimitTokenCountTokenFilter),
+			["lowercase"] = typeof(LowercaseTokenFilter),
+			["ngram"] = typeof(NGramTokenFilter),
+			["pattern_capture"] = typeof(PatternCaptureTokenFilter),
+			["pattern_replace"] = typeof(PatternReplaceTokenFilter),
+			["porter_stem"] = typeof(PorterStemTokenFilter),
+			["phonetic"] = typeof(PhoneticTokenFilter),
+			["reverse"] = typeof(ReverseTokenFilter),
+			["shingle"] = typeof(ShingleTokenFilter),
+			["snowball"] = typeof(SnowballTokenFilter),
+			["stemmer"] = typeof(StemmerTokenFilter),
+			["stemmer_override"] = typeof(StemmerOverrideTokenFilter),
+			["stop"] = typeof(StopTokenFilter),
+			["synonym"] = typeof(SynonymTokenFilter),
+			["synonym_graph"] = typeof(SynonymGraphTokenFilter),
+			["trim"] = typeof(TrimTokenFilter),
+			["truncate"] = typeof(TruncateTokenFilter),
+			["unique"] = typeof(UniqueTokenFilter),
+			["uppercase"] = typeof(UppercaseTokenFilter),
+			["word_delimiter"] = typeof(WordDelimiterTokenFilter),
+			["word_delimiter_graph"] = typeof(WordDelimiterGraphTokenFilter),
+			["fingerprint"] = typeof(FingerprintTokenFilter),
+			["nori_part_of_speech"] = typeof(NoriPartOfSpeechTokenFilter),
+			["kuromoji_readingform"] = typeof(KuromojiReadingFormTokenFilter),
+			["kuromoji_part_of_speech"] = typeof(KuromojiPartOfSpeechTokenFilter),
+			["kuromoji_stemmer"] = typeof(KuromojiStemmerTokenFilter),
+			["icu_collation"] = typeof(IcuCollationTokenFilter),
+			["icu_folding"] = typeof(IcuFoldingTokenFilter),
+			["icu_normalizer"] = typeof(IcuNormalizationTokenFilter),
+			["icu_transform"] = typeof(IcuTransformTokenFilter),
+			["condition"] = typeof(ConditionTokenFilter),
+			["multiplexer"] = typeof(MultiplexerTokenFilter),
+			["predicate_token_filter"] = typeof(PredicateTokenFilter),
+		};
+
+		public override ITokenFilter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			if (!root.TryGetProperty("type", out var typeProp) || typeProp.ValueKind != JsonValueKind.String)
+				return null;
+
+			var type = typeProp.GetString();
+			if (type == null || !TypeMapping.TryGetValue(type, out var concreteType))
+				return null;
+
+			return (ITokenFilter)root.Deserialize(concreteType, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, ITokenFilter value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Analysis/TokenFilters/TruncateTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/TruncateTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// The truncate token filter can be used to truncate tokens into a specific length. This can come in handy with keyword (single token)
 	/// <para> based mapped fields that are used for sorting in order to reduce memory usage.</para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ITruncateTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/UniqueTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/UniqueTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// The unique token filter can be used to only index unique tokens during analysis. By default it is applied on all the
 	/// token stream
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IUniqueTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/WordDelimiter/WordDelimiterTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/WordDelimiter/WordDelimiterTokenFilter.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Named word_delimiter, it Splits words into subwords and performs optional transformations on subword groups.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IWordDelimiterTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/TokenFilters/WordDelimiterGraph/WordDelimiterGraphTokenFilter.cs
+++ b/src/OpenSearch.Client/Analysis/TokenFilters/WordDelimiterGraph/WordDelimiterGraphTokenFilter.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// Named word_delimiter, it Splits words into subwords and performs optional transformations on subword groups.
 	/// Unlike the word_delimiter this token filter named word_delimiter_graph correctly handles multi terms expansion at query time.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IWordDelimiterGraphTokenFilter : ITokenFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/CharGroupTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/CharGroupTokenizer.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// A tokenizer that breaks text into terms whenever it encounters a character which is in a defined set. It is mostly useful
 	/// for cases where a simple custom tokenization is desired, and the overhead of use of <see cref="PatternTokenizer" /> is not acceptable.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ICharGroupTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/KeywordTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/KeywordTokenizer.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A tokenizer of type keyword that emits the entire input as a single input.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IKeywordTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/NGram/EdgeNGramTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/NGram/EdgeNGramTokenizer.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A tokenizer of type edgeNGram.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IEdgeNGramTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/NGram/NGramTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/NGram/NGramTokenizer.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A tokenizer of type nGram.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface INGramTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/NoriTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/NoriTokenizer.cs
@@ -51,6 +51,7 @@ namespace OpenSearch.Client
 	}
 
 	/// <summary> Tokenizer that ships with the analysis-nori plugin</summary>
+	[InterfaceDataContract]
 	public interface INoriTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/PathHierarchyTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/PathHierarchyTokenizer.cs
@@ -40,6 +40,7 @@ namespace OpenSearch.Client
 	/// <para>/something/something</para>
 	/// <para>/something/something/else</para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IPathHierarchyTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/PatternTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/PatternTokenizer.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A tokenizer of type pattern that can flexibly separate text into terms via a regular expression.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IPatternTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/StandardTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/StandardTokenizer.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// documents.
 	/// <para>The tokenizer implements the Unicode Text Segmentation algorithm, as specified in Unicode Standard Annex #29.</para>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IStandardTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/TokenizerBase.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/TokenizerBase.cs
@@ -27,10 +27,13 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
+	[JsonConverter(typeof(TokenizerConverter))]
 	[JsonFormatter(typeof(TokenizerFormatter))]
 	public interface ITokenizer
 	{

--- a/src/OpenSearch.Client/Analysis/Tokenizers/TokenizerConverter.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/TokenizerConverter.cs
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Polymorphic converter for <see cref="ITokenizer"/> that dispatches on the <c>"type"</c>
+	/// discriminator when reading, and serializes the concrete runtime type when writing.
+	/// Replaces the Utf8Json <c>TokenizerFormatter</c>.
+	/// </summary>
+	internal sealed class TokenizerConverter : JsonConverter<ITokenizer>
+	{
+		private static readonly Dictionary<string, Type> TypeMapping = new(StringComparer.Ordinal)
+		{
+			["char_group"] = typeof(CharGroupTokenizer),
+			["edgengram"] = typeof(EdgeNGramTokenizer),
+			["edge_ngram"] = typeof(EdgeNGramTokenizer),
+			["ngram"] = typeof(NGramTokenizer),
+			["path_hierarchy"] = typeof(PathHierarchyTokenizer),
+			["pattern"] = typeof(PatternTokenizer),
+			["standard"] = typeof(StandardTokenizer),
+			["uax_url_email"] = typeof(UaxEmailUrlTokenizer),
+			["whitespace"] = typeof(WhitespaceTokenizer),
+			["kuromoji_tokenizer"] = typeof(KuromojiTokenizer),
+			["icu_tokenizer"] = typeof(IcuTokenizer),
+			["nori_tokenizer"] = typeof(NoriTokenizer),
+		};
+
+		public override ITokenizer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			if (!root.TryGetProperty("type", out var typeProp) || typeProp.ValueKind != JsonValueKind.String)
+				return null;
+
+			var type = typeProp.GetString();
+			if (type == null || !TypeMapping.TryGetValue(type, out var concreteType))
+				return null;
+
+			return (ITokenizer)root.Deserialize(concreteType, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, ITokenizer value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Analysis/Tokenizers/UaxEmailUrlTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/UaxEmailUrlTokenizer.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A tokenizer of type uax_url_email which works exactly like the standard tokenizer, but tokenizes emails and urls as single tokens
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IUaxEmailUrlTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Analysis/Tokenizers/WhitespaceTokenizer.cs
+++ b/src/OpenSearch.Client/Analysis/Tokenizers/WhitespaceTokenizer.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A tokenizer of type whitespace that divides text at whitespace.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IWhitespaceTokenizer : ITokenizer
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/AllocateClusterRerouteCommandBase.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/AllocateClusterRerouteCommandBase.cs
@@ -27,9 +27,11 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IAllocateClusterRerouteCommand : IClusterRerouteCommand
 	{
 		[DataMember(Name ="index")]
@@ -42,14 +44,17 @@ namespace OpenSearch.Client
 		int? Shard { get; set; }
 	}
 
+	[InterfaceDataContract]
 	public interface IAllocateReplicaClusterRerouteCommand : IAllocateClusterRerouteCommand { }
 
+	[InterfaceDataContract]
 	public interface IAllocateEmptyPrimaryRerouteCommand : IAllocateClusterRerouteCommand
 	{
 		[DataMember(Name ="accept_data_loss")]
 		bool? AcceptDataLoss { get; set; }
 	}
 
+	[InterfaceDataContract]
 	public interface IAllocateStalePrimaryRerouteCommand : IAllocateClusterRerouteCommand
 	{
 		[DataMember(Name ="accept_data_loss")]

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/CancelClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/CancelClusterRerouteCommand.cs
@@ -27,9 +27,11 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface ICancelClusterRerouteCommand : IClusterRerouteCommand
 	{
 		[DataMember(Name ="allow_primary")]

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/ClusterRerouteCommandConverter.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/ClusterRerouteCommandConverter.cs
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="IClusterRerouteCommand"/> as <c>{ "&lt;command_name&gt;": { ...body... } }</c>
+	/// and dispatches deserialization on the single command-name key. Replaces the Utf8Json
+	/// <c>ClusterRerouteCommandFormatter</c>.
+	/// </summary>
+	internal sealed class ClusterRerouteCommandConverter : JsonConverter<IClusterRerouteCommand>
+	{
+		private static readonly Dictionary<string, Type> CommandTypes = new()
+		{
+			["allocate_replica"] = typeof(AllocateReplicaClusterRerouteCommand),
+			["allocate_empty_primary"] = typeof(AllocateEmptyPrimaryRerouteCommand),
+			["allocate_stale_primary"] = typeof(AllocateStalePrimaryRerouteCommand),
+			["move"] = typeof(MoveClusterRerouteCommand),
+			["cancel"] = typeof(CancelClusterRerouteCommand),
+		};
+
+		public override IClusterRerouteCommand Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Cannot deserialize IClusterRerouteCommand from {reader.TokenType}");
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			foreach (var prop in doc.RootElement.EnumerateObject())
+			{
+				if (CommandTypes.TryGetValue(prop.Name, out var commandType))
+					return (IClusterRerouteCommand)JsonSerializer.Deserialize(prop.Value.GetRawText(), commandType, options);
+			}
+
+			return null;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IClusterRerouteCommand value, JsonSerializerOptions options)
+		{
+			if (value?.Name == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(value.Name);
+			// Serialize the body by the runtime type so the concrete command's [InterfaceDataContract]
+			// property contract is used (not the empty IClusterRerouteCommand interface contract).
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/IClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/IClusterRerouteCommand.cs
@@ -27,10 +27,12 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(ClusterRerouteCommandConverter))]
 	[JsonFormatter(typeof(ClusterRerouteCommandFormatter))]
 	public interface IClusterRerouteCommand
 	{

--- a/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/MoveClusterRerouteCommand.cs
+++ b/src/OpenSearch.Client/Cluster/ClusterReroute/Commands/MoveClusterRerouteCommand.cs
@@ -27,9 +27,11 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IMoveClusterRerouteCommand : IClusterRerouteCommand
 	{
 		[DataMember(Name ="from_node")]

--- a/src/OpenSearch.Client/Cluster/ComponentTemplate/ComponentTemplate.cs
+++ b/src/OpenSearch.Client/Cluster/ComponentTemplate/ComponentTemplate.cs
@@ -12,6 +12,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client;
 
 [ReadAs(typeof(ComponentTemplate))]
+[InterfaceDataContract]
 public interface IComponentTemplate
 {
 	[DataMember(Name = "template")]

--- a/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -115,6 +115,11 @@ namespace OpenSearch.Client
 		private Func<string, string> _defaultFieldNameInferrer;
 		private string _defaultIndex;
 
+		// Rollback safety net for the Utf8Json -> System.Text.Json migration. Defaults to STJ (false).
+		// Seeded from the OSC_USE_UTF8JSON environment variable so the legacy engine can be forced without
+		// code changes (e.g. in test harnesses); an explicit UseUtf8Json(...) fluent call overrides it.
+		private bool _useUtf8Json = ReadUseUtf8JsonEnvironmentDefault();
+
 		protected ConnectionSettingsBase(
 			IConnectionPool connectionPool,
 			IConnection connection,
@@ -123,8 +128,7 @@ namespace OpenSearch.Client
 		)
 			: base(connectionPool, connection, null)
 		{
-			var formatterResolver = new OpenSearchClientFormatterResolver(this);
-			var defaultSerializer = new DefaultHighLevelSerializer(formatterResolver);
+			var defaultSerializer = new DefaultHighLevelSerializer(this);
 			var sourceSerializer = sourceSerializerFactory?.Invoke(defaultSerializer, this) ?? defaultSerializer;
 			var serializerAsMappingProvider = sourceSerializer as IPropertyMappingProvider;
 
@@ -153,6 +157,7 @@ namespace OpenSearch.Client
 		FluentDictionary<MemberInfo, IPropertyMapping> IConnectionSettingsValues.PropertyMappings => _propertyMappings;
 		FluentDictionary<Type, string> IConnectionSettingsValues.RouteProperties => _routeProperties;
 		IOpenSearchSerializer IConnectionSettingsValues.SourceSerializer => _sourceSerializer;
+		bool IConnectionSettingsValues.UseUtf8Json => _useUtf8Json;
 
 		/// <summary>
 		/// The default index to use for a request when no index has been explicitly specified
@@ -179,6 +184,24 @@ namespace OpenSearch.Client
 		/// <see cref="DefaultDisableIdInference"/>
 		/// </summary>
 		public TConnectionSettings DefaultDisableIdInference(bool disable = true) => Assign(disable, (a, v) => a._defaultDisableAllInference = v);
+
+		/// <summary>
+		/// Selects the legacy vendored Utf8Json serialization engine (honoring <c>[JsonFormatter]</c> attributes)
+		/// for the built-in high-level serializer instead of the default <see cref="System.Text.Json"/> engine.
+		/// <para></para>
+		/// This is a rollback safety net for the Utf8Json → System.Text.Json migration; leave it unset to use
+		/// System.Text.Json. It can also be forced globally via the <c>OSC_USE_UTF8JSON</c> environment variable.
+		/// </summary>
+		public TConnectionSettings UseUtf8Json(bool use = true) => Assign(use, (a, v) => a._useUtf8Json = v);
+
+		private static bool ReadUseUtf8JsonEnvironmentDefault()
+		{
+			var value = Environment.GetEnvironmentVariable("OSC_USE_UTF8JSON");
+			if (string.IsNullOrEmpty(value)) return false;
+			return value == "1"
+				|| string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase);
+		}
 
 		private void MapIdPropertyFor<TDocument>(Expression<Func<TDocument, object>> objectPath)
 		{

--- a/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
@@ -111,5 +111,14 @@ namespace OpenSearch.Client
 		/// The serializer use to serialize CLR types representing documents and other types related to documents.
 		/// </summary>
 		IOpenSearchSerializer SourceSerializer { get; }
+
+		/// <summary>
+		/// When <c>true</c>, the built-in high-level serializer uses the legacy vendored Utf8Json engine
+		/// (honoring <c>[JsonFormatter]</c> attributes) instead of the default <see cref="System.Text.Json"/>
+		/// engine (honoring <c>[JsonConverter]</c> attributes). This is provided as a rollback safety net for
+		/// the Utf8Json → System.Text.Json migration and defaults to <c>false</c> (System.Text.Json). It can
+		/// also be forced via the <c>OSC_USE_UTF8JSON</c> environment variable.
+		/// </summary>
+		bool UseUtf8Json { get; }
 	}
 }

--- a/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsADictionary/IIsADictionary.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/DictionaryLike/IsADictionary/IIsADictionary.cs
@@ -33,4 +33,13 @@ namespace OpenSearch.Client
 	public interface IIsADictionary { }
 
 	public interface IIsADictionary<TKey, TValue> : IDictionary<TKey, TValue>, IIsADictionary { }
+
+	/// <summary>
+	/// Marker for <see cref="IIsADictionary"/> types whose string keys are user-provided names
+	/// (e.g. suggester names) that must be serialized verbatim, without being run through the
+	/// <c>DefaultFieldNameInferrer</c>. Mirrors the historical Utf8Json <c>VerbatimDictionaryKeysFormatter</c>.
+	/// Only affects plain <see cref="string"/> keys; typed keys (Field/PropertyName/IndexName/RelationName)
+	/// are always resolved by the <c>Inferrer</c>.
+	/// </summary>
+	public interface IVerbatimDictionaryKeys { }
 }

--- a/src/OpenSearch.Client/CommonAbstractions/Fields/FieldValuesConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Fields/FieldValuesConverter.cs
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes the <c>fields</c> object of a hit / get response into a <see cref="FieldValues"/>
+	/// dictionary. Unlike the generic <c>IsADictionaryConverterFactory</c>, this converter injects the
+	/// connection settings <see cref="Inferrer"/> so that <see cref="FieldValues.ValueOf{T,TValue}"/> and
+	/// <see cref="FieldValues.ValuesOf{TValue}"/> can resolve expression/field lookups (the generic factory
+	/// only matches a parameterless or single-<c>IDictionary</c> constructor and therefore loses the
+	/// inferrer, leaving every lookup empty). Restores the pre-STJ <c>FieldValuesFormatter</c> behavior.
+	/// </summary>
+	internal sealed class FieldValuesConverter : JsonConverter<FieldValues>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public FieldValuesConverter(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override FieldValues Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return FieldValues.Empty;
+			}
+
+			var container = new Dictionary<string, LazyDocument>();
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var key = reader.GetString();
+				reader.Read();
+				var value = JsonSerializer.Deserialize<LazyDocument>(ref reader, options);
+				container[key] = value;
+			}
+
+			return new FieldValues(_settings.Inferrer, container);
+		}
+
+		public override void Write(Utf8JsonWriter writer, FieldValues value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			foreach (var kvp in value)
+			{
+				writer.WritePropertyName(kvp.Key);
+				JsonSerializer.Serialize(writer, kvp.Value, options);
+			}
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldConverter.cs
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class FieldConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public FieldConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(Field);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			new FieldConverter(_settings);
+	}
+
+	internal sealed class FieldConverter : JsonConverter<Field>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public FieldConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override Field Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var name = reader.GetString();
+				return name == null ? null : new Field(name);
+			}
+
+			if (reader.TokenType == JsonTokenType.StartObject)
+			{
+				string fieldName = null;
+				double? boost = null;
+				string format = null;
+
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+				{
+					if (reader.TokenType != JsonTokenType.PropertyName)
+						continue;
+
+					var propertyName = reader.GetString();
+					reader.Read();
+
+					switch (propertyName)
+					{
+						case "field":
+							fieldName = reader.GetString();
+							break;
+						case "boost":
+							boost = reader.GetDouble();
+							break;
+						case "format":
+							format = reader.GetString();
+							break;
+						default:
+							reader.Skip();
+							break;
+					}
+				}
+
+				if (fieldName == null)
+					return null;
+
+				return new Field(fieldName, boost, format);
+			}
+
+			throw new JsonException($"Unexpected token {reader.TokenType} when deserializing {nameof(Field)}");
+		}
+
+		public override void Write(Utf8JsonWriter writer, Field value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Note: Inferrer.Field already bakes any boost into the resolved name (e.g. "field^2.0"),
+			// so boost is never emitted as a separate object property. Only the presence of a format
+			// triggers the object form, matching the historical (Utf8Json) FieldFormatter behavior.
+			var fieldName = _settings.Inferrer.Field(value);
+
+			if (!string.IsNullOrEmpty(value.Format))
+			{
+				writer.WriteStartObject();
+				writer.WriteString("field", fieldName);
+				writer.WriteString("format", value.Format);
+				writer.WriteEndObject();
+			}
+			else
+			{
+				writer.WriteStringValue(fieldName);
+			}
+		}
+
+		public override Field ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var name = reader.GetString();
+			return name == null ? null : new Field(name);
+		}
+
+		public override void WriteAsPropertyName(Utf8JsonWriter writer, Field value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WritePropertyName(string.Empty);
+				return;
+			}
+
+			var fieldName = _settings.Inferrer.Field(value);
+			writer.WritePropertyName(fieldName ?? string.Empty);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldKeyedDictionaryConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Field/FieldKeyedDictionaryConverter.cs
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes an <see cref="IDictionary{TKey,TValue}"/> keyed by <see cref="Field"/>, resolving
+	/// the JSON property name for each key through the settings-aware <see cref="Field"/> converter.
+	/// <para>
+	/// System.Text.Json skips options-registered converter factories when resolving dictionary keys at
+	/// depth, so a plain <c>IDictionary&lt;Field, TValue&gt;</c> property would otherwise fall back to
+	/// the default object converter and throw. This converter is pinned onto such properties by
+	/// <see cref="InterfaceDataContractModifier"/>.
+	/// </para>
+	/// </summary>
+	internal sealed class FieldKeyedDictionaryConverter<TValue> : JsonConverter<IDictionary<Field, TValue>>
+	{
+		public override IDictionary<Field, TValue> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var result = new Dictionary<Field, TValue>();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var key = new Field(reader.GetString());
+				reader.Read();
+				var value = JsonSerializer.Deserialize<TValue>(ref reader, options);
+				result[key] = value;
+			}
+
+			return result;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IDictionary<Field, TValue> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var keyConverter = (JsonConverter<Field>)options.GetConverter(typeof(Field));
+
+			writer.WriteStartObject();
+			foreach (var kvp in value)
+			{
+				keyConverter.WriteAsPropertyName(writer, kvp.Key, options);
+				JsonSerializer.Serialize(writer, kvp.Value, options);
+			}
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/Fields.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/Fields.cs
@@ -33,13 +33,15 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using OpenSearch.Net;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
-	[JsonFormatter(typeof(FieldsFormatter))]
 	[DebuggerDisplay("{DebugDisplay,nq}")]
+	[JsonFormatter(typeof(FieldsFormatter))]
+	[JsonConverter(typeof(FieldsConverter))]
 	public class Fields : IUrlParameter, IEnumerable<Field>, IEquatable<Fields>
 	{
 		internal readonly List<Field> ListOfFields;

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/FieldsConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Fields/FieldsConverter.cs
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="Fields"/> as a JSON array of field strings, resolving each element
+	/// through the settings-aware <see cref="Field"/> converter. Replaces the Utf8Json
+	/// <c>FieldsFormatter</c>.
+	/// </summary>
+	internal sealed class FieldsConverter : JsonConverter<Fields>
+	{
+		public override Fields Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartArray)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var fieldConverter = (JsonConverter<Field>)options.GetConverter(typeof(Field));
+			var fields = new List<Field>();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+			{
+				var field = fieldConverter.Read(ref reader, typeof(Field), options);
+				if (field != null)
+					fields.Add(field);
+			}
+
+			return new Fields(fields);
+		}
+
+		public override void Write(Utf8JsonWriter writer, Fields value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var fieldConverter = (JsonConverter<Field>)options.GetConverter(typeof(Field));
+
+			writer.WriteStartArray();
+			foreach (var field in value.ListOfFields)
+				fieldConverter.Write(writer, field, options);
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Id/IdConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Id/IdConverter.cs
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class IdConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IdConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(Id);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			new IdConverter(_settings);
+	}
+
+	internal sealed class IdConverter : JsonConverter<Id>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IdConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override Id Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+			if (reader.TokenType == JsonTokenType.Number)
+				return new Id(reader.GetInt64());
+			return new Id(reader.GetString());
+		}
+
+		public override void Write(Utf8JsonWriter writer, Id value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			if (value.Document != null)
+			{
+				var documentId = _settings.Inferrer.Id(value.Document.GetType(), value.Document);
+				writer.WriteStringValue(documentId);
+			}
+			else if (value.LongValue != null)
+				writer.WriteNumberValue(value.LongValue.Value);
+			else
+				writer.WriteStringValue(value.StringValue);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexNameConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/IndexName/IndexNameConverter.cs
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class IndexNameConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IndexNameConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(IndexName);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			new IndexNameConverter(_settings);
+	}
+
+	internal sealed class IndexNameConverter : JsonConverter<IndexName>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IndexNameConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IndexName Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var name = reader.GetString();
+			return name == null ? null : (IndexName)name;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IndexName value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var indexName = _settings.Inferrer.IndexName(value);
+			writer.WriteStringValue(indexName);
+		}
+
+		public override IndexName ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var name = reader.GetString();
+			return name == null ? null : (IndexName)name;
+		}
+
+		public override void WriteAsPropertyName(Utf8JsonWriter writer, IndexName value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WritePropertyName(string.Empty);
+				return;
+			}
+
+			var indexName = _settings.Inferrer.IndexName(value);
+			writer.WritePropertyName(indexName ?? string.Empty);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesArrayConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesArrayConverter.cs
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="Indices"/> as a JSON array of index names (e.g. <c>["a", "b"]</c>),
+	/// as opposed to the default comma-separated multi-syntax string form. Applied via
+	/// <c>[JsonConverter]</c> on properties that expect the array shape (alias add/remove operations).
+	/// </summary>
+	internal sealed class IndicesArrayConverter : JsonConverter<Indices>
+	{
+		public override Indices Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.String:
+					return reader.GetString();
+				case JsonTokenType.StartArray:
+				{
+					var indices = new List<IndexName>();
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+					{
+						if (reader.TokenType == JsonTokenType.String)
+							indices.Add(reader.GetString());
+						else
+							reader.Skip();
+					}
+					return new Indices(indices);
+				}
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, Indices value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			value.Match(
+				all =>
+				{
+					writer.WriteStartArray();
+					writer.WriteStringValue("_all");
+					writer.WriteEndArray();
+				},
+				many =>
+				{
+					writer.WriteStartArray();
+					foreach (var index in many.Indices)
+						JsonSerializer.Serialize(writer, index, typeof(IndexName), options);
+					writer.WriteEndArray();
+				});
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/Indices/IndicesConverter.cs
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="Indices"/> using the "multi syntax" wire format: a single
+	/// comma-separated string (e.g. <c>"index-a,index-b"</c>) or <c>"_all"</c>. This matches
+	/// the historical (Utf8Json) default (<c>IndicesMultiSyntaxFormatter</c>) applied at the
+	/// <see cref="Indices"/> type level. Reading also accepts a JSON array of index strings.
+	/// </summary>
+	internal sealed class IndicesConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IndicesConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(Indices);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			new IndicesConverter(_settings);
+	}
+
+	internal sealed class IndicesConverter : JsonConverter<Indices>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IndicesConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override Indices Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.String:
+					return Indices.Parse(reader.GetString());
+				case JsonTokenType.StartArray:
+				{
+					var indices = new List<IndexName>();
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+					{
+						var s = reader.GetString();
+						if (s != null)
+							indices.Add(s);
+					}
+					return indices.Count == 0 ? null : Indices.Index(indices);
+				}
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, Indices value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStringValue(((IUrlParameter)value).GetString(_settings));
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/Routing.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/Routing.cs
@@ -177,11 +177,17 @@ namespace OpenSearch.Client
 			}
 		}
 
-		internal bool ShouldSerialize(IJsonFormatterResolver formatterResolver)
+		internal bool ShouldSerialize(IConnectionSettingsValues settings)
 		{
-			var inferrer = formatterResolver.GetConnectionSettings().Inferrer;
-			var resolved = inferrer.Resolve(this);
+			var resolved = settings.Inferrer.Resolve(this);
 			return !resolved.IsNullOrEmpty();
 		}
+
+		// Utf8Json discovers a type-level ShouldSerialize hook by looking for a method taking a single
+		// IJsonFormatterResolver parameter (see ReflectionExtensions.GetShouldSerializeMethod). Provide that
+		// overload so a Routing that resolves to empty is omitted on the Utf8Json path rather than emitted
+		// as "routing": null.
+		internal bool ShouldSerialize(OpenSearch.Net.Utf8Json.IJsonFormatterResolver formatterResolver) =>
+			ShouldSerialize(formatterResolver.GetConnectionSettings());
 	}
 }

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/RoutingConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/JoinFieldRouting/RoutingConverter.cs
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class RoutingConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public RoutingConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(Routing);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			new RoutingConverter(_settings);
+	}
+
+	internal sealed class RoutingConverter : JsonConverter<Routing>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public RoutingConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override Routing Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+			if (reader.TokenType == JsonTokenType.Number)
+				return new Routing(reader.GetInt64());
+			return new Routing(reader.GetString());
+		}
+
+		public override void Write(Utf8JsonWriter writer, Routing value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			if (value.Document != null)
+			{
+				var documentId = _settings.Inferrer.Routing(value.Document.GetType(), value.Document);
+				writer.WriteStringValue(documentId);
+			}
+			else if (value.DocumentGetter != null)
+			{
+				var doc = value.DocumentGetter();
+				var documentId = _settings.Inferrer.Routing(doc.GetType(), doc);
+				writer.WriteStringValue(documentId);
+			}
+			else if (value.LongValue != null)
+				writer.WriteNumberValue(value.LongValue.Value);
+			else
+				writer.WriteStringValue(value.StringValue);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/PropertyName/PropertyNameConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/PropertyName/PropertyNameConverter.cs
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class PropertyNameConverter : JsonConverter<PropertyName>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public PropertyNameConverter() { }
+
+		public PropertyNameConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override PropertyName Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var name = reader.GetString();
+			return name == null ? null : new PropertyName(name);
+		}
+
+		public override void Write(Utf8JsonWriter writer, PropertyName value, JsonSerializerOptions options)
+		{
+			if (value == null || value.IsConditionless())
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStringValue(Resolve(value));
+		}
+
+		public override PropertyName ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var name = reader.GetString();
+			return name == null ? null : new PropertyName(name);
+		}
+
+		public override void WriteAsPropertyName(Utf8JsonWriter writer, PropertyName value, JsonSerializerOptions options)
+		{
+			if (value == null || value.IsConditionless())
+			{
+				writer.WritePropertyName(string.Empty);
+				return;
+			}
+
+			writer.WritePropertyName(Resolve(value) ?? string.Empty);
+		}
+
+		// Resolve the wire name via the Inferrer (honors expressions, suffixes, property mappings and
+		// the DefaultFieldNameInferrer). Falls back to the literal name when no settings are available.
+		private string Resolve(PropertyName value) =>
+			_settings != null ? _settings.Inferrer.PropertyName(value) : value.Name;
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationNameConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/RelationName/RelationNameConverter.cs
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class RelationNameConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public RelationNameConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(RelationName);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			new RelationNameConverter(_settings);
+	}
+
+	internal sealed class RelationNameConverter : JsonConverter<RelationName>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public RelationNameConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override RelationName Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var name = reader.GetString();
+			return name == null ? null : (RelationName)name;
+		}
+
+		public override void Write(Utf8JsonWriter writer, RelationName value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var relationName = _settings.Inferrer.RelationName(value);
+			writer.WriteStringValue(relationName);
+		}
+
+		public override RelationName ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var name = reader.GetString();
+			return name == null ? null : (RelationName)name;
+		}
+
+		public override void WriteAsPropertyName(Utf8JsonWriter writer, RelationName value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WritePropertyName(string.Empty);
+				return;
+			}
+
+			var relationName = _settings.Inferrer.RelationName(value);
+			writer.WritePropertyName(relationName ?? string.Empty);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Infer/TaskId/TaskIdConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Infer/TaskId/TaskIdConverter.cs
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class TaskIdConverter : JsonConverter<TaskId>
+	{
+		public override TaskId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var value = reader.GetString();
+			return value == null ? null : new TaskId(value);
+		}
+
+		public override void Write(Utf8JsonWriter writer, TaskId value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStringValue(value.FullyQualifiedId);
+		}
+
+		public override TaskId ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var value = reader.GetString();
+			return value == null ? null : new TaskId(value);
+		}
+
+		public override void WriteAsPropertyName(Utf8JsonWriter writer, TaskId value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WritePropertyName(string.Empty);
+				return;
+			}
+
+			writer.WritePropertyName(value.FullyQualifiedId);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/LazyDocument/LazyDocument.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/LazyDocument/LazyDocument.cs
@@ -77,14 +77,18 @@ namespace OpenSearch.Client
 		private readonly IOpenSearchSerializer _requestResponseSerializer;
 		private readonly IMemoryStreamFactory _memoryStreamFactory;
 
-		internal LazyDocument(byte[] bytes, IJsonFormatterResolver formatterResolver)
+		internal LazyDocument(byte[] bytes, IConnectionSettingsValues settings)
 		{
 			Bytes = bytes;
-			var settings = formatterResolver.GetConnectionSettings();
 			_sourceSerializer = settings.SourceSerializer;
 			_requestResponseSerializer = settings.RequestResponseSerializer;
 			_memoryStreamFactory = settings.MemoryStreamFactory;
 		}
+
+		// Resolver-based overload used by the restored Utf8Json formatters, which carry a formatter resolver
+		// rather than the settings directly. Only reachable on the legacy Utf8Json serialization path.
+		internal LazyDocument(byte[] bytes, IJsonFormatterResolver formatterResolver)
+			: this(bytes, formatterResolver.GetConnectionSettings()) { }
 
 		internal byte[] Bytes { get; }
 

--- a/src/OpenSearch.Client/CommonAbstractions/LazyDocument/LazyDocumentConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/LazyDocument/LazyDocumentConverter.cs
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Converts <see cref="ILazyDocument"/> / <see cref="LazyDocument"/>. On read the raw JSON is
+	/// captured verbatim (as UTF-8 bytes) so it can later be deserialized on demand via the source or
+	/// request/response serializer. On write the captured bytes are emitted unchanged. Ports the
+	/// Utf8Json <c>LazyDocumentFormatter</c>.
+	/// </summary>
+	internal sealed class LazyDocumentConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public LazyDocumentConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeToConvert == typeof(ILazyDocument) || typeToConvert == typeof(LazyDocument);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			typeToConvert == typeof(ILazyDocument)
+				? new LazyDocumentConverter<ILazyDocument>(_settings)
+				: new LazyDocumentConverter<LazyDocument>(_settings);
+	}
+
+	internal sealed class LazyDocumentConverter<T> : JsonConverter<T>
+		where T : class, ILazyDocument
+	{
+		private static readonly ConstructorInfo Ctor = typeof(LazyDocument).GetConstructor(
+			BindingFlags.NonPublic | BindingFlags.Instance,
+			binder: null,
+			new[] { typeof(byte[]), typeof(IConnectionSettingsValues) },
+			modifiers: null);
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public LazyDocumentConverter(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			using var ms = _settings.MemoryStreamFactory.Create();
+			using (var writer = new Utf8JsonWriter(ms))
+			{
+				doc.RootElement.WriteTo(writer);
+				writer.Flush();
+			}
+			var bytes = ms.ToArray();
+
+			return (T)Ctor.Invoke(new object[] { bytes, _settings });
+		}
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			if (value is LazyDocument lazy && lazy.Bytes != null)
+				writer.WriteRawValue(lazy.Bytes, skipInputValidation: true);
+			else
+				writer.WriteNullValue();
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/Response/DictionaryResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/DictionaryResponseBase.cs
@@ -51,11 +51,21 @@ namespace OpenSearch.Client
 
 	internal class ResponseFormatterHelpers
 	{
-        internal static readonly AutomataDictionary ServerErrorFields = new AutomataDictionary
-        {
-            { "error", 0 },
-            { "status", 1 }
-        };
+		internal static readonly Dictionary<string, int> ServerErrorFields = new Dictionary<string, int>
+		{
+			{ "error", 0 },
+			{ "status", 1 }
+		};
+
+		// Byte-segment keyed variant used by the restored Utf8Json response formatters, which match raw
+		// property-name segments (ArraySegment&lt;byte&gt;) rather than decoded strings. Only used on the
+		// legacy Utf8Json serialization path.
+		internal static readonly OpenSearch.Net.Utf8Json.Internal.AutomataDictionary ServerErrorFieldsAutomata =
+			new OpenSearch.Net.Utf8Json.Internal.AutomataDictionary
+			{
+				{ "error", 0 },
+				{ "status", 1 }
+			};
 	}
 
 	internal class DictionaryResponseFormatter<TResponse, TKey, TValue> : IJsonFormatter<TResponse>
@@ -72,7 +82,7 @@ namespace OpenSearch.Client
 			while (reader.ReadIsInObject(ref count))
 			{
 				var property = reader.ReadPropertyNameSegmentRaw();
-				if (ResponseFormatterHelpers.ServerErrorFields.TryGetValue(property, out var errorValue))
+				if (ResponseFormatterHelpers.ServerErrorFieldsAutomata.TryGetValue(property, out var errorValue))
 				{
 					switch (errorValue)
 					{
@@ -109,4 +119,6 @@ namespace OpenSearch.Client
 
 		public void Serialize(ref JsonWriter writer, TResponse value, IJsonFormatterResolver formatterResolver) => throw new NotSupportedException();
 	}
+
+
 }

--- a/src/OpenSearch.Client/CommonAbstractions/Response/DictionaryResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/DictionaryResponseBase.cs
@@ -51,11 +51,11 @@ namespace OpenSearch.Client
 
 	internal class ResponseFormatterHelpers
 	{
-		internal static readonly AutomataDictionary ServerErrorFields = new AutomataDictionary
-		{
-			{ "error", 0 },
-			{ "status", 1 }
-		};
+        internal static readonly AutomataDictionary ServerErrorFields = new AutomataDictionary
+        {
+            { "error", 0 },
+            { "status", 1 }
+        };
 	}
 
 	internal class DictionaryResponseFormatter<TResponse, TKey, TValue> : IJsonFormatter<TResponse>

--- a/src/OpenSearch.Client/CommonAbstractions/Response/DynamicResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/DynamicResponseBase.cs
@@ -72,7 +72,7 @@ namespace OpenSearch.Client
 			while (reader.ReadIsInObject(ref count))
 			{
 				var property = reader.ReadPropertyNameSegmentRaw();
-				if (ResponseFormatterHelpers.ServerErrorFields.TryGetValue(property, out var errorValue))
+				if (ResponseFormatterHelpers.ServerErrorFieldsAutomata.TryGetValue(property, out var errorValue))
 				{
 					switch (errorValue)
 					{

--- a/src/OpenSearch.Client/CommonAbstractions/Response/ResolvableDictionaryProxy.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/ResolvableDictionaryProxy.cs
@@ -118,7 +118,7 @@ namespace OpenSearch.Client
 			while (reader.ReadIsInObject(ref count))
 			{
 				var property = reader.ReadPropertyNameSegmentRaw();
-				if (ResponseFormatterHelpers.ServerErrorFields.TryGetValue(property, out var errorValue))
+				if (ResponseFormatterHelpers.ServerErrorFieldsAutomata.TryGetValue(property, out var errorValue))
 				{
 					switch (errorValue)
 					{

--- a/src/OpenSearch.Client/CommonAbstractions/Response/ResponseBase.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Response/ResponseBase.cs
@@ -97,9 +97,11 @@ namespace OpenSearch.Client
 		private int? _statusCode;
 
 		/// <summary> Returns useful information about the request(s) that were part of this API call. </summary>
+		[IgnoreDataMember]
 		public virtual IApiCallDetails ApiCall => _originalApiCall;
 
 		/// <inheritdoc />
+		[IgnoreDataMember]
 		public string DebugInformation
 		{
 			get
@@ -114,6 +116,7 @@ namespace OpenSearch.Client
 		}
 
 		/// <inheritdoc />
+		[IgnoreDataMember]
 		public virtual bool IsValid
 		{
 			get
@@ -125,9 +128,11 @@ namespace OpenSearch.Client
 
 
 		/// <inheritdoc />
+		[IgnoreDataMember]
 		public Exception OriginalException => ApiCall?.OriginalException;
 
 		/// <inheritdoc />
+		[IgnoreDataMember]
 		public ServerError ServerError
 		{
 			get

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/SourceSerializationAttribute.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/SourceSerializationAttribute.cs
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Marks a contract property whose value must be (de)serialized by the configured
+	/// <see cref="IConnectionSettingsValues.SourceSerializer"/> rather than the high-level
+	/// serializer. Used for embedded user-document payloads (e.g. the <c>doc</c> of a
+	/// more_like_this <c>like</c> item, or a percolate document) which are typed as
+	/// <see cref="object"/> and would otherwise be handled by the high-level serializer.
+	/// <para>
+	/// This is the System.Text.Json equivalent of the Utf8Json
+	/// <c>[JsonFormatter(typeof(SourceFormatter&lt;object&gt;))]</c> annotation.
+	/// </para>
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	internal sealed class SourceSerializationAttribute : Attribute { }
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/StringTimeSpanAttribute.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/Attributes/StringTimeSpanAttribute.cs
@@ -27,9 +27,27 @@
 */
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
+	/// <summary>
+	/// Marks a <see cref="TimeSpan"/> (or <see cref="Nullable{TimeSpan}"/>) property to serialize as its
+	/// string form (e.g. <c>"10.10:38:32"</c>) rather than the default ticks number. Inherits
+	/// <see cref="JsonConverterAttribute"/> so it is honored through the attribute/contract channel.
+	/// </summary>
 	[AttributeUsage(AttributeTargets.Property)]
-	public class StringTimeSpanAttribute : Attribute { }
+	public class StringTimeSpanAttribute : JsonConverterAttribute
+	{
+		public override JsonConverter CreateConverter(Type typeToConvert)
+		{
+			if (typeToConvert == typeof(TimeSpan))
+				return new TimeSpanStringConverter();
+			if (typeToConvert == typeof(TimeSpan?))
+				return new NullableTimeSpanStringConverter();
+			return null;
+		}
+	}
 }

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
@@ -28,51 +28,230 @@
 
 using System;
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net;
-using OpenSearch.Net.Utf8Json;
-using JsonSerializerOptions = System.Text.Json.JsonSerializerOptions;
+using IJsonFormatterResolver = OpenSearch.Net.Utf8Json.IJsonFormatterResolver;
+using Utf8JsonSerializer = OpenSearch.Net.Utf8Json.JsonSerializer;
 
 namespace OpenSearch.Client
 {
 	/// <summary>The built in internal serializer that the high level client OpenSearch.Client uses.</summary>
 	internal class DefaultHighLevelSerializer : IOpenSearchSerializer, IInternalSerializer
 	{
-		public DefaultHighLevelSerializer(IJsonFormatterResolver formatterResolver) => FormatterResolver = formatterResolver;
+		private readonly OpenSearchClientSerializerOptions _serializerOptions;
+		private readonly IConnectionSettingsValues _settings;
 
-		private IJsonFormatterResolver FormatterResolver { get; }
+		// Non-null only on the legacy Utf8Json path. When set, all (de)serialization is routed through the
+		// vendored Utf8Json engine using this resolver and the System.Text.Json options are never built.
+		private readonly IJsonFormatterResolver _formatterResolver;
+
+		public DefaultHighLevelSerializer(IConnectionSettingsValues settings)
+		{
+			_settings = settings;
+			// Select the engine once, at construction, from the resolved setting (which already folds in the
+			// OSC_USE_UTF8JSON environment default). STJ is the default; Utf8Json is the rollback path.
+			if (settings != null && settings.UseUtf8Json)
+				_formatterResolver = new OpenSearchClientFormatterResolver(settings);
+			else
+				_serializerOptions = new OpenSearchClientSerializerOptions(settings);
+		}
+
+		// Legacy Utf8Json entry point retained so stateful serializers (see StatefulSerializerExtensions) and
+		// other resolver-based callers can construct a serializer directly from a formatter resolver.
+		public DefaultHighLevelSerializer(IJsonFormatterResolver formatterResolver)
+		{
+			_formatterResolver = formatterResolver;
+			_settings = (formatterResolver as IJsonFormatterResolverWithSettings)?.Settings;
+		}
+
+		private bool UsesUtf8Json => _formatterResolver != null;
 
 		bool IInternalSerializer.TryGetJsonFormatter(out IJsonFormatterResolver formatterResolver)
 		{
-			formatterResolver = FormatterResolver;
-			return true;
+			formatterResolver = _formatterResolver;
+			return UsesUtf8Json;
 		}
 
 		bool IInternalSerializer.TryGetJsonSerializerOptions(out JsonSerializerOptions options)
 		{
-			options = null;
+			if (UsesUtf8Json)
+			{
+				options = null;
+				return false;
+			}
+			options = _serializerOptions.Options;
+			return true;
+		}
+
+		// A bare user document serialized/deserialized at the JSON root (the root type IS the document,
+		// not a document nested inside an OpenSearch envelope such as a bulk body or a hit's _source)
+		// follows the high-level naming path. The pre-STJ Utf8Json client attached its SourceFormatter
+		// only to explicitly attributed _source members, never as a top-level catch-all, so a document
+		// at the root honored OSC field-name inference (DefaultFieldNameInferrer, PropertyName/DataMember,
+		// DefaultMappingFor) rather than a distinct source serializer's own naming. Route those through
+		// the inference-aware terminal source options.
+		//
+		// Only types the domain options would themselves hand to SourceConverter qualify: if a
+		// higher-precedence domain converter claims the root type (e.g. IsADictionaryConverterFactory for
+		// IIsADictionary types), the domain options are used unchanged so that converter still runs.
+		// Embedded document bodies are likewise unaffected: index/bulk request bodies serialize via the
+		// configured source serializer directly through IProxyRequest.WriteJson, and _source members are
+		// (de)serialized by nested converters — neither reaches this entry point with a bare-document
+		// root type. In the default case (no distinct source serializer) the domain options would anyway
+		// delegate the root document to SourceConverter, which already uses these same terminal options,
+		// so the produced JSON is unchanged.
+		private JsonSerializerOptions OptionsForRoot(Type rootType, JsonSerializerOptions domainOptions)
+		{
+			if (!SourceConverterFactory.IsSourceDocumentType(rootType))
+				return domainOptions;
+			// Confirm the domain options resolve the root type to the SourceConverter and not some
+			// higher-precedence domain converter; only then does the inference-aware terminal path match
+			// the domain behavior for the document itself.
+			return domainOptions.GetConverter(rootType) is ISourceConverter
+				? SourceConverterHelper.GetDefaultSourceOptions(_settings)
+				: domainOptions;
+		}
+
+		public T Deserialize<T>(Stream stream)
+		{
+			if (IsNullOrEmpty(ref stream)) return default;
+			if (UsesUtf8Json) return Utf8JsonSerializer.Deserialize<T>(stream, _formatterResolver);
+			return JsonSerializer.Deserialize<T>(stream, OptionsForRoot(typeof(T), _serializerOptions.Options));
+		}
+
+		public object Deserialize(Type type, Stream stream)
+		{
+			if (IsNullOrEmpty(ref stream)) return type is { IsValueType: true } ? Activator.CreateInstance(type) : null;
+			if (UsesUtf8Json) return Utf8JsonSerializer.NonGeneric.Deserialize(type, stream, _formatterResolver);
+			return JsonSerializer.Deserialize(stream, type, OptionsForRoot(type, _serializerOptions.Options));
+		}
+
+		public async Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default)
+		{
+			var empty = await IsNullOrEmptyAsync(stream, cancellationToken).ConfigureAwait(false);
+			if (empty.IsEmpty) return default;
+			if (UsesUtf8Json) return await Utf8JsonSerializer.DeserializeAsync<T>(empty.Stream, _formatterResolver).ConfigureAwait(false);
+			return await JsonSerializer.DeserializeAsync<T>(empty.Stream, OptionsForRoot(typeof(T), _serializerOptions.Options), cancellationToken).ConfigureAwait(false);
+		}
+
+		public async Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default)
+		{
+			var empty = await IsNullOrEmptyAsync(stream, cancellationToken).ConfigureAwait(false);
+			if (empty.IsEmpty) return type is { IsValueType: true } ? Activator.CreateInstance(type) : null;
+			if (UsesUtf8Json) return await Utf8JsonSerializer.NonGeneric.DeserializeAsync(type, empty.Stream, _formatterResolver).ConfigureAwait(false);
+			return await JsonSerializer.DeserializeAsync(empty.Stream, type, OptionsForRoot(type, _serializerOptions.Options), cancellationToken).ConfigureAwait(false);
+		}
+
+		// A response with no body (e.g. a HEAD request such as Ping, or a 200 with an empty payload) can
+		// arrive as an empty, possibly non-seekable, network stream. STJ throws "The input does not contain
+		// any JSON tokens" on such input, so short-circuit to default. For a seekable stream we can check the
+		// length directly; for a non-seekable stream we peek a single byte and, if present, splice it back in
+		// front of the remaining data so deserialization sees the full body.
+		private static bool IsNullOrEmpty(ref Stream stream)
+		{
+			if (stream == null) return true;
+			if (stream.CanSeek) return stream.Length == 0 || stream.Position >= stream.Length;
+
+			var first = stream.ReadByte();
+			if (first == -1) return true;
+			stream = new PrependByteStream((byte)first, stream);
 			return false;
 		}
 
-		public T Deserialize<T>(Stream stream) =>
-			JsonSerializer.Deserialize<T>(stream, FormatterResolver);
+		private static async Task<(bool IsEmpty, Stream Stream)> IsNullOrEmptyAsync(Stream stream, CancellationToken cancellationToken)
+		{
+			if (stream == null) return (true, null);
+			if (stream.CanSeek) return (stream.Length == 0 || stream.Position >= stream.Length, stream);
 
-		public object Deserialize(Type type, Stream stream) =>
-			JsonSerializer.NonGeneric.Deserialize(type, stream, FormatterResolver);
+			var buffer = new byte[1];
+			var read = await stream.ReadAsync(buffer, 0, 1, cancellationToken).ConfigureAwait(false);
+			if (read == 0) return (true, stream);
+			return (false, new PrependByteStream(buffer[0], stream));
+		}
 
-		public Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default) =>
-			JsonSerializer.DeserializeAsync<T>(stream, FormatterResolver);
-
-		public Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default) =>
-			JsonSerializer.NonGeneric.DeserializeAsync(type, stream, FormatterResolver);
-
-		public virtual void Serialize<T>(T data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.None) =>
-			JsonSerializer.Serialize(writableStream, data, FormatterResolver);
+		public virtual void Serialize<T>(T data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.None)
+		{
+			if (UsesUtf8Json)
+			{
+				Utf8JsonSerializer.Serialize(writableStream, data, _formatterResolver);
+				return;
+			}
+			var options = formatting == SerializationFormatting.Indented
+				? _serializerOptions.Indented
+				: _serializerOptions.Options;
+			JsonSerializer.Serialize(writableStream, data, OptionsForRoot(typeof(T), options));
+		}
 
 		public Task SerializeAsync<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.None,
-			CancellationToken cancellationToken = default
-		) => JsonSerializer.SerializeAsync(stream, data, FormatterResolver);
+			CancellationToken cancellationToken = default)
+		{
+			if (UsesUtf8Json)
+				return Utf8JsonSerializer.SerializeAsync(stream, data, _formatterResolver);
+			var options = formatting == SerializationFormatting.Indented
+				? _serializerOptions.Indented
+				: _serializerOptions.Options;
+			return JsonSerializer.SerializeAsync(stream, data, OptionsForRoot(typeof(T), options), cancellationToken);
+		}
 
+		/// <summary>
+		/// A read-only forward-only stream that yields a single already-read "peek" byte before delegating
+		/// to the underlying stream. Used to non-destructively test a non-seekable response stream for
+		/// emptiness while still allowing the full body to be deserialized.
+		/// </summary>
+		private sealed class PrependByteStream : Stream
+		{
+			private readonly byte _first;
+			private readonly Stream _inner;
+			private bool _firstConsumed;
+
+			public PrependByteStream(byte first, Stream inner)
+			{
+				_first = first;
+				_inner = inner;
+			}
+
+			public override bool CanRead => true;
+			public override bool CanSeek => false;
+			public override bool CanWrite => false;
+			public override long Length => throw new NotSupportedException();
+			public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				if (count <= 0) return 0;
+				if (!_firstConsumed)
+				{
+					_firstConsumed = true;
+					buffer[offset] = _first;
+					return 1;
+				}
+				return _inner.Read(buffer, offset, count);
+			}
+
+			public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			{
+				if (count <= 0) return 0;
+				if (!_firstConsumed)
+				{
+					_firstConsumed = true;
+					buffer[offset] = _first;
+					return 1;
+				}
+				return await _inner.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+			}
+
+			public override void Flush() => throw new NotSupportedException();
+			public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+			public override void SetLength(long value) => throw new NotSupportedException();
+			public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+			protected override void Dispose(bool disposing)
+			{
+				if (disposing) _inner.Dispose();
+				base.Dispose(disposing);
+			}
+		}
 	}
 }

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
@@ -32,6 +32,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
+using JsonSerializerOptions = System.Text.Json.JsonSerializerOptions;
 
 namespace OpenSearch.Client
 {
@@ -46,6 +47,12 @@ namespace OpenSearch.Client
 		{
 			formatterResolver = FormatterResolver;
 			return true;
+		}
+
+		bool IInternalSerializer.TryGetJsonSerializerOptions(out JsonSerializerOptions options)
+		{
+			options = null;
+			return false;
 		}
 
 		public T Deserialize<T>(Stream stream) =>

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/InterfaceDataContractModifier.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/InterfaceDataContractModifier.cs
@@ -1,0 +1,551 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using OpenSearch.Net.Utf8Json;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="DefaultJsonTypeInfoResolver"/> modifier that rebuilds the JSON contract
+	/// for any concrete type implementing an interface marked with
+	/// <see cref="InterfaceDataContractAttribute"/>.
+	/// <para>
+	/// This is the System.Text.Json equivalent of Utf8Json's <c>[InterfaceDataContract]</c> behavior:
+	/// the type is serialized/deserialized purely against its interface contract. Only interface
+	/// properties carrying a <see cref="DataMemberAttribute"/> are emitted, using the
+	/// <see cref="DataMemberAttribute.Name"/> as the JSON name. This works uniformly for:
+	/// </para>
+	/// <list type="bullet">
+	/// <item>Descriptors (explicit interface implementations, e.g. <c>IAliases IIndexState.Aliases</c>)</item>
+	/// <item>Request classes (public properties that implement interface members, where non-body
+	/// members like route values are <see cref="IgnoreDataMemberAttribute"/> on the interface)</item>
+	/// </list>
+	/// <para>
+	/// Because it uses the interface property getters/setters, deserialization works for free —
+	/// no write-only converter is needed.
+	/// </para>
+	/// </summary>
+	internal sealed class InterfaceDataContractModifier
+	{
+		// Enum-member converter factory used to pin the correct string/numeric enum converter onto
+		// rebuilt-contract enum properties (bypassing the options factory list, whose lowest-precedence
+		// SourceConverterFactory also claims enums). Naming is verbatim, matching the base serializer.
+		private static readonly OpenSearch.Net.EnumMemberConverterFactory EnumMemberConverterFactoryInstance =
+			new OpenSearch.Net.EnumMemberConverterFactory(useVerbatimName: true);
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public InterfaceDataContractModifier(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public void Modify(JsonTypeInfo typeInfo)
+		{
+			if (typeInfo.Kind != JsonTypeInfoKind.Object)
+				return;
+
+			// Never override a converter already resolved from a [JsonConverter] attribute
+			// (dedicated polymorphic/wrapper converters). Their JsonTypeInfoKind is typically
+			// None, but guard explicitly so collection-element resolution keeps the converter.
+			if (typeInfo.Converter is not null && typeInfo.Converter.GetType().Namespace?.StartsWith("System") == false)
+				return;
+
+			var type = typeInfo.Type;
+
+			if (type.IsInterface || type.IsAbstract)
+			{
+				// Interfaces/abstracts are not rebuilt here (their contract is produced by
+				// DataMemberPropertyNameModifier), but a value serialized against its interface type
+				// (e.g. each IMultiTermVectorOperation element of an IEnumerable<...> contract) must still
+				// honor any type-level ShouldSerialize hook declared by a property's type — otherwise a
+				// Routing that resolves to empty is emitted as "routing": null. Apply those hooks to the
+				// existing interface-contract properties.
+				foreach (var prop in typeInfo.Properties)
+					ApplyTypeLevelShouldSerialize(prop, prop.PropertyType);
+				return;
+			}
+
+			// Types serialized by a dedicated converter (dictionaries, scripts, etc.) never reach here.
+			if (typeof(IIsADictionary).IsAssignableFrom(type))
+				return;
+
+			var contractInterfaces = GetContractInterfaces(type);
+			if (contractInterfaces.Count == 0)
+				return;
+
+			// User-defined analysis components (custom ITokenizer/ITokenFilter/ICharFilter/IAnalyzer/
+			// INormalizer implementations declared outside the client assembly) are serialized by their
+			// full public property set — matching the Utf8Json behavior where unknown analysis types fell
+			// through to the object formatter. Interface [DataMember]s still take precedence for naming.
+			var isUserDefinedAnalysisComponent = IsUserDefinedAnalysisComponent(type);
+
+			// Build the contract from the interface [DataMember] properties.
+			var seen = new HashSet<string>(StringComparer.Ordinal);
+			var rebuilt = new List<JsonPropertyInfo>();
+			// CLR member names that the contract interfaces declare as [IgnoreDataMember] — their concrete
+			// counterparts must never be emitted even if the concrete property carries its own annotation.
+			var ignoredMemberNames = new HashSet<string>(StringComparer.Ordinal);
+
+			foreach (var iface in contractInterfaces)
+			{
+				foreach (var ifaceProp in iface.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+				{
+					if (ifaceProp.GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+					{
+						ignoredMemberNames.Add(ifaceProp.Name);
+						continue;
+					}
+
+					var dataMember = ifaceProp.GetCustomAttribute<DataMemberAttribute>();
+					if (dataMember == null)
+						continue;
+
+					var jsonName = dataMember.Name
+						?? JsonNamingPolicy.CamelCase.ConvertName(ifaceProp.Name);
+
+					if (!seen.Add(jsonName))
+						continue;
+
+					var jsonProp = typeInfo.CreateJsonPropertyInfo(ifaceProp.PropertyType, jsonName);
+
+					// Properties marked [SourceSerialization] carry an embedded user-document payload
+					// (typically typed as object) that must be (de)serialized by the SourceSerializer.
+					// STJ would otherwise handle an object-typed property with the high-level serializer.
+					if (ifaceProp.GetCustomAttribute<SourceSerializationAttribute>() != null)
+					{
+						var sourceConverter = GetSourceConverter(typeInfo.Options, ifaceProp.PropertyType);
+						if (sourceConverter != null)
+							jsonProp.CustomConverter = sourceConverter;
+
+						var capturedSource = ifaceProp;
+						if (capturedSource.CanRead)
+							jsonProp.Get = obj => capturedSource.GetValue(obj);
+						if (capturedSource.CanWrite)
+							jsonProp.Set = (obj, value) => capturedSource.SetValue(obj, value);
+						else
+						{
+							// Getter-only interface member (e.g. IInlineGet.Source): use the concrete
+							// implementation's internal setter so the embedded document deserializes.
+							var concreteSourceProp = type.GetProperty(ifaceProp.Name,
+								BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+							var concreteSourceSetter = concreteSourceProp?.GetSetMethod(true);
+							if (concreteSourceSetter != null)
+								jsonProp.Set = (obj, value) => concreteSourceSetter.Invoke(obj, new[] { value });
+						}
+
+						rebuilt.Add(jsonProp);
+						continue;
+					}
+
+					// Honor an explicit [JsonConverter] attribute on the interface property. The
+					// manually-rebuilt JsonPropertyInfo does not inherit attribute-channel converters,
+					// so apply it here (e.g. SourceValueWriteConverter on weakly-typed query values).
+					var converterAttr = ifaceProp.GetCustomAttribute<JsonConverterAttribute>();
+					if (converterAttr != null)
+					{
+						var converter = converterAttr.ConverterType != null
+							? (JsonConverter)Activator.CreateInstance(converterAttr.ConverterType)
+							: converterAttr.CreateConverter(ifaceProp.PropertyType);
+						if (converter != null)
+							jsonProp.CustomConverter = converter;
+					}
+
+					// Pin the options-registered converter for leaf value types and enums.
+					// These factory converters (Field/IndexName/RelationName, enums) are skipped for
+					// properties on contracts rebuilt by this modifier when used at depth.
+					var propType = ifaceProp.PropertyType;
+					var underlying = Nullable.GetUnderlyingType(propType) ?? propType;
+					// Enums (including Nullable<enum>) that serialize to a string form ([StringEnum],
+					// [Flags], or any [EnumMember] value) must be pinned to the enum-member converter.
+					// The lowest-precedence SourceConverterFactory (a catch-all for non-framework types)
+					// also claims enums — and a nullable enum's own assembly is CoreLib, so it is not
+					// excluded as a framework type. Resolving through the options factory list would
+					// therefore hand back a SourceConverter that delegates the enum to the source
+					// serializer, dropping the [StringEnum]/[Flags] "AND|NEAR" formatting. Build the
+					// enum-member converter directly instead of asking the options. Enums that serialize
+					// numerically (e.g. GeoHashPrecision) are not claimed by the factory and are left to
+					// STJ's numeric default.
+					if (underlying.IsEnum && EnumMemberConverterFactoryInstance.CanConvert(propType))
+					{
+						try
+						{
+							var conv = EnumMemberConverterFactoryInstance.CreateConverter(propType, typeInfo.Options);
+							if (conv != null)
+								jsonProp.CustomConverter = conv;
+						}
+						catch { /* leave unset — STJ will resolve normally */ }
+					}
+					else if (!propType.IsGenericType && !propType.IsInterface && !propType.IsAbstract
+						&& ConverterBackedValueTypes.Contains(underlying))
+					{
+						try
+						{
+							var conv = typeInfo.Options.GetConverter(propType);
+							if (conv != null && conv.GetType().Namespace?.StartsWith("System", StringComparison.Ordinal) != true)
+								jsonProp.CustomConverter = conv;
+						}
+						catch { /* If GetConverter throws, leave it unset — STJ will resolve normally */ }
+					}
+					// Dictionaries keyed by Field need settings-aware key inference. STJ skips the
+					// options-registered Field converter factory for dictionary keys at depth, so pin a
+					// dedicated converter that resolves each key through the Field converter.
+					else if (TryGetFieldKeyedDictionaryValueType(propType, out var dictValueType))
+					{
+						try
+						{
+							var convType = typeof(FieldKeyedDictionaryConverter<>).MakeGenericType(dictValueType);
+							jsonProp.CustomConverter = (System.Text.Json.Serialization.JsonConverter)Activator.CreateInstance(convType);
+						}
+						catch { /* If construction fails, leave it unset — STJ will resolve normally */ }
+					}
+					// IEnumerable<double> properties must keep the client's trailing-".0" wire format for
+					// integral values. STJ skips the options-registered DoubleConverter for collection
+					// elements at depth, so pin a converter that routes each element through it.
+					else if (propType == typeof(IEnumerable<double>))
+					{
+						jsonProp.CustomConverter = new DoubleEnumerableConverter();
+					}
+
+					var captured = ifaceProp;
+					if (captured.CanRead)
+						jsonProp.Get = obj => captured.GetValue(obj);
+					if (captured.CanWrite)
+						jsonProp.Set = (obj, value) => captured.SetValue(obj, value);
+					else
+					{
+						// The contract interface commonly declares getter-only properties (e.g.
+						// IInlineGet.Found/Source/Fields) whose concrete implementation has an internal setter.
+						// Resolve the concrete property on the target type and use its (possibly non-public)
+						// setter so the member can deserialize — otherwise it stays at its default (Found=false,
+						// Source=null).
+						var concreteProp = type.GetProperty(ifaceProp.Name,
+							BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+						var concreteSetter = concreteProp?.GetSetMethod(true);
+						if (concreteSetter != null)
+							jsonProp.Set = (obj, value) => concreteSetter.Invoke(obj, new[] { value });
+					}
+
+					// A QueryContainer that is conditionless (e.g. an empty bool query) must be
+					// omitted entirely rather than emitted as "prop": null. Utf8Json achieved this
+					// by not writing conditionless queries; mirror it with a ShouldSerialize guard.
+					if (propType == typeof(QueryContainer))
+						jsonProp.ShouldSerialize = (_, value) => value is QueryContainer qc && qc.IsWritable;
+					else
+						ApplyTypeLevelShouldSerialize(jsonProp, propType);
+
+					rebuilt.Add(jsonProp);
+				}
+			}
+
+			// Custom (e.g. plugin) implementations may declare additional public properties that carry
+			// their own [PropertyName]/[DataMember] annotation but are not part of the contract interface.
+			// Emit those too (honoring the interface-declared [IgnoreDataMember] exclusions), matching the
+			// Utf8Json behavior where any [PropertyName]/[DataMember]-marked property is serialized.
+			foreach (var clrProp in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+			{
+				if (ignoredMemberNames.Contains(clrProp.Name))
+					continue;
+
+				var propertyNameAttr = clrProp.GetCustomAttribute<PropertyNameAttribute>();
+				var dataMemberAttr = clrProp.GetCustomAttribute<DataMemberAttribute>();
+				// For user-defined analysis components emit every readable/writable public property, even
+				// unannotated ones (e.g. a plugin tokenizer's custom setting). Otherwise, only emit
+				// properties carrying their own [PropertyName]/[DataMember] annotation.
+				if (propertyNameAttr == null && dataMemberAttr == null && !isUserDefinedAnalysisComponent)
+					continue;
+
+				if (propertyNameAttr?.Ignore == true)
+					continue;
+
+				if (clrProp.GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+					continue;
+
+				// Skip indexers and non-public accessors for the unannotated fallback path.
+				if (isUserDefinedAnalysisComponent && propertyNameAttr == null && dataMemberAttr == null
+					&& clrProp.GetIndexParameters().Length > 0)
+					continue;
+
+				var jsonName = propertyNameAttr?.Name
+					?? dataMemberAttr?.Name
+					?? JsonNamingPolicy.CamelCase.ConvertName(clrProp.Name);
+
+				if (!seen.Add(jsonName))
+					continue;
+
+				var jsonProp = typeInfo.CreateJsonPropertyInfo(clrProp.PropertyType, jsonName);
+
+				var captured = clrProp;
+				if (captured.CanRead)
+					jsonProp.Get = obj => captured.GetValue(obj);
+				if (captured.CanWrite)
+					jsonProp.Set = (obj, value) => captured.SetValue(obj, value);
+
+				ApplyTypeLevelShouldSerialize(jsonProp, clrProp.PropertyType);
+
+				rebuilt.Add(jsonProp);
+			}
+
+			// Inherited non-public [DataMember] members (e.g. ResponseBase.Error / StatusCode, which carry
+			// the "error"/"status" wire fields) are surfaced by neither the interface loop nor the public
+			// CLR loop above. STJ's default resolver would also drop them (non-public), so a response whose
+			// contract is rebuilt here (e.g. GetResponse<T>, an [InterfaceDataContract] type) would lose its
+			// ServerError. Re-add any non-public instance [DataMember] property that has not already been
+			// collected and whose wire name does not collide with a property already present.
+			for (var baseType = type; baseType != null && baseType != typeof(object); baseType = baseType.BaseType)
+			{
+				foreach (var nonPublic in baseType.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+				{
+					if (ignoredMemberNames.Contains(nonPublic.Name))
+						continue;
+
+					var dataMemberAttr = nonPublic.GetCustomAttribute<DataMemberAttribute>();
+					if (dataMemberAttr == null || nonPublic.GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+						continue;
+
+					var jsonName = dataMemberAttr.Name ?? JsonNamingPolicy.CamelCase.ConvertName(nonPublic.Name);
+					if (!seen.Add(jsonName))
+						continue;
+
+					var jsonProp = typeInfo.CreateJsonPropertyInfo(nonPublic.PropertyType, jsonName);
+
+					var getter = nonPublic.GetGetMethod(true);
+					if (getter != null)
+						jsonProp.Get = obj => getter.Invoke(obj, null);
+
+					var setter = nonPublic.GetSetMethod(true);
+					if (setter != null)
+						jsonProp.Set = (obj, value) => setter.Invoke(obj, new[] { value });
+
+					rebuilt.Add(jsonProp);
+				}
+			}
+
+			// If the rebuilt contract has no properties, decide between two cases:
+			//  - The concrete class itself declares [DataMember] properties (e.g. response types such as
+			//    GetResponse<T> whose members live on the class, not the interface). Leave the default
+			//    contract intact so those class properties still (de)serialize.
+			//  - Neither the interface nor the concrete class declares [DataMember] properties on their
+			//    own members (e.g. GlobalAggregation, whose only inherited property Aggregations is not a
+			//    [DataMember] and is emitted by the aggregation container, not inline). Fall through to
+			//    rebuild the contract to an empty object so it serializes as {}.
+			if (rebuilt.Count == 0 && ConcreteTypeDeclaresDataMember(type))
+				return;
+
+			// These types are (de)serialized purely by their property contract. Many define a
+			// public convenience constructor (e.g. AverageAggregation(string name, Field field))
+			// that STJ would otherwise treat as the deserialization constructor and fail to bind.
+			// Force construction through a parameterless constructor instead.
+			var ctor = type.GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+				binder: null, Type.EmptyTypes, modifiers: null);
+			if (ctor != null)
+				typeInfo.CreateObject = () => ctor.Invoke(null);
+
+			// Rebuild the contract deterministically from the collected properties.
+			typeInfo.Properties.Clear();
+			foreach (var jsonProp in rebuilt)
+				typeInfo.Properties.Add(jsonProp);
+		}
+
+		/// <summary>
+		/// Cache of the type-level <c>bool ShouldSerialize(IConnectionSettingsValues)</c> method (if any)
+		/// declared by a property type. This mirrors Utf8Json's per-type <c>ShouldSerialize</c> hook
+		/// (see <c>ReflectionExtensions.GetShouldSerializeMethod</c>): any property whose <em>type</em>
+		/// declares such a method had it invoked to decide whether the property is emitted at all.
+		/// </summary>
+		private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, MethodInfo> ShouldSerializeMethods = new();
+
+		/// <summary>
+		/// Applies the type-level <c>ShouldSerialize(IConnectionSettingsValues)</c> hook (if the property
+		/// type declares one) as a STJ <see cref="JsonPropertyInfo.ShouldSerialize"/> predicate. This is the
+		/// System.Text.Json equivalent of Utf8Json's per-type <c>ShouldSerialize</c> emission guard, used by
+		/// e.g. <see cref="Routing"/> so that a routing value that resolves to empty is omitted entirely
+		/// rather than written as <c>"routing": null</c>.
+		/// </summary>
+		private void ApplyTypeLevelShouldSerialize(JsonPropertyInfo jsonProp, Type propType)
+		{
+			var method = ShouldSerializeMethods.GetOrAdd(propType, static t =>
+				t.GetMethod("ShouldSerialize",
+					BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+					binder: null, new[] { typeof(IConnectionSettingsValues) }, modifiers: null) is { ReturnType: var rt } m
+				&& rt == typeof(bool)
+					? m
+					: null);
+
+			if (method == null)
+				return;
+
+			var settings = _settings;
+			jsonProp.ShouldSerialize = (_, value) =>
+				value != null && (bool)method.Invoke(value, new object[] { settings });
+		}
+
+		/// <summary>
+		/// Resolves a <see cref="System.Text.Json.Serialization.JsonConverter"/> that delegates to the
+		/// SourceSerializer for the given property type, by locating the <c>SourceConverterFactory</c>
+		/// registered on the options. Returns <c>null</c> if it cannot be resolved.
+		/// </summary>
+		private static System.Text.Json.Serialization.JsonConverter GetSourceConverter(JsonSerializerOptions options, Type propertyType)
+		{
+			foreach (var converter in options.Converters)
+			{
+				if (converter is SourceConverterFactory factory)
+				{
+					try
+					{
+						return factory.CreateSourceConverter(propertyType, options);
+					}
+					catch
+					{
+						return null;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Analysis component base interfaces. A concrete type implementing one of these but defined
+		/// outside the OpenSearch.Client assembly is a user-defined (plugin) analysis component whose
+		/// full public property set must be serialized (matching the Utf8Json object-formatter fallback).
+		/// </summary>
+		private static readonly Type[] AnalysisComponentInterfaces =
+		{
+			typeof(IAnalyzer),
+			typeof(INormalizer),
+			typeof(ITokenizer),
+			typeof(ITokenFilter),
+			typeof(ICharFilter),
+		};
+
+		private static bool IsUserDefinedAnalysisComponent(Type type)
+		{
+			// Types shipped in the client assembly are handled by their explicit contracts.
+			if (type.Assembly == typeof(InterfaceDataContractModifier).Assembly)
+				return false;
+
+			foreach (var iface in AnalysisComponentInterfaces)
+			{
+				if (iface.IsAssignableFrom(type))
+					return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Returns true if the concrete type (or a base class) declares at least one instance property
+		/// carrying a <see cref="DataMemberAttribute"/>. Used to distinguish response-style types whose
+		/// contract lives on the class from parameterless marker types (e.g. GlobalAggregation).
+		/// </summary>
+		private static bool ConcreteTypeDeclaresDataMember(Type type)
+		{
+			foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+			{
+				if (prop.GetCustomAttribute<DataMemberAttribute>() != null)
+					return true;
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Concrete non-generic value types whose serialization depends on settings-aware converter
+		/// factories registered on the options. STJ skips options-registered factories for properties
+		/// on rebuilt contracts at depth, so we pin the converter explicitly via CustomConverter.
+		/// Only leaf (non-collection, non-interface) types are included to avoid interfering with
+		/// STJ's built-in collection/interface resolution.
+		/// </summary>
+		private static readonly HashSet<Type> ConverterBackedValueTypes = new()
+		{
+			typeof(Field),
+			typeof(IndexName),
+			typeof(Indices),
+			typeof(RelationName),
+			typeof(Id),
+			typeof(Routing),
+			typeof(Name),
+			typeof(Names),
+			typeof(TaskId),
+		};
+
+		/// <summary>
+		/// Determines whether <paramref name="propType"/> is an <see cref="IDictionary{TKey,TValue}"/>
+		/// (or a type implementing it) whose key type is <see cref="Field"/>, returning the value type.
+		/// </summary>
+		private static bool TryGetFieldKeyedDictionaryValueType(Type propType, out Type valueType)
+		{
+			valueType = null;
+
+			if (!propType.IsGenericType)
+				return false;
+
+			var def = propType.GetGenericTypeDefinition();
+			if (def != typeof(IDictionary<,>) && def != typeof(Dictionary<,>))
+				return false;
+
+			var args = propType.GetGenericArguments();
+			if (args.Length != 2 || args[0] != typeof(Field))
+				return false;
+
+			valueType = args[1];
+			return true;
+		}
+
+		/// <summary>
+		/// Returns all interfaces in <paramref name="type"/>'s hierarchy that participate in the
+		/// interface data contract — i.e. reachable from an interface marked
+		/// <see cref="InterfaceDataContractAttribute"/> — most-derived first so that overriding
+		/// [DataMember] names win.
+		/// </summary>
+		private static List<Type> GetContractInterfaces(Type type)
+		{
+			var roots = type.GetInterfaces()
+				.Where(i => i.GetCustomAttribute<InterfaceDataContractAttribute>() != null)
+				.ToList();
+
+			if (roots.Count == 0)
+				return roots;
+
+			// Order roots most-derived first, so a derived contract interface's [DataMember] properties
+			// are emitted before the base interface's (e.g. ICompletionSuggester's "fuzzy" before
+			// ISuggester's "field"/"size"). Type.GetInterfaces() does not guarantee this ordering.
+			// A more-derived interface implements (transitively) more interfaces than its bases, so
+			// ordering by implemented-interface count (descending) yields derived-first and is a stable sort.
+			roots = roots
+				.OrderByDescending(i => i.GetInterfaces().Length)
+				.ToList();
+
+			var ordered = new List<Type>();
+			var seen = new HashSet<Type>();
+
+			void Visit(Type iface)
+			{
+				if (!seen.Add(iface))
+					return;
+				ordered.Add(iface);
+				foreach (var parent in iface.GetInterfaces())
+				{
+					if (parent.Namespace?.StartsWith("System", StringComparison.Ordinal) == true)
+						continue;
+					Visit(parent);
+				}
+			}
+
+			foreach (var root in roots)
+				Visit(root);
+
+			return ordered;
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DictionaryResponseConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DictionaryResponseConverterFactory.cs
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes responses derived from <see cref="DictionaryResponseBase{TKey,TValue}"/> (e.g.
+	/// <c>GetIndexResponse</c>, <c>GetAliasResponse</c>, <c>GetMappingResponse</c>, <c>GetPipelineResponse</c>).
+	/// The response body is a JSON object whose members are the dictionary entries, plus the optional
+	/// server <c>error</c>/<c>status</c> fields. This replaces the Utf8Json
+	/// <c>ResolvableDictionaryResponseFormatter</c> / <c>DictionaryResponseFormatter</c> that were applied via
+	/// a <c>[JsonFormatter]</c> attribute in the pre-migration client.
+	/// </summary>
+	/// <remarks>
+	/// When the key type implements <see cref="IUrlParameter"/> the backing dictionary is wrapped in a
+	/// <see cref="ResolvableDictionaryProxy{TKey,TValue}"/> so that inferred keys resolve correctly, matching
+	/// the behavior of the old <c>ResolvableDictionaryResponseFormatter</c>.
+	/// </remarks>
+	internal sealed class DictionaryResponseConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public DictionaryResponseConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			!typeToConvert.IsAbstract && GetDictionaryResponseArguments(typeToConvert) != null;
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var args = GetDictionaryResponseArguments(typeToConvert);
+			var converterType = typeof(DictionaryResponseConverter<,,>).MakeGenericType(typeToConvert, args[0], args[1]);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+
+		/// <summary>
+		/// Returns the <c>[TKey, TValue]</c> type arguments if <paramref name="type"/> derives from
+		/// <see cref="DictionaryResponseBase{TKey,TValue}"/>, otherwise <c>null</c>.
+		/// </summary>
+		private static Type[] GetDictionaryResponseArguments(Type type)
+		{
+			var current = type.BaseType;
+			while (current != null && current != typeof(object))
+			{
+				if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(DictionaryResponseBase<,>))
+					return current.GetGenericArguments();
+				current = current.BaseType;
+			}
+			return null;
+		}
+	}
+
+	internal sealed class DictionaryResponseConverter<TResponse, TKey, TValue> : JsonConverter<TResponse>
+		where TResponse : ResponseBase, IDictionaryResponse<TKey, TValue>, new()
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public DictionaryResponseConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override TResponse Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+			var response = new TResponse();
+			var dictionary = new Dictionary<TKey, TValue>();
+
+			reader.Read();
+			while (reader.TokenType != JsonTokenType.EndObject)
+			{
+				var property = reader.GetString();
+				reader.Read();
+
+				if (property == "error")
+				{
+					if (reader.TokenType == JsonTokenType.String)
+						response.Error = new Error { Reason = reader.GetString() };
+					else
+						response.Error = JsonSerializer.Deserialize<Error>(ref reader, options);
+				}
+				else if (property == "status")
+				{
+					if (reader.TokenType == JsonTokenType.Number)
+						response.StatusCode = reader.GetInt32();
+					else
+						reader.Skip();
+				}
+				else
+				{
+					var key = ConvertKey(property);
+					var value = JsonSerializer.Deserialize<TValue>(ref reader, options);
+					dictionary[key] = value;
+				}
+
+				reader.Read();
+			}
+
+			response.BackingDictionary = CreateBackingDictionary(dictionary);
+			return response;
+		}
+
+		public override void Write(Utf8JsonWriter writer, TResponse value, JsonSerializerOptions options) =>
+			throw new NotSupportedException($"{typeof(TResponse).Name} is a response type and is not serialized.");
+
+		private static TKey ConvertKey(string keyString)
+		{
+			if (typeof(TKey) == typeof(string))
+				return (TKey)(object)keyString;
+			if (typeof(TKey) == typeof(IndexName))
+				return (TKey)(object)(IndexName)keyString;
+			if (typeof(TKey) == typeof(Name))
+				return (TKey)(object)(Name)keyString;
+			return (TKey)(object)keyString;
+		}
+
+		private IReadOnlyDictionary<TKey, TValue> CreateBackingDictionary(Dictionary<TKey, TValue> dictionary)
+		{
+			// IUrlParameter keys (e.g. IndexName) get the resolvable proxy so inferred keys resolve
+			// to their wire form, matching the old ResolvableDictionaryResponseFormatter behavior.
+			if (typeof(IUrlParameter).IsAssignableFrom(typeof(TKey)))
+			{
+				var proxyType = typeof(ResolvableDictionaryProxy<,>).MakeGenericType(typeof(TKey), typeof(TValue));
+				var ctor = proxyType.GetConstructor(
+					BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+					binder: null,
+					new[] { typeof(IConnectionConfigurationValues), typeof(IReadOnlyDictionary<TKey, TValue>) },
+					modifiers: null);
+
+				if (ctor != null)
+					return (IReadOnlyDictionary<TKey, TValue>)ctor.Invoke(new object[] { _settings, dictionary });
+			}
+
+			return dictionary;
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DoubleEnumerableConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DoubleEnumerableConverter.cs
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes an <see cref="IEnumerable{Double}"/> using the options-registered
+	/// <see cref="double"/> converter for each element, so integral values keep their trailing
+	/// <c>.0</c> (e.g. <c>95.0</c> not <c>95</c>). System.Text.Json skips the options-registered
+	/// <c>DoubleConverter</c> for collection elements at depth, so this converter is pinned onto
+	/// <c>IEnumerable&lt;double&gt;</c> contract properties by <see cref="InterfaceDataContractModifier"/>.
+	/// </summary>
+	internal sealed class DoubleEnumerableConverter : JsonConverter<IEnumerable<double>>
+	{
+		public override IEnumerable<double> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartArray)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var doubleConverter = (JsonConverter<double>)options.GetConverter(typeof(double));
+			var list = new List<double>();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+				list.Add(doubleConverter.Read(ref reader, typeof(double), options));
+
+			return list;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IEnumerable<double> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var doubleConverter = (JsonConverter<double>)options.GetConverter(typeof(double));
+
+			writer.WriteStartArray();
+			foreach (var v in value)
+				doubleConverter.Write(writer, v, options);
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DynamicResponseConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/DynamicResponseConverterFactory.cs
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes responses deriving from <see cref="DynamicResponseBase"/> (e.g.
+	/// <see cref="ClusterStateResponse"/>) by reading the whole JSON body into the response's
+	/// <see cref="DynamicDictionary"/> backing store, peeling off <c>error</c>/<c>status</c> into the
+	/// <see cref="ResponseBase"/> error members. Replaces the pre-STJ <c>DynamicResponseFormatter&lt;T&gt;</c>.
+	/// Without it these responses deserialize via STJ's default object contract, which never populates the
+	/// backing dictionary — so computed accessors such as <c>ClusterStateResponse.ClusterName</c> return null.
+	/// </summary>
+	internal sealed class DynamicResponseConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public DynamicResponseConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			!typeToConvert.IsAbstract && !typeToConvert.IsInterface && typeof(DynamicResponseBase).IsAssignableFrom(typeToConvert);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var converterType = typeof(DynamicResponseConverter<>).MakeGenericType(typeToConvert);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+	}
+
+	internal sealed class DynamicResponseConverter<TResponse> : JsonConverter<TResponse>
+		where TResponse : DynamicResponseBase, new()
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public DynamicResponseConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override TResponse Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+			var response = new TResponse();
+			var dictionary = new Dictionary<string, object>();
+
+			reader.Read();
+			while (reader.TokenType != JsonTokenType.EndObject)
+			{
+				var property = reader.GetString();
+				reader.Read();
+
+				if (property == "error")
+				{
+					if (reader.TokenType == JsonTokenType.String)
+						response.Error = new Error { Reason = reader.GetString() };
+					else
+						response.Error = JsonSerializer.Deserialize<Error>(ref reader, options);
+				}
+				else if (property == "status" && reader.TokenType == JsonTokenType.Number)
+				{
+					response.StatusCode = reader.GetInt32();
+				}
+				else
+				{
+					// Values deserialize via the registered ObjectConverter into .NET primitives / nested
+					// Dictionary<string,object> / List<object>, which DynamicDictionary.Create wraps.
+					dictionary[property] = JsonSerializer.Deserialize<object>(ref reader, options);
+				}
+
+				reader.Read();
+			}
+
+			((IDynamicResponse)response).BackingDictionary = DynamicDictionary.Create(dictionary);
+			return response;
+		}
+
+		public override void Write(Utf8JsonWriter writer, TResponse value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var backing = ((IDynamicResponse)value).BackingDictionary;
+			JsonSerializer.Serialize(writer, backing, options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/EmbeddedDomainTypeConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/EmbeddedDomainTypeConverterFactory.cs
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+using InterfaceDataContractAttribute = OpenSearch.Net.Utf8Json.InterfaceDataContractAttribute;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> for the terminal source options that delegates OpenSearch.Client
+	/// domain-contract types (e.g. <see cref="QueryContainer"/> and the query DSL, mappings, aggregations)
+	/// back to the full high-level domain options when they appear as members of a user document.
+	/// <para>
+	/// The terminal source options (<see cref="SourceConverterHelper.GetDefaultSourceOptions"/>) are
+	/// POCO-oriented and intentionally omit the high-level domain converters. Without this delegation an
+	/// embedded domain type such as a percolator query stored on <c>ProjectPercolation.Query</c> would emit
+	/// an empty object (its query bodies are exposed only through explicit-interface members and require the
+	/// field-name-query wrapping converters) — producing a percolator that matches nothing.
+	/// </para>
+	/// </summary>
+	internal sealed class EmbeddedDomainTypeConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public EmbeddedDomainTypeConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => IsDomainContractType(typeToConvert);
+
+		/// <summary>
+		/// Whether <paramref name="type"/> is (or implements) an OpenSearch.Client domain contract — an
+		/// interface marked <see cref="InterfaceDataContractAttribute"/>, or a concrete type implementing one.
+		/// These must round-trip through the domain machinery rather than plain POCO reflection.
+		/// </summary>
+		private static bool IsDomainContractType(Type type)
+		{
+			if (type == null) return false;
+
+			var assemblyName = type.Assembly.GetName().Name;
+			var isFrameworkType = assemblyName != null &&
+				(assemblyName.StartsWith("OpenSearch.Net", StringComparison.Ordinal) ||
+				 assemblyName.StartsWith("OpenSearch.Client", StringComparison.Ordinal));
+
+			// Only OpenSearch framework types (or user types implementing a framework contract) qualify.
+			if (type.IsInterface && isFrameworkType && Attribute.IsDefined(type, typeof(InterfaceDataContractAttribute)))
+				return true;
+
+			foreach (var iface in type.GetInterfaces())
+			{
+				var ifaceAssembly = iface.Assembly.GetName().Name;
+				if (ifaceAssembly != null &&
+					(ifaceAssembly.StartsWith("OpenSearch.Net", StringComparison.Ordinal) ||
+					 ifaceAssembly.StartsWith("OpenSearch.Client", StringComparison.Ordinal)) &&
+					Attribute.IsDefined(iface, typeof(InterfaceDataContractAttribute)))
+					return true;
+			}
+
+			return false;
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var converterType = typeof(EmbeddedDomainTypeConverter<>).MakeGenericType(typeToConvert);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+	}
+
+	internal sealed class EmbeddedDomainTypeConverter<T> : JsonConverter<T>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public EmbeddedDomainTypeConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		private JsonSerializerOptions DomainOptions =>
+			_settings.RequestResponseSerializer is IInternalSerializer s && s.TryGetJsonSerializerOptions(out var o)
+				? o
+				: null;
+
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var domain = DomainOptions;
+			return domain != null
+				? JsonSerializer.Deserialize<T>(ref reader, domain)
+				: default;
+		}
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			var domain = DomainOptions;
+			if (domain != null)
+				JsonSerializer.Serialize(writer, value, domain);
+			else
+				writer.WriteNullValue();
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/EpochMillisecondsDateTimeConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/EpochMillisecondsDateTimeConverter.cs
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes a <see cref="DateTimeOffset"/> as a string containing milliseconds-since-Unix-epoch,
+	/// and deserializes either an epoch-milliseconds number/string or an ISO-8601 date string. Replaces
+	/// the Utf8Json <c>DateTimeOffsetEpochMillisecondsFormatter</c>.
+	/// </summary>
+	internal sealed class EpochMillisecondsDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+	{
+		private static readonly DateTimeOffset UnixEpoch =
+			new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+		public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Number:
+					return UnixEpoch.AddMilliseconds(reader.GetDouble());
+				case JsonTokenType.String:
+					var s = reader.GetString();
+					if (s == null)
+						return default;
+					if (long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var epochMs))
+						return UnixEpoch.AddMilliseconds(epochMs);
+					return DateTimeOffset.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+				default:
+					reader.Skip();
+					return default;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options) =>
+			writer.WriteStringValue(value.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IntStringConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IntStringConverter.cs
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes a JSON number OR string into a <see cref="string"/>, and serializes a string back
+	/// as a JSON number. Mirrors the historical (Utf8Json) <c>IntStringFormatter</c>: some OpenSearch
+	/// responses return integer-valued identifiers (e.g. <c>shard_id</c>) as bare numbers even though
+	/// the client models them as strings.
+	/// </summary>
+	internal sealed class IntStringConverter : JsonConverter<string>
+	{
+		public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.Number:
+					return reader.GetInt64().ToString(CultureInfo.InvariantCulture);
+				case JsonTokenType.String:
+					return reader.GetString();
+				default:
+					throw new JsonException($"expected string or int but found {reader.TokenType}");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i))
+				writer.WriteNumberValue(i);
+			else
+				throw new InvalidOperationException($"expected a int string value, but found {value}");
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IsADictionaryConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/IsADictionaryConverterFactory.cs
@@ -1,0 +1,298 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class IsADictionaryConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IsADictionaryConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(IIsADictionary).IsAssignableFrom(typeToConvert) && GetDictionaryArguments(typeToConvert) != null;
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var args = GetDictionaryArguments(typeToConvert);
+			var converterType = typeof(IsADictionaryConverter<,,>).MakeGenericType(args[0], args[1], typeToConvert);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+
+		private static Type[] GetDictionaryArguments(Type type)
+		{
+			var iface = type.GetInterfaces()
+				.FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IIsADictionary<,>));
+
+			if (iface != null)
+				return iface.GetGenericArguments();
+
+			if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IIsADictionary<,>))
+				return type.GetGenericArguments();
+
+			return null;
+		}
+	}
+
+	internal sealed class IsADictionaryConverter<TKey, TValue, TDictionary> : JsonConverter<TDictionary>
+		where TDictionary : class, IIsADictionary<TKey, TValue>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		// When true, plain string keys are written verbatim rather than being run through the
+		// DefaultFieldNameInferrer. Mirrors the historical Utf8Json VerbatimDictionaryKeysFormatter,
+		// used for dictionaries whose string keys are user-provided names (e.g. suggester names).
+		private static readonly bool VerbatimKeys = typeof(IVerbatimDictionaryKeys).IsAssignableFrom(typeof(TDictionary));
+
+		public IsADictionaryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override TDictionary Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+			var dict = new Dictionary<TKey, TValue>();
+
+			reader.Read();
+			while (reader.TokenType != JsonTokenType.EndObject)
+			{
+				var key = ReadKey(ref reader, options);
+				reader.Read();
+				var value = JsonSerializer.Deserialize<TValue>(ref reader, options);
+				dict[key] = value;
+				reader.Read();
+			}
+
+			return CreateInstance(dict);
+		}
+
+		public override void Write(Utf8JsonWriter writer, TDictionary value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			// Deduplicate entries whose keys resolve to the same wire-format string. This mirrors
+			// the Utf8Json PropertiesFormatter behavior where AutoMap-generated PropertyName keys
+			// (with _type set from reflection) and explicit-mapping PropertyName keys (string-only)
+			// can both resolve to the same JSON property name. The last entry wins (override semantics).
+			HashSet<string> seenKeys = null;
+			List<KeyValuePair<string, TValue>> deduplicatedEntries = null;
+			var entries = (IEnumerable<KeyValuePair<TKey, TValue>>)value;
+
+			// First pass: check if deduplication is needed (only for PropertyName-keyed dictionaries
+			// where AutoMap + explicit mapping can produce duplicates).
+			if (typeof(TKey) == typeof(PropertyName))
+			{
+				seenKeys = new HashSet<string>(StringComparer.Ordinal);
+				deduplicatedEntries = new List<KeyValuePair<string, TValue>>();
+				foreach (var kvp in entries)
+				{
+					var keyString = ResolveKey(kvp.Key);
+					if (keyString == null)
+						continue;
+
+					// Find and remove any existing entry with the same resolved key (last-wins)
+					if (!seenKeys.Add(keyString))
+					{
+						for (var i = deduplicatedEntries.Count - 1; i >= 0; i--)
+						{
+							if (string.Equals(deduplicatedEntries[i].Key, keyString, StringComparison.Ordinal))
+							{
+								deduplicatedEntries.RemoveAt(i);
+								break;
+							}
+						}
+					}
+					deduplicatedEntries.Add(new KeyValuePair<string, TValue>(keyString, kvp.Value));
+				}
+
+				foreach (var entry in deduplicatedEntries)
+				{
+					writer.WritePropertyName(entry.Key);
+					if (entry.Value is null)
+						writer.WriteNullValue();
+					else
+						JsonSerializer.Serialize(writer, entry.Value, entry.Value.GetType(), options);
+				}
+			}
+			else
+			{
+				foreach (var kvp in entries)
+				{
+					var keyString = ResolveKey(kvp.Key);
+					if (keyString == null)
+						continue;
+
+					writer.WritePropertyName(keyString);
+					// Serialize by the value's runtime type so polymorphic values (e.g. ITokenFilter,
+					// IAnalyzer, IProperty) emit their full concrete contract rather than the (often empty)
+					// declared-interface contract. STJ resolves the runtime type's converter/contract.
+					if (kvp.Value is null)
+						writer.WriteNullValue();
+					else
+						JsonSerializer.Serialize(writer, kvp.Value, kvp.Value.GetType(), options);
+				}
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private string ResolveKey(TKey key)
+		{
+			if (key == null) return string.Empty;
+
+			if (key is PropertyName propertyName)
+			{
+				if (propertyName.Property != null)
+				{
+					// Honor an explicit ignore from DefaultMappingFor<T> property mappings.
+					if (_settings.PropertyMappings.TryGetValue(propertyName.Property, out var mapping) && mapping.Ignore)
+						return null;
+
+					// Honor ignore from OSC property attributes ([PropertyName(Ignore=true)],
+					// serializer-specific [Ignore]/[JsonIgnore]) via the property mapping provider.
+					var providerMapping = _settings.PropertyMappingProvider?.CreatePropertyMapping(propertyName.Property);
+					if (providerMapping != null && providerMapping.Ignore)
+						return null;
+				}
+
+				return _settings.Inferrer.PropertyName(propertyName) ?? string.Empty;
+			}
+
+			if (key is IndexName indexName)
+				return _settings.Inferrer.IndexName(indexName) ?? string.Empty;
+
+			if (key is Field field)
+				return _settings.Inferrer.Field(field) ?? string.Empty;
+
+			if (key is RelationName relationName)
+				return _settings.Inferrer.RelationName(relationName) ?? string.Empty;
+
+			// Plain string (or arbitrary object) keys are camel-cased via the DefaultFieldNameInferrer,
+			// matching the Utf8Json IsADictionary formatter (which applied the inferrer "mutator" to every
+			// key). Typed keys above (PropertyName/IndexName/Field/RelationName) are already resolved to
+			// their final wire form by the Inferrer and are returned as-is.
+			// Verbatim-key dictionaries (IVerbatimDictionaryKeys) keep their string keys untouched.
+			if (key is string s)
+				return VerbatimKeys ? s : (_settings.DefaultFieldNameInferrer(s) ?? s);
+
+			return VerbatimKeys
+				? key.ToString()
+				: (_settings.DefaultFieldNameInferrer(key.ToString()) ?? key.ToString());
+		}
+
+		private TKey ReadKey(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			var keyString = reader.GetString();
+
+			if (typeof(TKey) == typeof(string))
+				return (TKey)(object)keyString;
+
+			if (typeof(TKey) == typeof(PropertyName))
+				return (TKey)(object)(PropertyName)keyString;
+
+			if (typeof(TKey) == typeof(IndexName))
+				return (TKey)(object)(IndexName)keyString;
+
+			if (typeof(TKey) == typeof(Field))
+				return (TKey)(object)(Field)keyString;
+
+			if (typeof(TKey) == typeof(RelationName))
+				return (TKey)(object)(RelationName)keyString;
+
+			return (TKey)Convert.ChangeType(keyString, typeof(TKey));
+		}
+
+		private TDictionary CreateInstance(Dictionary<TKey, TValue> dict)
+		{
+			var type = typeof(TDictionary);
+			if (type.IsInterface || type.IsAbstract)
+			{
+				var readAsAttribute = type.GetCustomAttribute<ReadAsAttribute>();
+				if (readAsAttribute != null)
+				{
+					type = readAsAttribute.Type.IsGenericType && !readAsAttribute.Type.IsConstructedGenericType
+						? readAsAttribute.Type.MakeGenericType(typeof(TKey), typeof(TValue))
+						: readAsAttribute.Type;
+				}
+				else
+				{
+					// Try to find a concrete implementation in the same assembly
+					var candidateType = type.Assembly.GetTypes()
+						.FirstOrDefault(t => !t.IsInterface && !t.IsAbstract && type.IsAssignableFrom(t));
+					if (candidateType != null)
+						type = candidateType;
+					else
+						throw new JsonException($"Unable to deserialize interface {typeof(TDictionary).FullName} — no [ReadAs] attribute found.");
+				}
+			}
+
+			var genericDictionaryInterface = typeof(IDictionary<TKey, TValue>);
+
+			// Prefer a settings-aware constructor when available (e.g. Properties(IConnectionSettingsValues)):
+			// these dictionaries resolve their keys through the Inferrer on Add and on lookup, so they must
+			// be built settings-first and populated via Add (which sanitizes the key). Without this, keys are
+			// stored raw and an expression-path lookup (e.g. p => p.LeadDeveloper) never matches.
+			var settingsCtor = _settings == null
+				? null
+				: type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+					.FirstOrDefault(c =>
+					{
+						var ps = c.GetParameters();
+						return ps.Length == 1 && typeof(IConnectionSettingsValues).IsAssignableFrom(ps[0].ParameterType);
+					});
+
+			if (settingsCtor != null)
+			{
+				var settingsInstance = (TDictionary)settingsCtor.Invoke(new object[] { _settings });
+				foreach (var kvp in dict)
+					((IDictionary<TKey, TValue>)settingsInstance).Add(kvp.Key, kvp.Value);
+				return settingsInstance;
+			}
+
+			var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+				.Select(c => new { Constructor = c, Parameters = c.GetParameters() })
+				.Where(x => x.Parameters.Length == 0
+					|| (x.Parameters.Length == 1 && genericDictionaryInterface.IsAssignableFrom(x.Parameters[0].ParameterType)))
+				.OrderByDescending(x => x.Parameters.Length)
+				.FirstOrDefault();
+
+			if (ctor == null)
+				throw new JsonException($"Cannot create an instance of {type.FullName} — no suitable constructor found.");
+
+			TDictionary instance;
+			if (ctor.Parameters.Length == 1)
+			{
+				instance = (TDictionary)ctor.Constructor.Invoke(new object[] { dict });
+			}
+			else
+			{
+				instance = (TDictionary)ctor.Constructor.Invoke(Array.Empty<object>());
+				foreach (var kvp in dict)
+					((IDictionary<TKey, TValue>)instance).Add(kvp.Key, kvp.Value);
+			}
+
+			return instance;
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ProxyRequestConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ProxyRequestConverterFactory.cs
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> for request types implementing <see cref="IProxyRequest"/>
+	/// (e.g. <see cref="IIndexRequest{TDocument}"/>, <see cref="ICreateRequest{TDocument}"/>).
+	/// <para>
+	/// These requests do not serialize themselves against their interface contract; instead the body
+	/// is the document written by <see cref="IProxyRequest.WriteJson"/> using the configured
+	/// <see cref="IConnectionSettingsValues.SourceSerializer"/>. This replaces the Utf8Json-based
+	/// <c>ProxyRequestFormatterBase</c>.
+	/// </para>
+	/// </summary>
+	internal sealed class ProxyRequestConverterFactory : JsonConverterFactory
+	{
+		// Instance-level cache: the converter captures this factory's settings, so it must not be
+		// shared across factories built for different IConnectionSettingsValues (e.g. clients with a
+		// custom source serializer). A static cache would leak the first settings to all clients.
+		private readonly ConcurrentDictionary<Type, JsonConverter> _converterCache = new();
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public ProxyRequestConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(IProxyRequest).IsAssignableFrom(typeToConvert);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			_converterCache.GetOrAdd(typeToConvert, type =>
+			{
+				var converterType = typeof(ProxyRequestConverter<>).MakeGenericType(type);
+				return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+			});
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> that writes a proxy request's body by delegating to
+	/// <see cref="IProxyRequest.WriteJson"/> using the source serializer.
+	/// </summary>
+	internal sealed class ProxyRequestConverter<T> : JsonConverter<T>
+		where T : class, IProxyRequest
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public ProxyRequestConverter(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			// Deserializing proxy requests is uncommon. Buffer the JSON, deserialize the document type
+			// via the source serializer, and construct the request around it.
+			var requestType = ResolveConcreteRequestType(typeToConvert);
+			if (requestType == null || !requestType.IsGenericType)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var documentType = requestType.GetGenericArguments()[0];
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			using var ms = _settings.MemoryStreamFactory.Create();
+			using (var writer = new Utf8JsonWriter(ms))
+			{
+				doc.WriteTo(writer);
+				writer.Flush();
+			}
+			ms.Position = 0;
+			var document = _settings.SourceSerializer.Deserialize(documentType, ms);
+
+			var request = requestType.IsGenericTypeDefinition
+				? requestType.CreateGenericInstance(documentType, document, null, null)
+				: requestType.CreateInstance(document, null, null);
+
+			return (T)request;
+		}
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// The document body is always written compact, matching the Utf8Json ProxyRequestFormatter
+			// which wrote it via WriteRaw with SerializationFormatting.None regardless of the request-level
+			// formatting (PrettyJson only indents the enclosing request, never the source document).
+			using var ms = _settings.MemoryStreamFactory.Create();
+			value.WriteJson(_settings.SourceSerializer, ms, SerializationFormatting.None);
+			ms.Position = 0;
+
+			if (ms.Length == 0)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Write the pre-serialized bytes verbatim so the compact document is not re-indented by an
+			// indented writer (WriteTo would re-format using the writer's options).
+			writer.WriteRawValue(ms.ToArray(), skipInputValidation: false);
+		}
+
+		private static Type ResolveConcreteRequestType(Type typeToConvert)
+		{
+			// If the target is an interface (e.g. IIndexRequest<TDocument>), map to the concrete
+			// request type (IndexRequest<TDocument>) living in the same namespace.
+			if (!typeToConvert.IsInterface)
+				return typeToConvert;
+
+			if (!typeToConvert.IsGenericType)
+				return null;
+
+			var ifaceName = typeToConvert.Name; // e.g. IIndexRequest`1
+			if (ifaceName.StartsWith("I", StringComparison.Ordinal))
+			{
+				var concreteName = typeToConvert.Namespace + "." + ifaceName.Substring(1);
+				var concrete = typeToConvert.Assembly.GetType(concreteName);
+				if (concrete != null && concrete.IsGenericTypeDefinition)
+					return concrete.MakeGenericType(typeToConvert.GetGenericArguments());
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ReadAsConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ReadAsConverterFactory.cs
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> that implements the equivalent of Utf8Json's
+	/// <c>[InterfaceDataContract]</c> + <c>[ReadAs(typeof(ConcreteType))]</c> pattern.
+	/// When a type (typically an interface) has a <see cref="ReadAsAttribute"/>, this factory
+	/// creates a converter that deserializes JSON into the specified concrete implementation type
+	/// and serializes using the actual runtime type.
+	/// </summary>
+	internal sealed class ReadAsConverterFactory : JsonConverterFactory
+	{
+		private static readonly ConcurrentDictionary<Type, JsonConverter> ConverterCache = new();
+
+		/// <inheritdoc />
+		public override bool CanConvert(Type typeToConvert)
+		{
+			var readAsAttribute = typeToConvert.GetCustomAttribute<ReadAsAttribute>();
+			if (readAsAttribute == null)
+				return false;
+
+			// A type may carry both [ReadAs] (for the Utf8Json engine) and an explicit [JsonConverter]
+			// (for System.Text.Json) — e.g. IBoolQuery. When an explicit STJ converter is present it must
+			// win here, otherwise this factory would shadow it and change STJ output.
+			var jsonConverterAttribute = typeToConvert.GetCustomAttribute<JsonConverterAttribute>();
+			return jsonConverterAttribute == null;
+		}
+
+		/// <inheritdoc />
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			return ConverterCache.GetOrAdd(typeToConvert, type =>
+			{
+				var readAsAttribute = type.GetCustomAttribute<ReadAsAttribute>();
+				if (readAsAttribute == null)
+					throw new InvalidOperationException(
+						$"Type {type.FullName} does not have a {nameof(ReadAsAttribute)}.");
+
+				Type concreteType;
+				if (readAsAttribute.Type.IsGenericType && !readAsAttribute.Type.IsConstructedGenericType)
+				{
+					// Handle open generic types: e.g., [ReadAs(typeof(HasChildQueryDescriptor<>))]
+					// Construct the generic type using the interface's own type arguments
+					concreteType = readAsAttribute.Type.MakeGenericType(type.GenericTypeArguments);
+				}
+				else
+				{
+					concreteType = readAsAttribute.Type;
+				}
+
+				var converterType = typeof(ReadAsConverter<,>).MakeGenericType(type, concreteType);
+				return (JsonConverter)Activator.CreateInstance(converterType);
+			});
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> that deserializes JSON as a concrete type <typeparamref name="TConcrete"/>
+	/// but exposes it as the interface/abstract type <typeparamref name="TInterface"/>.
+	/// This replaces the Utf8Json <c>ReadAsFormatter&lt;TRead, T&gt;</c>.
+	/// </summary>
+	/// <typeparam name="TInterface">The interface or abstract type requested for deserialization.</typeparam>
+	/// <typeparam name="TConcrete">The concrete implementation type to deserialize into.</typeparam>
+	internal sealed class ReadAsConverter<TInterface, TConcrete> : JsonConverter<TInterface>
+		where TConcrete : TInterface
+	{
+		public override TInterface Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			// Deserialize as the concrete implementation type
+			return JsonSerializer.Deserialize<TConcrete>(ref reader, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, TInterface value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Serialize using the actual runtime type to ensure all properties are written
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ReadOnlyDictionaryConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ReadOnlyDictionaryConverterFactory.cs
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes dictionary types that System.Text.Json cannot construct on its own — those without
+	/// a public parameterless constructor, such as <see cref="System.Collections.ObjectModel.ReadOnlyDictionary{TKey,TValue}"/>
+	/// and custom <c>IReadOnlyDictionary&lt;,&gt;</c>/<c>IDictionary&lt;,&gt;</c> implementations that only
+	/// expose a single <c>IDictionary&lt;,&gt;</c>-accepting constructor. STJ's built-in dictionary
+	/// converter handles serialization fine but throws on deserialization for these; the legacy JsonNet
+	/// source serializer supported them, so this factory restores that behavior on the source path.
+	/// </summary>
+	internal sealed class ReadOnlyDictionaryConverterFactory : JsonConverterFactory
+	{
+		public override bool CanConvert(Type typeToConvert)
+		{
+			// The concrete type need not itself be generic — a non-generic class that implements a
+			// generic dictionary interface (e.g. class Foo : IReadOnlyDictionary<object, object>) also
+			// qualifies. Only reject interfaces/abstract types, which cannot be instantiated at all.
+			if (typeToConvert.IsInterface || typeToConvert.IsAbstract)
+				return false;
+
+			var args = GetDictionaryArguments(typeToConvert);
+			if (args == null)
+				return false;
+
+			// Only claim types STJ cannot construct itself (no public parameterless ctor) but which
+			// DO expose a single-parameter constructor accepting an IDictionary<,> / IReadOnlyDictionary<,>.
+			if (typeToConvert.GetConstructor(Type.EmptyTypes) != null)
+				return false;
+
+			return FindDictionaryConstructor(typeToConvert, args) != null;
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var args = GetDictionaryArguments(typeToConvert);
+			var converterType = typeof(ReadOnlyDictionaryConverter<,,>).MakeGenericType(args[0], args[1], typeToConvert);
+			return (JsonConverter)Activator.CreateInstance(converterType);
+		}
+
+		internal static Type[] GetDictionaryArguments(Type type)
+		{
+			foreach (var iface in type.GetInterfaces())
+			{
+				if (!iface.IsGenericType)
+					continue;
+				var def = iface.GetGenericTypeDefinition();
+				if (def == typeof(IDictionary<,>) || def == typeof(IReadOnlyDictionary<,>))
+					return iface.GetGenericArguments();
+			}
+			return null;
+		}
+
+		internal static ConstructorInfo FindDictionaryConstructor(Type type, Type[] args)
+		{
+			var dict = typeof(IDictionary<,>).MakeGenericType(args);
+			var readOnly = typeof(IReadOnlyDictionary<,>).MakeGenericType(args);
+			return type.GetConstructors()
+				.FirstOrDefault(c =>
+				{
+					var ps = c.GetParameters();
+					return ps.Length == 1
+						&& (ps[0].ParameterType.IsAssignableFrom(dict) || ps[0].ParameterType.IsAssignableFrom(readOnly));
+				});
+		}
+	}
+
+	internal sealed class ReadOnlyDictionaryConverter<TKey, TValue, TDictionary> : JsonConverter<TDictionary>
+		where TDictionary : class
+	{
+		public override TDictionary Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var backing = JsonSerializer.Deserialize<Dictionary<TKey, TValue>>(ref reader, options)
+				?? new Dictionary<TKey, TValue>();
+
+			var args = ReadOnlyDictionaryConverterFactory.GetDictionaryArguments(typeToConvert);
+			var ctor = ReadOnlyDictionaryConverterFactory.FindDictionaryConstructor(typeToConvert, args);
+			return (TDictionary)ctor.Invoke(new object[] { backing });
+		}
+
+		public override void Write(Utf8JsonWriter writer, TDictionary value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			foreach (var kvp in (IEnumerable<KeyValuePair<TKey, TValue>>)value)
+			{
+				writer.WritePropertyName(kvp.Key?.ToString() ?? string.Empty);
+				JsonSerializer.Serialize(writer, kvp.Value, options);
+			}
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ResolvableDictionaryProxyConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ResolvableDictionaryProxyConverterFactory.cs
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Handles deserialization of concrete subclasses of <see cref="ResolvableDictionaryProxy{TKey,TValue}"/>
+	/// (e.g. <c>FieldCapabilitiesFields</c>, <c>IndicesStatsDictionary</c>). These types require
+	/// <see cref="IConnectionConfigurationValues"/> in their constructors, so STJ cannot instantiate
+	/// them directly. This factory reads the JSON object into a <c>Dictionary&lt;TKey, TValue&gt;</c>
+	/// and invokes the appropriate constructor.
+	/// </summary>
+	internal sealed class ResolvableDictionaryProxyConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public ResolvableDictionaryProxyConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			!typeToConvert.IsAbstract && !typeToConvert.IsInterface && GetProxyArguments(typeToConvert) != null;
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var args = GetProxyArguments(typeToConvert);
+			var converterType = typeof(ResolvableDictionaryProxyConverter<,,>).MakeGenericType(typeToConvert, args[0], args[1]);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+
+		/// <summary>
+		/// Returns the [TKey, TValue] type arguments if <paramref name="type"/> derives from
+		/// <see cref="ResolvableDictionaryProxy{TKey,TValue}"/>, otherwise null.
+		/// </summary>
+		private static Type[] GetProxyArguments(Type type)
+		{
+			var current = type.BaseType;
+			while (current != null && current != typeof(object))
+			{
+				if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(ResolvableDictionaryProxy<,>))
+					return current.GetGenericArguments();
+				current = current.BaseType;
+			}
+			return null;
+		}
+	}
+
+	internal sealed class ResolvableDictionaryProxyConverter<TProxy, TKey, TValue> : JsonConverter<TProxy>
+		where TProxy : ResolvableDictionaryProxy<TKey, TValue>
+		where TKey : IUrlParameter
+	{
+		private readonly IConnectionSettingsValues _settings;
+		private readonly ConstructorInfo _ctor;
+
+		public ResolvableDictionaryProxyConverter(IConnectionSettingsValues settings)
+		{
+			_settings = settings;
+
+			// Find the constructor that takes (IConnectionConfigurationValues, IReadOnlyDictionary<TKey, TValue>)
+			_ctor = typeof(TProxy).GetConstructor(
+				BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+				binder: null,
+				new[] { typeof(IConnectionConfigurationValues), typeof(IReadOnlyDictionary<TKey, TValue>) },
+				modifiers: null);
+
+			if (_ctor == null)
+				throw new InvalidOperationException(
+					$"Type {typeof(TProxy).FullName} does not have a constructor accepting " +
+					$"(IConnectionConfigurationValues, IReadOnlyDictionary<{typeof(TKey).Name}, {typeof(TValue).Name}>).");
+		}
+
+		public override TProxy Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+			var dict = new Dictionary<TKey, TValue>();
+
+			reader.Read();
+			while (reader.TokenType != JsonTokenType.EndObject)
+			{
+				var key = ReadKey(reader.GetString());
+				reader.Read();
+				var value = JsonSerializer.Deserialize<TValue>(ref reader, options);
+				dict[key] = value;
+				reader.Read();
+			}
+
+			return (TProxy)_ctor.Invoke(new object[] { _settings, (IReadOnlyDictionary<TKey, TValue>)dict });
+		}
+
+		public override void Write(Utf8JsonWriter writer, TProxy value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			foreach (var kvp in (IEnumerable<KeyValuePair<TKey, TValue>>)value)
+			{
+				var keyString = kvp.Key?.GetString(_settings);
+				if (keyString == null) continue;
+				writer.WritePropertyName(keyString);
+				JsonSerializer.Serialize(writer, kvp.Value, options);
+			}
+			writer.WriteEndObject();
+		}
+
+		private static TKey ReadKey(string keyString)
+		{
+			if (typeof(TKey) == typeof(string))
+				return (TKey)(object)keyString;
+			if (typeof(TKey) == typeof(IndexName))
+				return (TKey)(object)(IndexName)keyString;
+			if (typeof(TKey) == typeof(Field))
+				return (TKey)(object)(Field)keyString;
+			if (typeof(TKey) == typeof(RelationName))
+				return (TKey)(object)(RelationName)keyString;
+			return (TKey)(object)keyString;
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ResolvableReadOnlyFieldDictionaryConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ResolvableReadOnlyFieldDictionaryConverterFactory.cs
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes response properties typed <see cref="IReadOnlyDictionary{TKey,TValue}"/> with an
+	/// inferrer-resolved key (<see cref="Field"/>, <see cref="IndexName"/>, <see cref="RelationName"/>) into
+	/// a settings-aware <see cref="ResolvableDictionaryProxy{TKey,TValue}"/>. Examples:
+	/// <c>TermVectorsResult.TermVectors</c>, <c>TypeFieldMappings.Mappings</c> (Field);
+	/// <c>ClusterHealthResponse.Indices</c> (IndexName).
+	/// <para>
+	/// The proxy stores keys as their inferrer-resolved wire strings and resolves lookups the same way, so an
+	/// expression-path <see cref="Field"/> or an inferred <see cref="IndexName"/> matches the deserialized
+	/// string-based key. Restores the pre-STJ <c>ResolvableReadOnlyDictionaryFormatter&lt;TKey, T&gt;</c>
+	/// behavior; without it these dictionaries deserialize into plain typed-key maps whose keys never compare
+	/// equal to an inferred key, so lookups miss (<see cref="KeyNotFoundException"/> or an empty result).
+	/// </para>
+	/// </summary>
+	internal sealed class ResolvableReadOnlyFieldDictionaryConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public ResolvableReadOnlyFieldDictionaryConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert)
+		{
+			if (!typeToConvert.IsGenericType) return false;
+			if (typeToConvert.GetGenericTypeDefinition() != typeof(IReadOnlyDictionary<,>)) return false;
+			var keyType = typeToConvert.GetGenericArguments()[0];
+			return keyType == typeof(Field) || keyType == typeof(IndexName) || keyType == typeof(RelationName);
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var args = typeToConvert.GetGenericArguments();
+			var converterType = typeof(ResolvableReadOnlyDictionaryConverter<,>).MakeGenericType(args[0], args[1]);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+	}
+
+	internal sealed class ResolvableReadOnlyDictionaryConverter<TKey, TValue> : JsonConverter<IReadOnlyDictionary<TKey, TValue>>
+		where TKey : IUrlParameter
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public ResolvableReadOnlyDictionaryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IReadOnlyDictionary<TKey, TValue> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return new ResolvableDictionaryProxy<TKey, TValue>(_settings, new Dictionary<TKey, TValue>());
+			}
+
+			var dict = new Dictionary<TKey, TValue>();
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var key = ConvertKey(reader.GetString());
+				reader.Read();
+				dict[key] = JsonSerializer.Deserialize<TValue>(ref reader, options);
+			}
+
+			return new ResolvableDictionaryProxy<TKey, TValue>(_settings, dict);
+		}
+
+		public override void Write(Utf8JsonWriter writer, IReadOnlyDictionary<TKey, TValue> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			foreach (var kvp in value)
+			{
+				var keyString = (kvp.Key as IUrlParameter)?.GetString(_settings);
+				if (keyString == null) continue;
+				writer.WritePropertyName(keyString);
+				JsonSerializer.Serialize(writer, kvp.Value, options);
+			}
+			writer.WriteEndObject();
+		}
+
+		private static TKey ConvertKey(string key)
+		{
+			if (typeof(TKey) == typeof(Field))
+				return (TKey)(object)(Field)key;
+			if (typeof(TKey) == typeof(IndexName))
+				return (TKey)(object)(IndexName)key;
+			if (typeof(TKey) == typeof(RelationName))
+				return (TKey)(object)(RelationName)key;
+			return (TKey)(object)key;
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceConverterFactory.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceConverterFactory.cs
@@ -1,0 +1,457 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using OpenSearch.Net;
+using InterfaceDataContractAttribute = OpenSearch.Net.Utf8Json.InterfaceDataContractAttribute;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> that delegates serialization of user document types
+	/// to the configured <see cref="IConnectionSettingsValues.SourceSerializer"/>.
+	/// This replaces the Utf8Json-based <c>SourceFormatter&lt;T&gt;</c>.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This factory is registered as the lowest-precedence domain converter in
+	/// <see cref="OpenSearchClientSerializerOptions"/>, acting as a catch-all for user document
+	/// types that are not handled by any other registered converter.
+	/// </para>
+	/// <para>
+	/// Fast path: if the source serializer implements <see cref="IInternalSerializer"/> and
+	/// exposes <see cref="JsonSerializerOptions"/>, the converter delegates directly to the
+	/// <see cref="Utf8JsonReader"/>/<see cref="Utf8JsonWriter"/> without buffering.
+	/// </para>
+	/// <para>
+	/// Slow path: if the source serializer is an opaque <see cref="IOpenSearchSerializer"/>,
+	/// JSON is buffered to a stream and passed to the serializer's stream-based methods.
+	/// </para>
+	/// </remarks>
+	internal sealed class SourceConverterFactory : JsonConverterFactory
+	{
+		// Instance-level cache: SourceConverter<T> captures this factory's settings (and therefore its
+		// SourceSerializer). A static cache would leak the first client's settings to every other client,
+		// e.g. a client configured with a custom source serializer would reuse the default serializer.
+		private readonly ConcurrentDictionary<Type, JsonConverter> _converterCache = new();
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public SourceConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		/// <summary>The connection settings (and thus the configured SourceSerializer) this factory is bound to.</summary>
+		internal IConnectionSettingsValues Settings => _settings;
+
+		/// <inheritdoc />
+		/// <remarks>
+		/// Returns <c>true</c> for types that should be serialized by the SourceSerializer.
+		/// This includes types NOT defined in the OpenSearch.Net or OpenSearch.Client assemblies,
+		/// effectively acting as a catch-all for user document types (e.g., the generic <c>T</c>
+		/// in <c>SearchResponse&lt;T&gt;</c>).
+		/// </remarks>
+		public override bool CanConvert(Type typeToConvert) => IsSourceDocumentType(typeToConvert);
+
+		/// <summary>
+		/// Whether <paramref name="typeToConvert"/> is a user document type that should be serialized by
+		/// the SourceSerializer rather than the high-level domain machinery. Exposed statically so the
+		/// high-level serializer can recognize a bare top-level document and route it through the
+		/// inference-aware terminal source options (matching the pre-STJ behavior, where a document
+		/// serialized at the JSON root honored OSC field-name inference rather than a distinct source
+		/// serializer's own naming — the source serializer only applied to nested <c>_source</c> members).
+		/// </summary>
+		internal static bool IsSourceDocumentType(Type typeToConvert)
+		{
+			if (typeToConvert == null) return false;
+
+			// System.Object must be handled by STJ's runtime-type dispatch, never by the
+			// source serializer. Capturing it here causes infinite recursion when the JsonNet
+			// source serializer round-trips a nested OpenSearch type back through the built-in
+			// serializer as object (HandleOscTypesOnSourceJsonConverter -> builtin -> SourceConverter<object>).
+			if (typeToConvert == typeof(object))
+				return false;
+
+			// Primitive types and common BCL types are handled by STJ natively
+			if (typeToConvert.IsPrimitive || typeToConvert == typeof(string) || typeToConvert == typeof(decimal)
+				|| typeToConvert == typeof(DateTime) || typeToConvert == typeof(DateTimeOffset)
+				|| typeToConvert == typeof(Guid) || typeToConvert == typeof(Uri)
+				|| typeToConvert == typeof(byte[]))
+				return false;
+
+			// Nullable primitives
+			var underlying = Nullable.GetUnderlyingType(typeToConvert);
+			if (underlying != null && (underlying.IsPrimitive || underlying == typeof(decimal)
+				|| underlying == typeof(DateTime) || underlying == typeof(DateTimeOffset)
+				|| underlying == typeof(Guid)))
+				return false;
+
+			// Types from the OpenSearch framework assemblies are NOT source types
+			var assembly = typeToConvert.Assembly;
+			var assemblyName = assembly.GetName().Name;
+			if (assemblyName != null &&
+				(assemblyName.StartsWith("OpenSearch.Net", StringComparison.Ordinal) ||
+				 assemblyName.StartsWith("OpenSearch.Client", StringComparison.Ordinal)))
+				return false;
+
+			// Custom (user-assembly) implementations of an OpenSearch domain contract interface
+			// (e.g. a plugin IProperty) are domain types, not source documents. They must be handled
+			// by the high-level contract machinery, not delegated to the source serializer.
+			foreach (var iface in typeToConvert.GetInterfaces())
+			{
+				var ifaceAssembly = iface.Assembly.GetName().Name;
+				if (ifaceAssembly != null &&
+					(ifaceAssembly.StartsWith("OpenSearch.Net", StringComparison.Ordinal) ||
+					 ifaceAssembly.StartsWith("OpenSearch.Client", StringComparison.Ordinal)) &&
+					Attribute.IsDefined(iface, typeof(InterfaceDataContractAttribute)))
+					return false;
+			}
+
+			// Generic collection types (IList<T>, IDictionary<K,V>, etc.) whose element types
+			// are NOT user document types are handled by STJ's built-in collection handling,
+			// with element converters resolved from the options. This covers both OpenSearch
+			// domain collections (e.g. IList<IProperty>) and dynamic collections keyed/valued by
+			// simple framework types such as Dictionary<string, object> (e.g. script params).
+			// Delegating the latter to the SourceSerializer would drop the registered element
+			// converters (e.g. the fractional-number converter that emits 1.0 rather than 1).
+			if (typeToConvert.IsGenericType)
+			{
+				var args = typeToConvert.GetGenericArguments();
+				if (args.Length > 0 && AllNonUserTypes(args) && IsStjConstructible(typeToConvert))
+					return false;
+			}
+
+			// Everything else is a user document type that should be delegated to the SourceSerializer
+			return true;
+		}
+
+		/// <summary>
+		/// Whether STJ can construct <paramref name="type"/> on deserialize. Interfaces and arrays
+		/// map to STJ's default concrete collection; concrete types need a public parameterless
+		/// constructor. Types that are not STJ-constructible (e.g. <c>ReadOnlyDictionary&lt;,&gt;</c>)
+		/// must still be delegated to the source serializer so round-tripping keeps working.
+		/// </summary>
+		private static bool IsStjConstructible(Type type)
+		{
+			if (type.IsInterface || type.IsArray)
+				return true;
+			return type.GetConstructor(Type.EmptyTypes) != null;
+		}
+
+		private static bool AllNonUserTypes(Type[] types)
+		{
+			foreach (var t in types)
+			{
+				if (!IsNonUserType(t))
+					return false;
+			}
+			return true;
+		}
+
+		private static bool IsNonUserType(Type t)
+		{
+			// System.Object and simple BCL types are handled natively by STJ (with the
+			// registered ObjectConverter / fractional-number converters for object values).
+			if (t == typeof(object) || t == typeof(string) || t.IsPrimitive || t == typeof(decimal)
+				|| t == typeof(DateTime) || t == typeof(DateTimeOffset) || t == typeof(Guid))
+				return true;
+
+			var underlying = Nullable.GetUnderlyingType(t);
+			if (underlying != null)
+				return IsNonUserType(underlying);
+
+			// Unwrap nested generic collections (e.g. IList<ISuggestContextQuery> nested inside a
+			// IDictionary<string, IList<...>>) so a domain collection of domain types is still
+			// recognised as a non-user type and handled by STJ's built-in collection processing.
+			if (t.IsGenericType)
+			{
+				var innerArgs = t.GetGenericArguments();
+				if (innerArgs.Length > 0 && AllNonUserTypes(innerArgs))
+					return true;
+			}
+
+			// Types from the OpenSearch framework assemblies are domain types, not user documents.
+			var name = t.Assembly.GetName().Name;
+			return name != null
+				&& (name.StartsWith("OpenSearch.Net", StringComparison.Ordinal)
+					|| name.StartsWith("OpenSearch.Client", StringComparison.Ordinal));
+		}
+
+		/// <inheritdoc />
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			return _converterCache.GetOrAdd(typeToConvert, type =>
+			{
+				var converterType = typeof(SourceConverter<>).MakeGenericType(type);
+				return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+			});
+		}
+
+		/// <summary>
+		/// Creates a <see cref="SourceConverter{T}"/> for <paramref name="typeToConvert"/> that delegates
+		/// to the SourceSerializer, bypassing the <see cref="CanConvert"/> exclusions. Used to pin a
+		/// source converter onto contract properties marked <see cref="SourceSerializationAttribute"/>
+		/// (e.g. an <see cref="object"/>-typed embedded document payload).
+		/// </summary>
+		internal JsonConverter CreateSourceConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			// Do NOT use the shared static ConverterCache here: that cache is keyed only by type,
+			// but each SourceConverter<T> is bound to this factory's settings (and its SourceSerializer).
+			// This path is the sole creator of SourceConverter<object>, so caching it statically would
+			// leak one settings instance's converter into other settings instances.
+			var converterType = typeof(SourceConverter<>).MakeGenericType(typeToConvert);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+	}
+
+	/// <summary>
+	/// Non-generic marker for <see cref="SourceConverter{T}"/> so callers can detect that the domain
+	/// options resolve a given type to the source-delegating converter without knowing its type argument.
+	/// </summary>
+	internal interface ISourceConverter { }
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> that delegates serialization/deserialization of user
+	/// document type <typeparamref name="T"/> to the configured SourceSerializer.
+	/// </summary>
+	/// <typeparam name="T">The user document type being serialized or deserialized.</typeparam>
+	internal sealed class SourceConverter<T> : JsonConverter<T>, ISourceConverter
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public SourceConverter(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		/// <inheritdoc />
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			// Fast path: if source serializer is STJ-based, delegate directly
+			if (_settings.SourceSerializer is IInternalSerializer s
+				&& s.TryGetJsonSerializerOptions(out var sourceOptions))
+			{
+				// When the source serializer IS the high-level serializer (no distinct source
+				// serializer configured), delegating back to the same options would re-enter this
+				// converter and recurse infinitely. Use the terminal source options — a POCO-oriented
+				// clone that honors OSC property naming but does NOT apply the high-level domain
+				// converters (Field->string, EnumMember->string, etc.), matching how a plain user
+				// document round-trips through a distinct source serializer.
+				if (ReferenceEquals(sourceOptions, options))
+					return JsonSerializer.Deserialize<T>(ref reader, SourceConverterHelper.GetDefaultSourceOptions(_settings));
+				return JsonSerializer.Deserialize<T>(ref reader, sourceOptions);
+			}
+
+			// Slow path: buffer JSON to a stream, then pass to the source serializer
+			using var doc = JsonDocument.ParseValue(ref reader);
+			using var ms = _settings.MemoryStreamFactory.Create();
+			using (var writer = new Utf8JsonWriter(ms))
+			{
+				doc.WriteTo(writer);
+				writer.Flush();
+			}
+			ms.Position = 0;
+			return _settings.SourceSerializer.Deserialize<T>(ms);
+		}
+
+		/// <inheritdoc />
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			// Fast path: if source serializer is STJ-based, delegate directly
+			if (_settings.SourceSerializer is IInternalSerializer s
+				&& s.TryGetJsonSerializerOptions(out var sourceOptions))
+			{
+				if (ReferenceEquals(sourceOptions, options))
+					JsonSerializer.Serialize(writer, value, SourceConverterHelper.GetDefaultSourceOptions(_settings));
+				else
+					JsonSerializer.Serialize(writer, value, sourceOptions);
+				return;
+			}
+
+			// Slow path: serialize to buffer stream, then write raw JSON to the writer
+			using var ms = _settings.MemoryStreamFactory.Create();
+			_settings.SourceSerializer.Serialize(value, ms, SerializationFormatting.None);
+			ms.Position = 0;
+			using var doc = JsonDocument.Parse(ms);
+			doc.RootElement.WriteTo(writer);
+		}
+	}
+
+	internal static class SourceConverterHelper
+	{
+		internal static readonly JsonSerializerOptions DefaultOptions = new(JsonSerializerDefaults.Web)
+		{
+			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+		};
+
+		// Cache of "self source" options (a clone of the high-level options without the
+		// SourceConverterFactory), keyed by the original options instance. Used when the source
+		// serializer is the high-level serializer itself, to avoid infinite recursion while still
+		// applying the full domain converter set to an embedded OpenSearch payload.
+		private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<JsonSerializerOptions, JsonSerializerOptions>
+			SelfSourceOptionsCache = new();
+
+		internal static JsonSerializerOptions GetSelfSourceOptions(JsonSerializerOptions options) =>
+			SelfSourceOptionsCache.GetValue(options, static o =>
+			{
+				var clone = new JsonSerializerOptions(o);
+				for (var i = clone.Converters.Count - 1; i >= 0; i--)
+				{
+					if (clone.Converters[i] is SourceConverterFactory)
+						clone.Converters.RemoveAt(i);
+				}
+				return clone;
+			});
+		// Per-settings options used by the built-in high-level source serializer to (de)serialize user
+		// document types. These honor OpenSearch.Client property-name inference (PropertyName/Text(Name)
+		// attributes, DataMember, DefaultMappingFor, DefaultFieldNameInferrer) via a settings-aware
+		// contract modifier, but do NOT register SourceConverterFactory (which would recurse) — they are
+		// the terminal serializer for POCO graphs.
+		private static readonly System.Collections.Concurrent.ConcurrentDictionary<IConnectionSettingsValues, JsonSerializerOptions>
+			SourceOptionsCache = new();
+
+		internal static JsonSerializerOptions GetDefaultSourceOptions(IConnectionSettingsValues settings) =>
+			SourceOptionsCache.GetOrAdd(settings, static s =>
+			{
+				var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+				{
+					DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+					PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+					// Match the base serializer's minimal escaping (only JSON-required characters +
+					// U+0085/U+2028/U+2029), matching the historical Utf8Json wire behavior, rather than
+					// STJ's default encoder that escapes U+007F and all non-allow-listed code points.
+					Encoder = OpenSearch.Net.MinimalJsonEscapingEncoder.Shared,
+					TypeInfoResolver = new DefaultJsonTypeInfoResolver
+					{
+						Modifiers =
+						{
+							DataMemberPropertyNameModifier.Modify,
+							new SourcePropertyNameModifier(s).Modify
+						}
+					}
+				};
+				// ObjectConverter so object-typed values deserialize to .NET primitives (not JsonElement)
+				// and, crucially, object-keyed dictionaries (IDictionary<object, object>) can (de)serialize
+				// their keys — STJ's built-in object converter has no property-name support and throws.
+				options.Converters.Add(new OpenSearch.Net.ObjectConverter());
+
+				// Fractional-number converters so whole-valued doubles/floats/decimals keep their
+				// trailing ".0" (e.g. 1.0 rather than 1) on the terminal source path, matching the
+				// base low-level serializer (OpenSearchNetSerializerOptions) behavior.
+				options.Converters.Add(new OpenSearch.Net.DoubleConverter());
+				options.Converters.Add(new OpenSearch.Net.SingleConverter());
+				options.Converters.Add(new OpenSearch.Net.DecimalConverter());
+
+				// ISO-8601 date converters so flexible offset / fractional-second date strings on user
+				// documents round-trip (STJ's built-in DateTime/DateTimeOffset readers are stricter).
+				options.Converters.Add(new OpenSearch.Net.IsoDateTimeConverter());
+				options.Converters.Add(new OpenSearch.Net.IsoDateTimeOffsetConverter());
+				// TimeSpan serialized as ticks (a long) on user documents, matching the wire format.
+				options.Converters.Add(new OpenSearch.Net.TimeSpanTicksConverter());
+				options.Converters.Add(new OpenSearch.Net.NullableTimeSpanTicksConverter());
+
+				// Read-only / non-parameterless dictionary types (ReadOnlyDictionary<,> and custom
+				// IReadOnlyDictionary/IDictionary implementations) that STJ cannot construct on read.
+				options.Converters.Add(new ReadOnlyDictionaryConverterFactory());
+
+				// Union<,> support so user-document properties typed as a domain union (e.g.
+				// Union<bool, ISourceFilter>) round-trip on the terminal source path. Union members that
+				// are OpenSearch types resolve via their own attribute-channel converters.
+				options.Converters.Add(new UnionConverterFactory());
+
+				// ValueTuple support: STJ does not serialize a value tuple's public Item1..ItemN fields
+				// unless IncludeFields is enabled, so a tuple-typed document property would otherwise be
+				// written as an empty object. This converter emits the Item fields verbatim.
+				options.Converters.Add(new ValueTupleConverter());
+
+				// OpenSearch.Client value types that can appear as fields on user documents and need
+				// settings-aware serialization even on the terminal source path.
+				options.Converters.Add(new JoinFieldConverter(s));
+
+				// Id support so a JoinField child's parent id (and any Id-typed user-document property)
+				// (de)serializes on the terminal source path. JoinFieldConverter.Read resolves the child
+				// "parent" via JsonSerializer.Deserialize<Id>, which otherwise falls through to STJ's
+				// default object converter and throws ("cannot convert to OpenSearch.Client.Id").
+				options.Converters.Add(new IdConverterFactory(s));
+
+				// Settings-aware Field converter so a Field-typed property (or a Fields collection, whose
+				// FieldsConverter resolves each element via options.GetConverter(typeof(Field))) reachable
+				// from a user type (e.g. SourceFilter.Includes on a Union<bool, ISourceFilter> document
+				// property) serializes to its resolved field-name string rather than a Field POCO object.
+				options.Converters.Add(new FieldConverterFactory(s));
+
+				// OpenSearch.Client domain types (QueryContainer, mappings, aggregations, etc.) that appear as
+				// members of a user document must serialize through the full high-level domain machinery, not
+				// the POCO-oriented terminal options — otherwise e.g. a percolator query stored on
+				// ProjectPercolation.Query would emit an empty object (QueryContainer exposes only explicit
+				// interface members) and its inner query bodies would lose their field-name-query wrapping.
+				// This factory detects such domain-contract types and delegates them to the domain options.
+				options.Converters.Add(new EmbeddedDomainTypeConverterFactory(s));
+				return options;
+			});
+	}
+
+	/// <summary>
+	/// A <see cref="DefaultJsonTypeInfoResolver"/> modifier that resolves JSON property names for user
+	/// document types using the OpenSearch.Client <see cref="Inferrer"/>, so that the built-in source
+	/// serializer honors <c>[PropertyName]</c>/<c>[Text(Name=...)]</c> attributes,
+	/// <c>DefaultMappingFor&lt;T&gt;</c> property mappings, and the <c>DefaultFieldNameInferrer</c>.
+    /// Only applied to non-OpenSearch (user) types; framework types keep their existing contracts.
+	/// </summary>
+	internal sealed class SourcePropertyNameModifier
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public SourcePropertyNameModifier(IConnectionSettingsValues settings) => _settings = settings;
+
+		public void Modify(System.Text.Json.Serialization.Metadata.JsonTypeInfo typeInfo)
+		{
+			if (typeInfo.Kind != System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Object)
+				return;
+
+			var assemblyName = typeInfo.Type.Assembly.GetName().Name;
+			if (assemblyName != null &&
+				(assemblyName.StartsWith("OpenSearch.Net", StringComparison.Ordinal) ||
+				 assemblyName.StartsWith("OpenSearch.Client", StringComparison.Ordinal)))
+				return;
+
+			for (var i = typeInfo.Properties.Count - 1; i >= 0; i--)
+			{
+				var property = typeInfo.Properties[i];
+				if (property.AttributeProvider is not System.Reflection.PropertyInfo propInfo)
+					continue;
+
+				// Mirror the Utf8Json resolver's GetMapping precedence:
+				//   PropertyMappings (DefaultMappingFor) > OSC property attribute > source PropertyMappingProvider.
+				if (!_settings.PropertyMappings.TryGetValue(propInfo, out var propertyMapping))
+					propertyMapping = OpenSearchPropertyAttributeBase.From(propInfo);
+
+				var serializerMapping = _settings.PropertyMappingProvider?.CreatePropertyMapping(propInfo);
+
+				var overrideIgnore = propertyMapping?.Ignore ?? serializerMapping?.Ignore;
+				if (overrideIgnore == true)
+				{
+					typeInfo.Properties.RemoveAt(i);
+					continue;
+				}
+
+				var nameOverride = propertyMapping?.Name ?? serializerMapping?.Name;
+				if (!string.IsNullOrEmpty(nameOverride))
+				{
+					property.Name = nameOverride;
+					continue;
+				}
+
+				// No explicit override: apply the DefaultFieldNameInferrer to the CLR member name.
+				var inferred = _settings.DefaultFieldNameInferrer(propInfo.Name);
+				if (!string.IsNullOrEmpty(inferred))
+					property.Name = inferred;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceValueWriteConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceValueWriteConverter.cs
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for weakly-typed (<c>object</c>) query/document values that
+	/// must be written through the configured source serializer when the value is a user type
+	/// (e.g. an enum, POCO), but through the built-in high-level converters when the value is an
+	/// OpenSearch.Client type.
+	/// <para>
+	/// This is the System.Text.Json equivalent of the Utf8Json <c>SourceWriteFormatter&lt;T&gt;</c>.
+	/// It is applied via the <see cref="JsonConverterAttribute"/> attribute channel so it takes effect
+	/// even when the value sits on a contract rebuilt by <see cref="InterfaceDataContractModifier"/> or
+	/// nested inside another converter, where options-registered factories are skipped.
+	/// </para>
+	/// <para>
+	/// Serialization dispatches on the runtime type: the <see cref="SourceConverterFactory"/> registered
+	/// on the main options already routes non-OpenSearch types to the source serializer, so serializing
+	/// with the runtime type and the ambient options produces the correct wire format for both the
+	/// default and a custom source serializer.
+	/// </para>
+	/// </summary>
+	internal sealed class SourceValueWriteConverter : JsonConverter<object>
+	{
+		public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			// Read into a loosely-typed representation; term/prefix/etc. values are scalars or arrays.
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.String:
+					return reader.GetString();
+				case JsonTokenType.Number:
+					// Note: avoid the ternary `ok ? l : GetDouble()` — C# unifies both branches to
+					// double, silently boxing integral values as double.
+					if (reader.TryGetInt64(out var l))
+						return l;
+					return reader.GetDouble();
+				case JsonTokenType.True:
+					return true;
+				case JsonTokenType.False:
+					return false;
+				default:
+					using (var doc = JsonDocument.ParseValue(ref reader))
+						return doc.RootElement.Clone();
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/StringBooleanConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/StringBooleanConverter.cs
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes a JSON boolean OR a JSON string (<c>"true"</c>/<c>"false"</c>) into a
+	/// <see cref="Nullable{Boolean}"/>, and serializes it back as a JSON boolean.
+	/// Mirrors the historical (Utf8Json) <c>NullableStringBooleanFormatter</c>: OpenSearch frequently
+	/// returns repository settings booleans (e.g. <c>compress</c>) as strings.
+	/// </summary>
+	internal sealed class NullableStringBooleanConverter : JsonConverter<bool?>
+	{
+		public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.True:
+					return true;
+				case JsonTokenType.False:
+					return false;
+				case JsonTokenType.String:
+					var s = reader.GetString();
+					if (bool.TryParse(s, out var b))
+						return b;
+					throw new JsonException($"Cannot parse {typeof(bool).FullName} from: {s}");
+				default:
+					throw new JsonException($"Cannot parse {typeof(bool).FullName} from: {reader.TokenType}");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				writer.WriteBooleanValue(value.Value);
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ValueTupleConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/JsonFormatters/ValueTupleConverter.cs
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> for <see cref="System.ValueTuple"/> types
+	/// (e.g. <c>(string info, int number)</c>). System.Text.Json does not serialize the public
+	/// <c>Item1</c>..<c>Item8</c> fields of a value tuple unless <c>IncludeFields</c> is enabled,
+	/// so a value-tuple-typed property is otherwise written as an empty object (<c>{}</c>).
+	/// </summary>
+	/// <remarks>
+	/// This converter emits the tuple as a JSON object with the field names <c>Item1</c>,
+	/// <c>Item2</c>, ... exactly as they are declared (they are not run through the naming policy),
+	/// matching the historical Utf8Json wire behavior. This also covers <see cref="Nullable{T}"/>
+	/// value tuples: STJ unwraps the nullable and delegates the non-null value to this converter.
+	/// </remarks>
+	internal sealed class ValueTupleConverter : JsonConverterFactory
+	{
+		private static readonly ConcurrentDictionary<Type, JsonConverter> Cache = new();
+
+		public override bool CanConvert(Type typeToConvert)
+		{
+			if (!typeToConvert.IsValueType || !typeToConvert.IsGenericType)
+				return false;
+
+			var def = typeToConvert.GetGenericTypeDefinition();
+			return def == typeof(ValueTuple<>)
+				|| def == typeof(ValueTuple<,>)
+				|| def == typeof(ValueTuple<,,>)
+				|| def == typeof(ValueTuple<,,,>)
+				|| def == typeof(ValueTuple<,,,,>)
+				|| def == typeof(ValueTuple<,,,,,>)
+				|| def == typeof(ValueTuple<,,,,,,>)
+				|| def == typeof(ValueTuple<,,,,,,,>);
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			Cache.GetOrAdd(typeToConvert, static t =>
+			{
+				var converterType = typeof(ValueTupleConverterInner<>).MakeGenericType(t);
+				return (JsonConverter)Activator.CreateInstance(converterType);
+			});
+
+		private sealed class ValueTupleConverterInner<T> : JsonConverter<T>
+		{
+			// Item1..Item7 (and Rest) in declaration order.
+			private static readonly FieldInfo[] Fields = typeof(T).GetFields(BindingFlags.Instance | BindingFlags.Public);
+
+			public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+			{
+				if (reader.TokenType == JsonTokenType.Null)
+					return default;
+
+				if (reader.TokenType != JsonTokenType.StartObject)
+					throw new JsonException($"Expected StartObject when deserializing {typeof(T)}, found {reader.TokenType}.");
+
+				// Boxing is required because ValueType fields cannot be set on a struct value directly via reflection
+				// without re-boxing; value tuples have no parameterless-settable path otherwise.
+				object boxed = Activator.CreateInstance(typeof(T));
+
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+				{
+					if (reader.TokenType != JsonTokenType.PropertyName)
+						continue;
+
+					var name = reader.GetString();
+					reader.Read();
+
+					var field = Array.Find(Fields, f => string.Equals(f.Name, name, StringComparison.OrdinalIgnoreCase));
+					if (field == null)
+					{
+						reader.Skip();
+						continue;
+					}
+
+					var value = JsonSerializer.Deserialize(ref reader, field.FieldType, options);
+					field.SetValue(boxed, value);
+				}
+
+				return (T)boxed;
+			}
+
+			public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+			{
+				writer.WriteStartObject();
+				foreach (var field in Fields)
+				{
+					writer.WritePropertyName(field.Name);
+					JsonSerializer.Serialize(writer, field.GetValue(value), field.FieldType, options);
+				}
+				writer.WriteEndObject();
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/OpenSearchClientSerializerOptions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/OpenSearchClientSerializerOptions.cs
@@ -116,6 +116,10 @@ namespace OpenSearch.Client
 			// read wholesale into a DynamicDictionary). Replaces the Utf8Json DynamicResponseFormatter<T>.
 			options.Converters.Insert(0, new DynamicResponseConverterFactory(settings));
 
+			// indices_boost dictionary converter (array-of-single-key-objects wire format).
+			// Must precede the generic dictionary handling.
+			options.Converters.Insert(0, new IndicesBoostConverterFactory(settings));
+
 			// Proxy request converter (Index/Create requests whose body is the source document written
 			// via IProxyRequest.WriteJson through the SourceSerializer). Inserted above the source/dictionary
 			// catch-alls so proxy requests never fall through to the interface-contract object handling.
@@ -123,6 +127,11 @@ namespace OpenSearch.Client
 
 			// --- 4. ReadAs converters (interface → implementation mapping) ---
 			options.Converters.Insert(0, new ReadAsConverterFactory());
+
+			// SourceFilter (_source) converter — must precede ReadAsConverterFactory so the
+			// string/array/object shorthand forms deserialize correctly (ReadAs would otherwise
+			// claim ISourceFilter and fail on the non-object shorthand forms).
+			options.Converters.Insert(0, new SourceFilterConverter());
 
 			// --- 1. Explicit singleton converters (highest precedence among domain converters) ---
 
@@ -173,6 +182,10 @@ namespace OpenSearch.Client
 			// Indices (a Union<AllIndicesMarker, ManyIndices>) and emit a nested object.
 			options.Converters.Insert(0, new IndicesConverterFactory(settings));
 
+			// Multi-search NDJSON request converters (header line + body line per operation)
+			options.Converters.Insert(0, new MultiSearchConverterFactory(settings));
+			options.Converters.Insert(0, new MultiSearchTemplateConverterFactory(settings));
+
 			// Query DSL converters
 			options.Converters.Insert(0, new QueryContainerConverter());
 			options.Converters.Insert(0, new QueryContainerConcretConverter());
@@ -207,6 +220,29 @@ namespace OpenSearch.Client
 			options.Converters.Insert(0, new AggregationDictionaryConverter());
 			options.Converters.Insert(0, new AggregateDictionaryResponseConverter());
 			options.Converters.Insert(0, new AggregateConverter());
+
+			// Mapping converters
+			options.Converters.Insert(0, new PropertyConverter());
+
+			// Dynamic templates container (array-of-single-key-objects wire format).
+			// Must precede IsADictionaryConverterFactory, which would otherwise serialize it
+			// as a plain JSON object.
+			options.Converters.Insert(0, new DynamicTemplatesConverter());
+
+			// Sort converter (ISort → { "field": { ...body... } } dispatch)
+			options.Converters.Insert(0, new SortConverter(settings));
+
+			// Ingest pipeline converters
+			options.Converters.Insert(0, new ProcessorConverter());
+
+			// Search response converters
+			options.Converters.Insert(0, new TotalHitsConverter());
+			options.Converters.Insert(0, new InnerHitsMetadataConverter());
+			options.Converters.Insert(0, new InnerHitsResultConverter());
+			options.Converters.Insert(0, new HitConverterFactory());
+			options.Converters.Insert(0, new HitsMetadataConverterFactory());
+			options.Converters.Insert(0, new SuggestDictionaryConverterFactory());
+			options.Converters.Insert(0, new SearchResponseConverterFactory());
 
 			return options;
 		}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/OpenSearchClientSerializerOptions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/OpenSearchClientSerializerOptions.cs
@@ -173,6 +173,41 @@ namespace OpenSearch.Client
 			// Indices (a Union<AllIndicesMarker, ManyIndices>) and emit a nested object.
 			options.Converters.Insert(0, new IndicesConverterFactory(settings));
 
+			// Query DSL converters
+			options.Converters.Insert(0, new QueryContainerConverter());
+			options.Converters.Insert(0, new QueryContainerConcretConverter());
+			options.Converters.Insert(0, new QueryContainerCollectionConverter());
+			options.Converters.Insert(0, new TermsQueryConverter(settings));
+			options.Converters.Insert(0, new RangeQueryConverter(settings));
+
+			// Field-name query wrapping (term, match, prefix, wildcard, fuzzy, regexp, span_term, etc.).
+			// Adds the { "<resolved-field>": { ...body... } } wrapping around concrete field-name queries
+			// that do not already have a dedicated converter. Inserted last so it takes precedence over
+			// the InterfaceDataContractModifier's default object handling for these concrete types.
+			options.Converters.Insert(0, new FieldNameQueryConverterFactory(settings));
+
+			// Fuzzy query converter (polymorphic dispatch string/numeric/date + field-name wrapping).
+			options.Converters.Insert(0, new FuzzyQueryConverter(settings));
+
+			// Score function converter (polymorphic function_score functions: decay, field_value_factor,
+			// random_score, script_score, weight).
+			options.Converters.Insert(0, new ScoreFunctionConverter(settings));
+
+			// Geo query converters (dedicated field-name-wrapping shapes). Inserted after the
+			// field-name query factory so they take precedence for their specific interfaces
+			// (the factory would otherwise claim them and emit the generic { field: { body } } wrapping).
+			options.Converters.Insert(0, new GeoShapeQueryConverter(settings));
+			options.Converters.Insert(0, new GeoBoundingBoxQueryConverter(settings));
+			options.Converters.Insert(0, new GeoDistanceQueryConverter(settings));
+			options.Converters.Insert(0, new GeoPolygonQueryConverter(settings));
+
+			// Aggregation converters
+			options.Converters.Insert(0, new AggregationContainerConverter());
+			options.Converters.Insert(0, new AggregationContainerInterfaceConverter());
+			options.Converters.Insert(0, new AggregationDictionaryConverter());
+			options.Converters.Insert(0, new AggregateDictionaryResponseConverter());
+			options.Converters.Insert(0, new AggregateConverter());
+
 			return options;
 		}
 	}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/OpenSearchClientSerializerOptions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/OpenSearchClientSerializerOptions.cs
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Provides per-<see cref="IConnectionSettingsValues"/> <see cref="JsonSerializerOptions"/> instances
+	/// for the high-level OpenSearch.Client serializer.
+	/// Replaces the Utf8Json-based <c>OpenSearchClientFormatterResolver</c>.
+	/// </summary>
+	/// <remarks>
+	/// Inherits all base settings from <see cref="OpenSearchNetSerializerOptions.Instance"/> and
+	/// adds high-level domain converters (query DSL, aggregations, mappings, ingest, etc.)
+	/// in the correct precedence order.
+	/// </remarks>
+	internal class OpenSearchClientSerializerOptions
+	{
+		/// <summary>
+		/// The <see cref="JsonSerializerOptions"/> instance for compact (non-indented) serialization.
+		/// </summary>
+		public JsonSerializerOptions Options { get; }
+
+		/// <summary>
+		/// The <see cref="JsonSerializerOptions"/> instance with <c>WriteIndented = true</c>,
+		/// used when <see cref="SerializationFormatting.Indented"/> is requested.
+		/// </summary>
+		public JsonSerializerOptions Indented { get; }
+
+		/// <summary>
+		/// Creates a new instance of <see cref="OpenSearchClientSerializerOptions"/> configured
+		/// for the given connection settings.
+		/// </summary>
+		/// <param name="settings">
+		/// The connection settings providing property name inference and source serializer configuration.
+		/// </param>
+		public OpenSearchClientSerializerOptions(IConnectionSettingsValues settings)
+		{
+			Options = CreateOptions(settings, writeIndented: false);
+			Indented = CreateOptions(settings, writeIndented: true);
+		}
+
+		private static JsonSerializerOptions CreateOptions(IConnectionSettingsValues settings, bool writeIndented)
+		{
+			// Copy from the base low-level options — this inherits PropertyNamingPolicy,
+			// DefaultIgnoreCondition, NumberHandling, Encoder, TypeInfoResolver (with
+			// DataMemberPropertyNameModifier that honors [DataMember(Name = "...")] attributes),
+			// and base converters (DynamicDictionaryConverter, DynamicValueConverter,
+			// EnumMemberConverterFactory, ExceptionConverter).
+			var options = new JsonSerializerOptions(OpenSearchNetSerializerOptions.Instance)
+			{
+				WriteIndented = writeIndented,
+				// Rebuild the resolver so that, in addition to the low-level [DataMember]/[IgnoreDataMember]
+				// handling, the high-level [InterfaceDataContract] rebuild runs. The contract rebuild
+				// makes request classes and descriptors serialize purely against their interface contract.
+				TypeInfoResolver = new DefaultJsonTypeInfoResolver
+				{
+					Modifiers =
+					{
+						DataMemberPropertyNameModifier.Modify,
+						new InterfaceDataContractModifier(settings).Modify,
+						// Honor OpenSearch.Client property-name inference (PropertyName/Text(Name) attributes,
+						// DefaultMappingFor, custom PropertyMappingProvider, DefaultFieldNameInferrer) for user
+						// document types serialized directly through the high-level serializer. No-op for
+						// OpenSearch framework types (they keep their existing [DataMember]/contract handling).
+						new SourcePropertyNameModifier(settings).Modify
+					}
+				}
+			};
+
+			// High-level domain converters are inserted at position 0 so they take
+			// precedence over the inherited base converters.
+			// Converter resolution order (first match wins):
+			//   1. Explicit singleton converters (domain-specific)
+			//   2. Enum converter (EnumMemberConverterFactory) — inherited from base
+			//   3. Attribute-based converters ([JsonConverter] on types) — handled by STJ automatically
+			//   4. ReadAs converters (interface → implementation mapping)
+			//   5. IsADictionary converters (for types implementing IsADictionaryBase)
+			//   6. SourceConverterFactory (catch-all for user document types)
+
+			// --- 6. SourceConverterFactory (lowest domain-converter precedence, inserted first) ---
+			options.Converters.Insert(0, new SourceConverterFactory(settings));
+
+			// --- 5. IsADictionary converters ---
+			options.Converters.Insert(0, new IsADictionaryConverterFactory(settings));
+
+			// FieldValues (hit/get "fields") needs the Inferrer injected so ValueOf/ValuesOf lookups
+			// resolve; the generic IsADictionary factory cannot call its (Inferrer, IDictionary) ctor.
+			// Must precede IsADictionaryConverterFactory since FieldValues is an IIsADictionary.
+			options.Converters.Insert(0, new FieldValuesConverter(settings));
+
+			// Field-keyed read-only dictionaries (TermVectors, GetFieldMapping, GetMapping field maps)
+			// need a settings-aware proxy so expression-path Field lookups resolve through the Inferrer.
+			// Must precede IsADictionaryConverterFactory.
+			options.Converters.Insert(0, new ResolvableReadOnlyFieldDictionaryConverterFactory(settings));
+
+			// ResolvableDictionaryProxy subclass converter (FieldCapabilitiesFields, IndicesStatsDictionary, etc.)
+			// These read-only dictionary types require IConnectionSettingsValues in their constructors.
+			// Must precede the generic IsADictionary handling since they are more specific.
+			options.Converters.Insert(0, new ResolvableDictionaryProxyConverterFactory(settings));
+
+			// Dictionary response converter (GetIndex/GetAlias/GetMapping/GetPipeline/... responses whose
+			// body is a JSON object of dictionary entries plus optional error/status fields). Replaces the
+			// Utf8Json ResolvableDictionaryResponseFormatter/DictionaryResponseFormatter [JsonFormatter]s.
+			options.Converters.Insert(0, new DictionaryResponseConverterFactory(settings));
+
+			// Dynamic response converter (ClusterState and other DynamicResponseBase types whose body is
+			// read wholesale into a DynamicDictionary). Replaces the Utf8Json DynamicResponseFormatter<T>.
+			options.Converters.Insert(0, new DynamicResponseConverterFactory(settings));
+
+			// Proxy request converter (Index/Create requests whose body is the source document written
+			// via IProxyRequest.WriteJson through the SourceSerializer). Inserted above the source/dictionary
+			// catch-alls so proxy requests never fall through to the interface-contract object handling.
+			options.Converters.Insert(0, new ProxyRequestConverterFactory(settings));
+
+			// --- 4. ReadAs converters (interface → implementation mapping) ---
+			options.Converters.Insert(0, new ReadAsConverterFactory());
+
+			// --- 1. Explicit singleton converters (highest precedence among domain converters) ---
+
+			// Script converter (type-dispatch for IScript → IInlineScript/IIndexedScript)
+			options.Converters.Insert(0, new ScriptConverter());
+
+			// PropertyName converter (dictionary key support for IProperties and similar types)
+			options.Converters.Insert(0, new PropertyNameConverter(settings));
+
+			// Field converter (resolves field names via Inferrer, handles boost/format)
+			options.Converters.Insert(0, new FieldConverterFactory(settings));
+
+			// IndexName converter (resolves index names via Inferrer)
+			options.Converters.Insert(0, new IndexNameConverterFactory(settings));
+
+			// RelationName converter (resolves relation/type names via Inferrer)
+			options.Converters.Insert(0, new RelationNameConverterFactory(settings));
+
+			// JoinField converter (parent relation string, or { name, parent } object for child)
+			options.Converters.Insert(0, new JoinFieldConverterFactory(settings));
+
+			// TaskId converter (supports dictionary key usage for task IDs in format "nodeId:taskNumber")
+			options.Converters.Insert(0, new TaskIdConverter());
+
+			// Id converter (resolves document IDs via Inferrer)
+			options.Converters.Insert(0, new IdConverterFactory(settings));
+
+			// Routing converter (resolves routing values via Inferrer)
+			options.Converters.Insert(0, new RoutingConverterFactory(settings));
+
+			// MultiGet request converter (flattens to ids/docs and strips redundant per-doc index)
+			options.Converters.Insert(0, new MultiGetRequestConverterFactory(settings));
+
+			// Bulk request converter (NDJSON: action-metadata line + body line per operation)
+			options.Converters.Insert(0, new BulkRequestConverterFactory(settings));
+
+			// LazyDocument converter (captures raw JSON for deferred source/response deserialization)
+			options.Converters.Insert(0, new LazyDocumentConverterFactory(settings));
+
+			// Bulk response item converter (single-key operation dispatch on deserialize)
+			options.Converters.Insert(0, new BulkResponseItemConverter());
+
+			// Union converter (writes whichever member is set; reads TFirst then falls back to TSecond)
+			options.Converters.Insert(0, new UnionConverterFactory());
+
+			// Indices converter (multi-syntax: comma-separated index string / "_all").
+			// Must take precedence over the UnionConverterFactory, which would otherwise claim
+			// Indices (a Union<AllIndicesMarker, ManyIndices>) and emit a nested object.
+			options.Converters.Insert(0, new IndicesConverterFactory(settings));
+
+			return options;
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/OpenSearchClientSerializerOptions.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/SerializationBehavior/OpenSearchClientSerializerOptions.cs
@@ -244,6 +244,10 @@ namespace OpenSearch.Client
 			options.Converters.Insert(0, new SuggestDictionaryConverterFactory());
 			options.Converters.Insert(0, new SearchResponseConverterFactory());
 
+			// Index settings converters (must precede IsADictionaryConverterFactory)
+			options.Converters.Insert(0, new IndexSettingsConverter());
+			options.Converters.Insert(0, new DynamicIndexSettingsConverter());
+
 			return options;
 		}
 	}

--- a/src/OpenSearch.Client/CommonAbstractions/Union/Union.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Union/Union.cs
@@ -27,6 +27,7 @@
 */
 
 using System;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// </summary>
 	/// <typeparam name="TFirst">The first type</typeparam>
 	/// <typeparam name="TSecond">The second type</typeparam>
+	[JsonConverter(typeof(UnionConverterFactory))]
 	[JsonFormatter(typeof(UnionFormatter<,>))]
 	public class Union<TFirst, TSecond>
 	{

--- a/src/OpenSearch.Client/CommonAbstractions/Union/UnionConverter.cs
+++ b/src/OpenSearch.Client/CommonAbstractions/Union/UnionConverter.cs
@@ -1,0 +1,219 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="Union{TFirst,TSecond}"/> as whichever member is set, and on read
+	/// attempts <c>TFirst</c> first, falling back to <c>TSecond</c>. Replaces the Utf8Json
+	/// <c>UnionFormatter</c>.
+	/// </summary>
+	internal sealed class UnionConverterFactory : JsonConverterFactory
+	{
+		public override bool CanConvert(Type typeToConvert)
+		{
+			if (GetUnionGenericArgs(typeToConvert) == null)
+				return false;
+
+			// Derived Union types (e.g. Context : Union<string, GeoLocation>) that declare their
+			// own [JsonConverter] should be handled by that converter, not the generic factory —
+			// otherwise this factory would produce a base Union<,> instance that cannot be assigned
+			// to the derived property type.
+			var declared = System.Reflection.CustomAttributeExtensions
+				.GetCustomAttributes(typeToConvert, typeof(JsonConverterAttribute), inherit: false);
+			foreach (var attr in declared)
+			{
+				if (((JsonConverterAttribute)attr).ConverterType != typeof(UnionConverterFactory))
+					return false;
+			}
+
+			return true;
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var args = GetUnionGenericArgs(typeToConvert);
+			if (args == null)
+				throw new JsonException($"{typeToConvert} is not a Union<,> type.");
+
+			var converterType = typeof(UnionConverter<,>).MakeGenericType(args[0], args[1]);
+			return (JsonConverter)Activator.CreateInstance(converterType, typeToConvert);
+		}
+
+		/// <summary>
+		/// Walks the type hierarchy to find the <c>Union&lt;TFirst,TSecond&gt;</c> base class
+		/// and returns its generic arguments, or null if not found. This handles both
+		/// <c>Union&lt;A,B&gt;</c> directly and derived types like <c>Like : Union&lt;string,ILikeDocument&gt;</c>.
+		/// </summary>
+		private static Type[] GetUnionGenericArgs(Type type)
+		{
+			var current = type;
+			while (current != null)
+			{
+				if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(Union<,>))
+					return current.GetGenericArguments();
+				current = current.BaseType;
+			}
+			return null;
+		}
+	}
+
+	internal sealed class UnionConverter<TFirst, TSecond> : JsonConverter<Union<TFirst, TSecond>>
+	{
+		// The concrete (possibly derived) union type requested, e.g. MinimumShouldMatch : Union<int?, string>.
+		// Constructing the derived type (rather than the base Union<,>) is required so the value can be
+		// assigned to a property typed as the derived type.
+		private readonly Type _unionType;
+
+		public UnionConverter() : this(typeof(Union<TFirst, TSecond>)) { }
+
+		public UnionConverter(Type unionType) => _unionType = unionType ?? typeof(Union<TFirst, TSecond>);
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(Union<TFirst, TSecond>).IsAssignableFrom(typeToConvert);
+
+		public override Union<TFirst, TSecond> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			// Buffer the value so we can attempt both member types against the same JSON.
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var element = doc.RootElement;
+
+			if (TryRead<TFirst>(element, options, out var first))
+				return Construct(first);
+
+			if (TryRead<TSecond>(element, options, out var second))
+				return Construct(second);
+
+			return null;
+		}
+
+		private Union<TFirst, TSecond> Construct<TItem>(TItem item)
+		{
+			// If the requested type is exactly the base Union<,>, construct it directly.
+			if (_unionType != typeof(Union<TFirst, TSecond>))
+			{
+				// Find a single-parameter constructor on the derived type whose parameter type is
+				// compatible with the item (handles e.g. MinimumShouldMatch(int) for a TFirst of int?).
+				foreach (var ctor in _unionType.GetConstructors())
+				{
+					var ps = ctor.GetParameters();
+					if (ps.Length != 1)
+						continue;
+
+					var pt = ps[0].ParameterType;
+					var underlying = Nullable.GetUnderlyingType(pt) ?? pt;
+
+					if (item == null)
+					{
+						if (!pt.IsValueType || Nullable.GetUnderlyingType(pt) != null)
+							return (Union<TFirst, TSecond>)ctor.Invoke(new object[] { null });
+						continue;
+					}
+
+					if (pt.IsInstanceOfType(item) || underlying.IsInstanceOfType(item))
+						return (Union<TFirst, TSecond>)ctor.Invoke(new object[] { item });
+				}
+			}
+
+			// Fall back to the base type if no matching derived constructor exists.
+			return new Union<TFirst, TSecond>((dynamic)item);
+		}
+
+		public override void Write(Utf8JsonWriter writer, Union<TFirst, TSecond> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			switch (value.Tag)
+			{
+				case 0:
+					SerializeValue(writer, value.Item1, options);
+					break;
+				case 1:
+					SerializeValue(writer, value.Item2, options);
+					break;
+				default:
+					throw new JsonException($"Unrecognized Union tag: {value.Tag}");
+			}
+		}
+
+		private static void SerializeValue<T>(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Use runtime type to ensure the concrete type's contract (with [InterfaceDataContract]
+			// properties) is used, not the declared interface type (which would serialize as {}).
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+
+		private static bool TryRead<T>(JsonElement element, JsonSerializerOptions options, out T value)
+		{
+			try
+			{
+				value = element.Deserialize<T>(options);
+
+				// For reference types, null means "couldn't produce a value".
+				if (value == null)
+					return false;
+
+				// For enums, the deserializer returns default(TEnum) for unrecognized strings.
+				// Validate by round-tripping: serialize back and compare to the original.
+				// This prevents "2d" from being accepted as DateInterval.Second.
+				if (typeof(T).IsEnum && element.ValueKind == JsonValueKind.String)
+				{
+					var original = element.GetString();
+					var reserialized = JsonSerializer.Serialize(value, options).Trim('"');
+					if (!string.Equals(original, reserialized, StringComparison.OrdinalIgnoreCase))
+						return false;
+				}
+
+				return true;
+			}
+			catch (JsonException)
+			{
+				value = default;
+				return false;
+			}
+			catch (NotSupportedException)
+			{
+				value = default;
+				return false;
+			}
+			// Some value types (e.g. Distance, Time) throw on unparseable input while attempting the
+			// first union member; treat these as "not this member" so the second member is attempted.
+			catch (InvalidCastException)
+			{
+				value = default;
+				return false;
+			}
+			catch (FormatException)
+			{
+				value = default;
+				return false;
+			}
+			catch (ArgumentException)
+			{
+				value = default;
+				return false;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonOptions/DateMath/DateMath.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateMath/DateMath.cs
@@ -30,6 +30,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using OpenSearch.Net.Extensions;
 using OpenSearch.Net.Utf8Json;
@@ -43,6 +45,63 @@ namespace OpenSearch.Client
 		DateMathTimeUnit? Round { get; }
 	}
 
+	/// <summary>
+	/// Serializes <see cref="DateMath"/> (and subclasses) as its string form and parses it back from a
+	/// string. A factory so it matches the abstract base and any concrete subtype (e.g.
+	/// <see cref="DateMathExpression"/>), since STJ resolves converters by the value's runtime type.
+	/// Declared via <c>[JsonConverter]</c> on the base type. Replaces the Utf8Json <c>DateMathFormatter</c>.
+	/// </summary>
+	internal sealed class DateMathConverter : JsonConverterFactory
+	{
+		public override bool CanConvert(Type typeToConvert) => typeof(DateMath).IsAssignableFrom(typeToConvert);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var converterType = typeof(DateMathConverterImpl<>).MakeGenericType(typeToConvert);
+			return (JsonConverter)Activator.CreateInstance(converterType);
+		}
+	}
+
+	internal sealed class DateMathConverterImpl<T> : JsonConverter<T> where T : DateMath
+	{
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.String)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var value = reader.GetString();
+			if (value == null)
+				return null;
+
+			// Mirror the Utf8Json DateMathExpressionFormatter: when the value has no date-math
+			// separator and parses as a DateTime, anchor on the DateTime (Union TFirst) so a
+			// round-tripped plain date exposes its Anchor as a DateTime rather than a string.
+			if (!ContainsDateMathSeparator(value)
+				&& System.DateTime.TryParse(value, System.Globalization.CultureInfo.InvariantCulture,
+					System.Globalization.DateTimeStyles.RoundtripKind, out var dateTime))
+				return (T)(DateMath)new DateMathExpression(dateTime);
+
+			return (T)DateMath.FromString(value);
+		}
+
+		private static bool ContainsDateMathSeparator(string value) =>
+			value.Contains("||") || value.EndsWith("|") || value.IndexOf('/') >= 0
+			// a '+' or '-' after the first char indicates a range (avoid matching a leading sign / date '-')
+			|| value.IndexOf('+') > 0;
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				writer.WriteStringValue(value.ToString());
+		}
+	}
+
+	[JsonConverter(typeof(DateMathConverter))]
 	[JsonFormatter(typeof(DateMathFormatter))]
 	public abstract class DateMath : IDateMath
 	{

--- a/src/OpenSearch.Client/CommonOptions/DateMath/DateMathExpression.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateMath/DateMathExpression.cs
@@ -27,11 +27,13 @@
 */
 
 using System;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Extensions;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(DateMathConverter))]
 	[JsonFormatter(typeof(DateMathExpressionFormatter))]
 	public class DateMathExpression : DateMath
 	{

--- a/src/OpenSearch.Client/CommonOptions/DateMath/DateMathTime.cs
+++ b/src/OpenSearch.Client/CommonOptions/DateMath/DateMathTime.cs
@@ -28,14 +28,47 @@
 
 using System;
 using System.Globalization;
-using System.Text.RegularExpressions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using System.Text.RegularExpressions;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
+	/// Serializes <see cref="DateMathTime"/> as its string form (e.g. <c>"5d"</c>) and parses it back.
+	/// Declared via <c>[JsonConverter]</c> so it is honored in every context (including Union members).
+	/// </summary>
+	internal sealed class DateMathTimeConverter : JsonConverter<DateMathTime>
+	{
+		public override DateMathTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.String:
+					var s = reader.GetString();
+					return s == null ? null : new DateMathTime(s);
+				case JsonTokenType.Number:
+					return new DateMathTime(reader.GetDouble());
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, DateMathTime value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				writer.WriteStringValue(value.ToString());
+		}
+	}
+
+	/// <summary>
 	/// A time representation for use within <see cref="DateMath" /> expressions.
 	/// </summary>
+	[JsonConverter(typeof(DateMathTimeConverter))]
 	[JsonFormatter(typeof(DateMathTimeFormatter))]
 	public class DateMathTime : IComparable<DateMathTime>, IEquatable<DateMathTime>
 	{

--- a/src/OpenSearch.Client/CommonOptions/Fuzziness/Fuzziness.cs
+++ b/src/OpenSearch.Client/CommonOptions/Fuzziness/Fuzziness.cs
@@ -26,10 +26,12 @@
 *  under the License.
 */
 
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(FuzzinessConverter))]
 	[JsonFormatter(typeof(FuzzinessFormatter))]
 	public class Fuzziness : IFuzziness
 	{

--- a/src/OpenSearch.Client/CommonOptions/Fuzziness/FuzzinessConverter.cs
+++ b/src/OpenSearch.Client/CommonOptions/Fuzziness/FuzzinessConverter.cs
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="IFuzziness"/>/<see cref="Fuzziness"/> as:
+	/// <list type="bullet">
+	/// <item><c>"AUTO"</c> or <c>"AUTO:low,high"</c></item>
+	/// <item>integer edit distance</item>
+	/// <item>double ratio</item>
+	/// </list>
+	/// </summary>
+	internal sealed class FuzzinessConverter : JsonConverter<IFuzziness>
+	{
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(IFuzziness).IsAssignableFrom(typeToConvert);
+
+		public override IFuzziness Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var str = reader.GetString();
+				if (string.Equals(str, "AUTO", StringComparison.OrdinalIgnoreCase))
+					return Fuzziness.Auto;
+
+				if (str != null && str.StartsWith("AUTO:", StringComparison.OrdinalIgnoreCase))
+				{
+					var parts = str.Substring(5).Split(',');
+					if (parts.Length == 2
+						&& int.TryParse(parts[0], out var low)
+						&& int.TryParse(parts[1], out var high))
+						return Fuzziness.AutoLength(low, high);
+				}
+
+				return Fuzziness.Auto;
+			}
+
+			if (reader.TokenType == JsonTokenType.Number)
+			{
+				if (reader.TryGetInt32(out var editDistance))
+					return Fuzziness.EditDistance(editDistance);
+				if (reader.TryGetDouble(out var ratio))
+					return Fuzziness.Ratio(ratio);
+			}
+
+			reader.Skip();
+			return null;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IFuzziness value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			if (value.Auto)
+			{
+				if (!value.Low.HasValue || !value.High.HasValue)
+					writer.WriteStringValue("AUTO");
+				else
+					writer.WriteStringValue($"AUTO:{value.Low},{value.High}");
+			}
+			else if (value.EditDistance.HasValue)
+				writer.WriteNumberValue(value.EditDistance.Value);
+			else if (value.Ratio.HasValue)
+				writer.WriteNumberValue(value.Ratio.Value);
+			else
+				writer.WriteNullValue();
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonOptions/Fuzziness/IFuzziness.cs
+++ b/src/OpenSearch.Client/CommonOptions/Fuzziness/IFuzziness.cs
@@ -26,10 +26,12 @@
 *  under the License.
 */
 
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(FuzzinessConverter))]
 	[JsonFormatter(typeof(FuzzinessInterfaceFormatter))]
 	public interface IFuzziness
 	{

--- a/src/OpenSearch.Client/CommonOptions/Geo/Distance.cs
+++ b/src/OpenSearch.Client/CommonOptions/Geo/Distance.cs
@@ -28,12 +28,42 @@
 
 using System;
 using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net.Utf8Json;
 using System.Text.RegularExpressions;
 using OpenSearch.Net;
-using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	/// <summary>Serializes <see cref="Distance"/> as its string form (e.g. <c>"200m"</c>) and parses it back.</summary>
+	internal sealed class DistanceConverter : JsonConverter<Distance>
+	{
+		public override Distance Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.String:
+					var s = reader.GetString();
+					return s == null ? null : new Distance(s);
+				case JsonTokenType.Number:
+					return new Distance(reader.GetDouble());
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, Distance value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				writer.WriteStringValue(value.ToString());
+		}
+	}
+
+	[JsonConverter(typeof(DistanceConverter))]
 	[JsonFormatter(typeof(DistanceFormatter))]
 	public class Distance
 	{

--- a/src/OpenSearch.Client/CommonOptions/Scripting/IndexedScript.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/IndexedScript.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(IndexedScript))]
 	public interface IIndexedScript : IScript
 	{
 		[DataMember(Name ="id")]

--- a/src/OpenSearch.Client/CommonOptions/Scripting/InlineScript.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/InlineScript.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(InlineScript))]
 	public interface IInlineScript : IScript
 	{
 		[DataMember(Name ="source")]

--- a/src/OpenSearch.Client/CommonOptions/Scripting/ScriptBase.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/ScriptBase.cs
@@ -29,8 +29,9 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using OpenSearch.Net;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
@@ -38,6 +39,7 @@ namespace OpenSearch.Client
 	/// A script to execute to provide custom computation
 	/// </summary>
 	[InterfaceDataContract]
+	[JsonConverter(typeof(ScriptConverter))]
 	[JsonFormatter(typeof(ScriptFormatter))]
 	public interface IScript
 	{

--- a/src/OpenSearch.Client/CommonOptions/Scripting/ScriptConverter.cs
+++ b/src/OpenSearch.Client/CommonOptions/Scripting/ScriptConverter.cs
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	internal sealed class ScriptConverter : JsonConverter<IScript>
+	{
+		public override IScript Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			string source = null;
+			string id = null;
+			string lang = null;
+			Dictionary<string, object> scriptParams = null;
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var propertyName = reader.GetString();
+				reader.Read();
+
+				switch (propertyName)
+				{
+					case "source":
+					case "inline":
+						source = reader.GetString();
+						break;
+					case "id":
+						id = reader.GetString();
+						break;
+					case "lang":
+						lang = reader.GetString();
+						break;
+					case "params":
+						scriptParams = JsonSerializer.Deserialize<Dictionary<string, object>>(ref reader, options);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			IScript script;
+			if (id != null)
+				script = new IndexedScript(id);
+			else if (source != null)
+				script = new InlineScript(source);
+			else
+				return null;
+
+			script.Lang = lang;
+			script.Params = scriptParams;
+			return script;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IScript value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			switch (value)
+			{
+				case IInlineScript inline:
+					JsonSerializer.Serialize(writer, inline, typeof(IInlineScript), options);
+					break;
+				case IIndexedScript indexed:
+					JsonSerializer.Serialize(writer, indexed, typeof(IIndexedScript), options);
+					break;
+				default:
+					JsonSerializer.Serialize(writer, value, value.GetType(), options);
+					break;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/CommonOptions/TimeUnit/Time.cs
+++ b/src/OpenSearch.Client/CommonOptions/TimeUnit/Time.cs
@@ -28,15 +28,17 @@
 
 using System;
 using System.Globalization;
+using System.Text.Json.Serialization;
+using OpenSearch.Net.Utf8Json;
 using System.Text.RegularExpressions;
 using OpenSearch.Net;
-using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// Represents a time value
 	/// </summary>
+	[JsonConverter(typeof(TimeConverter))]
 	[JsonFormatter(typeof(TimeFormatter))]
 	public class Time : IComparable<Time>, IEquatable<Time>, IUrlParameter
 	{

--- a/src/OpenSearch.Client/CommonOptions/TimeUnit/TimeConverter.cs
+++ b/src/OpenSearch.Client/CommonOptions/TimeUnit/TimeConverter.cs
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="Time"/> as either a string (<c>"7d"</c>) or milliseconds integer.
+	/// <list type="bullet">
+	/// <item>-1 → <c>-1</c> (special "minus one")</item>
+	/// <item>0 → <c>0</c> (special "zero")</item>
+	/// <item>Factor + Interval → string like <c>"7d"</c></item>
+	/// <item>Milliseconds only → integer</item>
+	/// </list>
+	/// </summary>
+	internal sealed class TimeConverter : JsonConverter<Time>
+	{
+		public override Time Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.String:
+					var str = reader.GetString();
+					return str == null ? null : new Time(str);
+				case JsonTokenType.Number:
+					var ms = reader.GetInt64();
+					if (ms == -1) return Time.MinusOne;
+					if (ms == 0) return Time.Zero;
+					return new Time(ms);
+				case JsonTokenType.Null:
+					return null;
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, Time value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			if (value == Time.MinusOne)
+				writer.WriteNumberValue(-1);
+			else if (value == Time.Zero)
+				writer.WriteNumberValue(0);
+			else if (value.Factor.HasValue && value.Interval.HasValue)
+				writer.WriteStringValue(value.ToString());
+			else if (value.Milliseconds != null)
+				writer.WriteNumberValue((long)value.Milliseconds);
+			else
+				writer.WriteNullValue();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
@@ -41,25 +41,25 @@ namespace OpenSearch.Client
 
 		[DataMember(Name ="doc")]
 		[JsonFormatter(typeof(CollapsedSourceFormatter<>))]
-		internal TPartialUpdate PartialUpdate { get; set; }
+		public TPartialUpdate PartialUpdate { get; set; }
 
 		[DataMember(Name ="script")]
-		internal IScript Script { get; set; }
+		public IScript Script { get; set; }
 
 		[DataMember(Name ="scripted_upsert")]
-		internal bool? ScriptedUpsert { get; set; }
+		public bool? ScriptedUpsert { get; set; }
 
 		[DataMember(Name ="upsert")]
 		[JsonFormatter(typeof(CollapsedSourceFormatter<>))]
-		internal TDocument Upsert { get; set; }
+		public TDocument Upsert { get; set; }
 
 		[DataMember(Name = "if_seq_no")]
-		internal long? IfSequenceNumber { get; set; }
+		public long? IfSequenceNumber { get; set; }
 
 		[DataMember(Name = "if_primary_term")]
-		internal long? IfPrimaryTerm { get; set; }
+		public long? IfPrimaryTerm { get; set; }
 
 		[DataMember(Name = "_source")]
-		internal Union<bool, ISourceFilter> Source { get; set; }
+		public Union<bool, ISourceFilter> Source { get; set; }
 	}
 }

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkRequestConverter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkRequestConverter.cs
@@ -1,0 +1,111 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	internal sealed class BulkRequestConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public BulkRequestConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeToConvert == typeof(IBulkRequest)
+			|| typeToConvert == typeof(BulkRequest)
+			|| typeToConvert == typeof(BulkDescriptor);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			(JsonConverter)Activator.CreateInstance(
+				typeof(BulkRequestConverter<>).MakeGenericType(typeToConvert), _settings);
+	}
+
+	/// <summary>
+	/// Serializes an <see cref="IBulkRequest"/> to the newline-delimited JSON (NDJSON) bulk format:
+	/// for each operation an action-metadata line (<c>{ "index": { ... } }</c>) is written, followed
+	/// by the operation body line (the source document, or the update body) when present.
+	/// Ports the Utf8Json <c>BulkRequestFormatter</c>.
+	/// </summary>
+	/// <remarks>
+	/// The bulk body is a sequence of top-level JSON documents separated by <c>\n</c>, which is not a
+	/// single valid JSON document. The whole payload is therefore assembled in a buffer and emitted in
+	/// one <see cref="Utf8JsonWriter.WriteRawValue(System.ReadOnlySpan{byte}, bool)"/> call (with input
+	/// validation disabled) so the writer treats it as a single opaque value rather than inserting
+	/// element separators between the individual lines.
+	/// </remarks>
+	internal sealed class BulkRequestConverter<T> : JsonConverter<T>
+		where T : IBulkRequest
+	{
+		private const byte Newline = (byte)'\n';
+		private static readonly byte[] EmptyBody = { Newline };
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public BulkRequestConverter(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+			throw new NotSupportedException();
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			var request = (IBulkRequest)value;
+
+			var inferrer = _settings.Inferrer;
+
+			using var ms = _settings.MemoryStreamFactory.Create();
+
+			for (var i = 0; request?.Operations != null && i < request.Operations.Count; i++)
+			{
+				var op = request.Operations[i];
+
+				op.Index ??= request.Index ?? op.ClrType;
+				if (op.Index.Equals(request.Index)) op.Index = null;
+				op.Id = op.GetIdForOperation(inferrer);
+
+				// GetRoutingForOperation falls back to deriving routing from the document; for
+				// operations without a document (e.g. a delete by id) this yields a Routing that
+				// resolves to null. STJ's WhenWritingNull only skips null CLR references, so null out
+				// the property when it resolves empty to avoid emitting "routing": null.
+				var routing = op.GetRoutingForOperation(inferrer);
+				op.Routing = string.IsNullOrEmpty(((IUrlParameter)routing)?.GetString(_settings)) ? null : routing;
+
+				// Action-metadata line: { "<operation>": { ...metadata... } }
+				using (var w = new Utf8JsonWriter(ms))
+				{
+					w.WriteStartObject();
+					w.WritePropertyName(op.Operation);
+					JsonSerializer.Serialize(w, op, op.GetType(), options);
+					w.WriteEndObject();
+				}
+				ms.WriteByte(Newline);
+
+				var body = op.GetBody();
+				if (body == null)
+					continue;
+
+				// Body line. Update bodies and lazy documents go through the high-level serializer;
+				// user documents are handled by the source serializer via SourceConverter — both are
+				// reachable through the same domain options.
+				using (var w = new Utf8JsonWriter(ms))
+					JsonSerializer.Serialize(w, body, body.GetType(), options);
+				ms.WriteByte(Newline);
+			}
+
+			var payload = ms.ToArray();
+			// An empty bulk request has an empty body; WriteRawValue rejects empty input, so emit a
+			// single newline (the server tolerates a blank bulk body) to keep the writer valid.
+			writer.WriteRawValue(payload.Length == 0 ? EmptyBody : payload, skipInputValidation: true);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
@@ -62,8 +62,11 @@ namespace OpenSearch.Client
 		[DataMember(Name = "_primary_term")]
 		public long PrimaryTerm { get; internal set; }
 
+		// Public getter (with a non-public setter honored by the DataMember contract modifier) so the
+		// response deserializer can populate the raw "get" payload; STJ surfaces only public getters.
 		[DataMember(Name = "get")]
-		internal LazyDocument Get { get; set; }
+		[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+		public LazyDocument Get { get; internal set; }
 
 		/// <summary>
 		/// Deserialize the <see cref="Get"/> property as a <see cref="GetResponse{TDocument}"/> type, where <typeparamref name="TDocument"/> is the document type.

--- a/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemConverter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemConverter.cs
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes a bulk response item, which is a single-key object whose key is the
+	/// operation (<c>index</c>/<c>create</c>/<c>update</c>/<c>delete</c>) and whose value is the
+	/// concrete item body. Replaces the Utf8Json <c>BulkResponseItemFormatter</c>.
+	/// </summary>
+	internal sealed class BulkResponseItemConverter : JsonConverter<BulkResponseItemBase>
+	{
+		public override BulkResponseItemBase Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			reader.Read(); // move to property name
+			if (reader.TokenType != JsonTokenType.PropertyName)
+			{
+				// empty object
+				return null;
+			}
+
+			var operation = reader.GetString();
+			reader.Read(); // move to the item body
+
+			BulkResponseItemBase item;
+			switch (operation)
+			{
+				case "delete":
+					item = JsonSerializer.Deserialize<BulkDeleteResponseItem>(ref reader, options);
+					break;
+				case "update":
+					item = JsonSerializer.Deserialize<BulkUpdateResponseItem>(ref reader, options);
+					break;
+				case "index":
+					item = JsonSerializer.Deserialize<BulkIndexResponseItem>(ref reader, options);
+					break;
+				case "create":
+					item = JsonSerializer.Deserialize<BulkCreateResponseItem>(ref reader, options);
+					break;
+				default:
+					reader.Skip();
+					item = null;
+					break;
+			}
+
+			reader.Read(); // consume EndObject of the wrapper
+			return item;
+		}
+
+		public override void Write(Utf8JsonWriter writer, BulkResponseItemBase value, JsonSerializerOptions options) =>
+			throw new NotSupportedException("Bulk response items are only ever deserialized.");
+	}
+}

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetRequestConverter.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetRequestConverter.cs
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	internal sealed class MultiGetRequestConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public MultiGetRequestConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeToConvert == typeof(IMultiGetRequest)
+			|| typeToConvert == typeof(MultiGetRequest)
+			|| typeToConvert == typeof(MultiGetDescriptor);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			(JsonConverter)Activator.CreateInstance(
+				typeof(MultiGetRequestConverter<>).MakeGenericType(typeToConvert), _settings);
+	}
+
+	internal sealed class MultiGetRequestConverter<T> : JsonConverter<T>
+		where T : IMultiGetRequest
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public MultiGetRequestConverter(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+			throw new NotSupportedException();
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			writer.WriteStartObject();
+
+			var request = (IMultiGetRequest)value;
+			if (request?.Documents == null || !request.Documents.Any())
+			{
+				writer.WriteEndObject();
+				return;
+			}
+
+			List<IMultiGetOperation> docs;
+
+			// If an index is specified at the request level and a document has the same index,
+			// clear the document-level index so it is not emitted redundantly.
+			if (request.Index != null)
+			{
+				var resolvedIndex = request.Index.GetString(_settings);
+				docs = request.Documents.Select(d =>
+					{
+						if (d.Index == null)
+							return d;
+
+						var docIndex = d.Index.GetString(_settings);
+						if (string.Equals(resolvedIndex, docIndex))
+							d.Index = null;
+						return d;
+					})
+					.ToList();
+			}
+			else
+				docs = request.Documents.ToList();
+
+			var flatten = docs.All(p => p.CanBeFlattened);
+
+			writer.WritePropertyName(flatten ? "ids" : "docs");
+			writer.WriteStartArray();
+			foreach (var doc in docs)
+			{
+				if (flatten)
+					JsonSerializer.Serialize(writer, doc.Id, options);
+				else
+					JsonSerializer.Serialize(writer, doc, options);
+			}
+			writer.WriteEndArray();
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetResponseBuilder.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Request/MultiGetResponseBuilder.cs
@@ -26,34 +26,118 @@
 *  under the License.
 */
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
+	/// <summary>
+	/// Builds a <see cref="MultiGetResponse"/> from the <c>{ "docs": [ ... ] }</c> envelope.
+	/// The order of the returned documents mirrors the order of the operations in the request, so each
+	/// hit is deserialized as a <see cref="MultiGetHit{T}"/> using the CLR type of the corresponding
+	/// operation.
+	/// </summary>
+	/// <remarks>
+	/// Dual-engine: when the built-in serializer exposes a Utf8Json formatter resolver (the current
+	/// default), delegates to the stateful <see cref="MultiGetResponseFormatter"/> — the same path
+	/// <c>main</c> uses. Only when the serializer exposes STJ options (once the default engine switches
+	/// in a later PR of #388) does this builder parse and dispatch the STJ way below.
+	/// </remarks>
 	internal class MultiGetResponseBuilder : CustomResponseBuilderBase
 	{
-		public MultiGetResponseBuilder(IMultiGetRequest request) => Formatter = new MultiGetResponseFormatter(request);
+		private static readonly ConcurrentDictionary<Type, MethodInfo> DeserializeHitMethods = new();
 
-		private MultiGetResponseFormatter Formatter { get; }
+		private static readonly MethodInfo DeserializeHitGenericMethod =
+			typeof(MultiGetResponseBuilder).GetMethod(nameof(DeserializeHit), BindingFlags.Static | BindingFlags.NonPublic);
 
-		public override object DeserializeResponse(IOpenSearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
-			response.Success
-				? builtInSerializer.CreateStateful(Formatter).Deserialize<MultiGetResponse>(stream)
-				: new MultiGetResponse();
+		public MultiGetResponseBuilder(IMultiGetRequest request) => Request = request;
+
+		private IMultiGetRequest Request { get; }
+
+		public override object DeserializeResponse(IOpenSearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
+		{
+			if (!response.Success)
+				return new MultiGetResponse();
+
+			if (builtInSerializer is IInternalSerializer internalSerializer && internalSerializer.TryGetJsonFormatter(out var formatterResolver))
+				return builtInSerializer.CreateStateful(new MultiGetResponseFormatter(Request)).Deserialize<MultiGetResponse>(stream);
+
+			if (IsEmpty(stream))
+				return new MultiGetResponse();
+
+			using var doc = JsonDocument.Parse(stream);
+			return Build(builtInSerializer, doc);
+		}
 
 		public override async Task<object> DeserializeResponseAsync(
 			IOpenSearchSerializer builtInSerializer,
 			IApiCallDetails response,
 			Stream stream,
 			CancellationToken ctx = default
-		) =>
-			response.Success
-				? await builtInSerializer.CreateStateful(Formatter)
+		)
+		{
+			if (!response.Success)
+				return new MultiGetResponse();
+
+			if (builtInSerializer is IInternalSerializer internalSerializer && internalSerializer.TryGetJsonFormatter(out var formatterResolver))
+				return await builtInSerializer.CreateStateful(new MultiGetResponseFormatter(Request))
 					.DeserializeAsync<MultiGetResponse>(stream, ctx)
-					.ConfigureAwait(false)
-				: new MultiGetResponse();
+					.ConfigureAwait(false);
+
+			if (IsEmpty(stream))
+				return new MultiGetResponse();
+
+			using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ctx).ConfigureAwait(false);
+			return Build(builtInSerializer, doc);
+		}
+
+		// Mocked/unit-test responses (URL and HTTP-method assertions) provide an empty response stream;
+		// JsonDocument.Parse throws on empty input, so short-circuit to an empty response.
+		private static bool IsEmpty(Stream stream) =>
+			stream == null || (stream.CanSeek && stream.Length == 0);
+
+		private MultiGetResponse Build(IOpenSearchSerializer builtInSerializer, JsonDocument doc)
+		{
+			var response = new MultiGetResponse();
+
+			if (Request?.Documents == null)
+				return response;
+
+			if (doc.RootElement.ValueKind != JsonValueKind.Object
+				|| !doc.RootElement.TryGetProperty("docs", out var docs)
+				|| docs.ValueKind != JsonValueKind.Array)
+				return response;
+
+			// The built-in high level serializer exposes the STJ options used for domain deserialization.
+			if (builtInSerializer is not IInternalSerializer internalSerializer
+				|| !internalSerializer.TryGetJsonSerializerOptions(out var options))
+				return response;
+
+			using var operationEnumerator = Request.Documents.GetEnumerator();
+			foreach (var hitElement in docs.EnumerateArray())
+			{
+				if (!operationEnumerator.MoveNext())
+					break;
+
+				var clrType = operationEnumerator.Current.ClrType ?? typeof(object);
+				var method = DeserializeHitMethods.GetOrAdd(clrType, static t => DeserializeHitGenericMethod.MakeGenericMethod(t));
+				var hit = (IMultiGetHit<object>)method.Invoke(null, new object[] { hitElement, options });
+				if (hit != null)
+					response.InternalHits.Add(hit);
+			}
+
+			return response;
+		}
+
+		private static IMultiGetHit<object> DeserializeHit<T>(JsonElement element, JsonSerializerOptions options)
+			where T : class =>
+			element.Deserialize<MultiGetHit<T>>(options);
 	}
 }

--- a/src/OpenSearch.Client/Document/Multiple/MultiGet/Response/MultiGetHit.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiGet/Response/MultiGetHit.cs
@@ -33,6 +33,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(MultiGetHit<>))]
+	[InterfaceDataContract]
 	public interface IMultiGetHit<out TDocument> where TDocument : class
 	{
 		Error Error { get; }

--- a/src/OpenSearch.Client/Document/Multiple/MultiTermVectors/MultiTermVectorOperation.cs
+++ b/src/OpenSearch.Client/Document/Multiple/MultiTermVectors/MultiTermVectorOperation.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// An operation to define the calculation of
 	/// term vectors when using Multi termvectors API
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IMultiTermVectorOperation
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexDestination.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexDestination.cs
@@ -27,6 +27,7 @@
 */
 
 using OpenSearch.Net;
+using OpenSearch.Net.Utf8Json;
 using System.Runtime.Serialization;
 
 
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Configures the destination for a reindex API request
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IReindexDestination
 	{
 		/// <summary>
@@ -54,6 +56,7 @@ namespace OpenSearch.Client
 		/// <summary>
 		/// Id of the pipeline to use to process documents
 		/// </summary>
+		[DataMember(Name = "pipeline")]
 		string Pipeline { get; set; }
 
 		/// <summary>

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexRouting.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexRouting.cs
@@ -26,10 +26,14 @@
 *  under the License.
 */
 
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(ReindexRoutingConverter))]
 	[JsonFormatter(typeof(ReindexRoutingFormatter))]
 	public class ReindexRouting
 	{
@@ -53,5 +57,30 @@ namespace OpenSearch.Client
 		public static implicit operator ReindexRouting(string routing) => new ReindexRouting(routing);
 
 		public override string ToString() => _newRoutingValue;
+	}
+
+	internal sealed class ReindexRoutingConverter : JsonConverter<ReindexRouting>
+	{
+		public override ReindexRouting Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var value = reader.GetString();
+			switch (value)
+			{
+				case "keep": return ReindexRouting.Keep;
+				case "discard": return ReindexRouting.Discard;
+				default: return value == null ? null : new ReindexRouting(value);
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, ReindexRouting value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				writer.WriteStringValue(value.ToString());
+		}
 	}
 }

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexSource.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/ReindexSource.cs
@@ -29,12 +29,14 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// Configures the source for a reindex API request
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IReindexSource
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/RemoteSource.cs
+++ b/src/OpenSearch.Client/Document/Multiple/ReindexOnServer/RemoteSource.cs
@@ -28,9 +28,11 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IRemoteSource
 	{
 		[DataMember(Name ="host")]

--- a/src/OpenSearch.Client/Document/Single/Get/GetResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/Get/GetResponse.cs
@@ -31,6 +31,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IGetResponse<out TDocument> : IResponse where TDocument : class
 	{
 		TDocument Source { get; }

--- a/src/OpenSearch.Client/Document/Single/Source/SourceRequestResponseBuilder.cs
+++ b/src/OpenSearch.Client/Document/Single/Source/SourceRequestResponseBuilder.cs
@@ -27,6 +27,7 @@
 */
 
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net;
@@ -37,44 +38,44 @@ namespace OpenSearch.Client
 	{
 		public static SourceRequestResponseBuilder<TDocument> Instance { get; } = new SourceRequestResponseBuilder<TDocument>();
 
-		public override object DeserializeResponse(IOpenSearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
-		{
-			if (response.Success)
-			{
-				if (builtInSerializer is IInternalSerializer internalSerializer &&
-					internalSerializer.TryGetJsonFormatter(out var formatter))
-				{
-					var sourceSerializer = formatter.GetConnectionSettings().SourceSerializer;
-					return new SourceResponse<TDocument> { Body = sourceSerializer.Deserialize<TDocument>(stream) };
-				}
+		public override object DeserializeResponse(IOpenSearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
+			response.Success
+				? new SourceResponse<TDocument> { Body = ResolveSourceSerializer(builtInSerializer).Deserialize<TDocument>(stream) }
+				: new SourceResponse<TDocument>();
 
-				return new SourceResponse<TDocument> { Body = builtInSerializer.Deserialize<TDocument>(stream) };
+		public override async Task<object> DeserializeResponseAsync(IOpenSearchSerializer builtInSerializer, IApiCallDetails response, Stream stream, CancellationToken ctx = default) =>
+			response.Success
+				? new SourceResponse<TDocument>
+				{
+					Body = await ResolveSourceSerializer(builtInSerializer).DeserializeAsync<TDocument>(stream, ctx).ConfigureAwait(false)
+				}
+				: new SourceResponse<TDocument>();
+
+		// A _source response body IS the raw user document, so it must be deserialized by the configured
+		// SourceSerializer — when a distinct source serializer is set (e.g. the JSON.NET serializer under
+		// source_serializer=true) the built-in high-level serializer would not honor the source serializer's
+		// converters. Resolve the SourceSerializer from whichever engine backs the built-in serializer: on
+		// Utf8Json via the formatter resolver's connection settings, on STJ via the registered
+		// SourceConverterFactory's bound settings. Falls back to the built-in serializer when unavailable —
+		// that path already routes a bare document root through the inference-aware terminal source options.
+		private static IOpenSearchSerializer ResolveSourceSerializer(IOpenSearchSerializer builtInSerializer)
+		{
+			if (builtInSerializer is not IInternalSerializer internalSerializer)
+				return builtInSerializer;
+
+			if (internalSerializer.TryGetJsonFormatter(out var formatter))
+				return formatter.GetConnectionSettings().SourceSerializer;
+
+			if (internalSerializer.TryGetJsonSerializerOptions(out var options))
+			{
+				foreach (var converter in options.Converters)
+				{
+					if (converter is SourceConverterFactory factory)
+						return factory.Settings.SourceSerializer;
+				}
 			}
 
-			return new SourceResponse<TDocument>();
-		}
-
-		public override async Task<object> DeserializeResponseAsync(IOpenSearchSerializer builtInSerializer, IApiCallDetails response, Stream stream, CancellationToken ctx = default)
-		{
-			if (response.Success)
-			{
-				if (builtInSerializer is IInternalSerializer internalSerializer &&
-					internalSerializer.TryGetJsonFormatter(out var formatter))
-				{
-					var sourceSerializer = formatter.GetConnectionSettings().SourceSerializer;
-					return new SourceResponse<TDocument>
-					{
-						Body = await sourceSerializer.DeserializeAsync<TDocument>(stream, ctx).ConfigureAwait(false)
-					};
-				}
-
-				return new SourceResponse<TDocument>
-				{
-					Body = await builtInSerializer.DeserializeAsync<TDocument>(stream, ctx).ConfigureAwait(false)
-				};
-			}
-
-			return new SourceResponse<TDocument>();
+			return builtInSerializer;
 		}
 	}
 }

--- a/src/OpenSearch.Client/Document/Single/TermVectors/TermVectors.cs
+++ b/src/OpenSearch.Client/Document/Single/TermVectors/TermVectors.cs
@@ -34,6 +34,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(TermVectorsResult))]
+	[InterfaceDataContract]
 	public interface ITermVectors
 	{
 		bool Found { get; }

--- a/src/OpenSearch.Client/Document/Single/Update/UpdateResponse.cs
+++ b/src/OpenSearch.Client/Document/Single/Update/UpdateResponse.cs
@@ -27,9 +27,11 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IUpdateResponse<out TDocument> : IResponse where TDocument : class
 	{
 		IInlineGet<TDocument> Get { get; }

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// An alias to one or more indices
 	/// </summary>
 	[ReadAs(typeof(Alias))]
+	[InterfaceDataContract]
 	public interface IAlias
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasActionConverter.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasActionConverter.cs
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Dispatches serialization of the <see cref="IAliasAction"/> marker interface to the concrete
+	/// action's own interface contract (<see cref="IAliasAddAction"/>, <see cref="IAliasRemoveAction"/>,
+	/// <see cref="IAliasRemoveIndexAction"/>). Without this, serializing through the marker interface
+	/// (e.g. as an element of <c>IList&lt;IAliasAction&gt;</c>) yields an empty object.
+	/// </summary>
+	internal sealed class AliasActionConverter : JsonConverter<IAliasAction>
+	{
+		public override IAliasAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			if (root.TryGetProperty("add", out _))
+				return root.Deserialize<AliasAddAction>(options);
+			if (root.TryGetProperty("remove_index", out _))
+				return root.Deserialize<AliasRemoveIndexAction>(options);
+			if (root.TryGetProperty("remove", out _))
+				return root.Deserialize<AliasRemoveAction>(options);
+
+			return null;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IAliasAction value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			switch (value)
+			{
+				case IAliasAddAction add:
+					JsonSerializer.Serialize(writer, add, typeof(IAliasAddAction), options);
+					break;
+				case IAliasRemoveIndexAction removeIndex:
+					JsonSerializer.Serialize(writer, removeIndex, typeof(IAliasRemoveIndexAction), options);
+					break;
+				case IAliasRemoveAction remove:
+					JsonSerializer.Serialize(writer, remove, typeof(IAliasRemoveAction), options);
+					break;
+				default:
+					JsonSerializer.Serialize(writer, value, value.GetType(), options);
+					break;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasAdd.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasAdd.cs
@@ -34,6 +34,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(AliasAddAction))]
 	public interface IAliasAddAction : IAliasAction
 	{
 		[DataMember(Name ="add")]

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasAddOperation.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasAddOperation.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -65,6 +66,7 @@ namespace OpenSearch.Client
 		/// The indices to which to add the alias
 		/// </summary>
 		[DataMember(Name = "indices")]
+		[JsonConverter(typeof(IndicesArrayConverter))]
 		[JsonFormatter(typeof(IndicesFormatter))]
 		public Indices Indices { get; set; }
 

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemove.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemove.cs
@@ -34,6 +34,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(AliasRemoveAction))]
 	public interface IAliasRemoveAction : IAliasAction
 	{
 		[DataMember(Name = "remove")]

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveIndex.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveIndex.cs
@@ -33,6 +33,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(AliasRemoveIndexAction))]
 	public interface IAliasRemoveIndexAction : IAliasAction
 	{
 		[DataMember(Name ="remove_index")]

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveOperation.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/AliasRemoveOperation.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -58,6 +59,7 @@ namespace OpenSearch.Client
 		/// The indices to which to remove the alias
 		/// </summary>
 		[DataMember(Name = "indices")]
+		[JsonConverter(typeof(IndicesArrayConverter))]
 		[JsonFormatter(typeof(IndicesFormatter))]
 		public Indices Indices { get; set; }
 

--- a/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/IAliasAction.cs
+++ b/src/OpenSearch.Client/Indices/AliasManagement/Alias/Actions/IAliasAction.cs
@@ -26,15 +26,18 @@
 *  under the License.
 */
 
+
+
+using System.Text.Json.Serialization;
+
 using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
-
-
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// Marker interface for alias operation
 	/// </summary>
+	[JsonConverter(typeof(AliasActionConverter))]
 	[JsonFormatter(typeof(AliasActionFormatter))]
 	public interface IAliasAction { }
 
@@ -124,4 +127,6 @@ namespace OpenSearch.Client
 			return formatter.Deserialize(ref reader, formatterResolver);
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Indices/IndexSettings/ComposableIndexTemplates/GetComposableIndexTemplate/ComposableIndexTemplate.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/ComposableIndexTemplates/GetComposableIndexTemplate/ComposableIndexTemplate.cs
@@ -14,6 +14,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client;
 
 [ReadAs(typeof(Template))]
+[InterfaceDataContract]
 public interface ITemplate
 {
 	[DataMember(Name = "aliases")]
@@ -53,6 +54,7 @@ public class TemplateDescriptor : DescriptorBase<TemplateDescriptor, ITemplate>,
 }
 
 [ReadAs(typeof(ComposableIndexTemplate))]
+[InterfaceDataContract]
 public interface IComposableIndexTemplate
 {
 	[DataMember(Name = "composed_of")]

--- a/src/OpenSearch.Client/Indices/IndexSettings/ComposableIndexTemplates/GetComposableIndexTemplate/DataStreamTemplate.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/ComposableIndexTemplates/GetComposableIndexTemplate/DataStreamTemplate.cs
@@ -7,10 +7,12 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client;
 
 [ReadAs(typeof(DataStreamTemplate))]
+[InterfaceDataContract]
 public interface IDataStreamTemplate
 {
 	[DataMember(Name = "timestamp_field")]
@@ -31,6 +33,7 @@ public class DataStreamTemplateDescriptor : DescriptorBase<DataStreamTemplateDes
 }
 
 [ReadAs(typeof(TimestampField))]
+[InterfaceDataContract]
 public interface ITimestampField
 {
 	[DataMember(Name = "name")]

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexState.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexState.cs
@@ -27,10 +27,12 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(IndexState))]
+	[InterfaceDataContract]
 	public interface IIndexState
 	{
 		[DataMember(Name ="aliases")]

--- a/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/TemplateMapping.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/TemplateMapping.cs
@@ -29,9 +29,11 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface ITemplateMapping
 	{
 		[DataMember(Name ="aliases")]

--- a/src/OpenSearch.Client/Indices/IndexSettings/Settings/AutoExpandReplicas.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/Settings/AutoExpandReplicas.cs
@@ -27,10 +27,13 @@
 */
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(AutoExpandReplicasConverter))]
 	[JsonFormatter(typeof(AutoExpandReplicasFormatter))]
 	public class AutoExpandReplicas
 	{
@@ -159,6 +162,43 @@ namespace OpenSearch.Client
 		}
 	}
 
+	/// <summary>
+	/// Serializes <see cref="AutoExpandReplicas"/> as a string (e.g. "0-all", "0-5") or
+	/// <c>false</c> when disabled. Replaces the Utf8Json AutoExpandReplicasFormatter.
+	/// </summary>
+	internal sealed class AutoExpandReplicasConverter : JsonConverter<AutoExpandReplicas>
+	{
+		public override AutoExpandReplicas Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.False:
+					return AutoExpandReplicas.Disabled;
+				case JsonTokenType.String:
+					var value = reader.GetString();
+					return string.IsNullOrEmpty(value) || value.Equals("false", StringComparison.OrdinalIgnoreCase)
+						? AutoExpandReplicas.Disabled
+						: AutoExpandReplicas.Create(value);
+				case JsonTokenType.True:
+					// "true" is not a valid value but be lenient
+					return AutoExpandReplicas.Disabled;
+				default:
+					reader.Skip();
+					return AutoExpandReplicas.Disabled;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, AutoExpandReplicas value, JsonSerializerOptions options)
+		{
+			if (value == null || !value.Enabled)
+			{
+				writer.WriteBooleanValue(false);
+				return;
+			}
+
+			writer.WriteStringValue(value.ToString());
+		}
+	}
 	internal class AutoExpandReplicasFormatter : IJsonFormatter<AutoExpandReplicas>
 	{
 		public AutoExpandReplicas Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
@@ -184,4 +224,6 @@ namespace OpenSearch.Client
 			writer.WriteString(value.ToString());
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Indices/IndexSettings/Settings/DynamicIndexSettings.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/Settings/DynamicIndexSettings.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// Dynamic index settings
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DynamicIndexSettings))]
 	[JsonFormatter(typeof(DynamicIndexSettingsFormatter))]
 	public interface IDynamicIndexSettings : IIsADictionary<string, object>
 	{

--- a/src/OpenSearch.Client/Indices/IndexSettings/Settings/DynamicIndexSettingsConverter.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/Settings/DynamicIndexSettingsConverter.cs
@@ -1,0 +1,412 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using static OpenSearch.Client.FixedIndexSettings;
+using static OpenSearch.Client.IndexSortSettings;
+using static OpenSearch.Client.UpdatableIndexSettings;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Handles serialization/deserialization of <see cref="IDynamicIndexSettings"/>.
+	/// Typed properties are flushed into the backing dictionary before the dictionary is serialized.
+	/// </summary>
+	internal class DynamicIndexSettingsConverter : JsonConverter<IDynamicIndexSettings>
+	{
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(IDynamicIndexSettings).IsAssignableFrom(typeToConvert)
+			&& !typeof(IIndexSettings).IsAssignableFrom(typeToConvert);
+
+		public override IDynamicIndexSettings Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var indexSettings = new IndexSettings();
+			ReadKnownSettings(ref reader, indexSettings, options);
+			return indexSettings;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IDynamicIndexSettings value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			IDictionary<string, object> d = value;
+
+			FlushDynamicProperties(value, d);
+
+			WriteDictionary(writer, d, options);
+		}
+
+		/// <summary>
+		/// Flushes the typed dynamic index setting properties into the backing dictionary.
+		/// </summary>
+		internal static void FlushDynamicProperties(IDynamicIndexSettings value, IDictionary<string, object> d)
+		{
+			Set(d, NumberOfReplicas, value.NumberOfReplicas);
+			Set(d, RefreshInterval, value.RefreshInterval);
+			Set(d, DefaultPipeline, value.DefaultPipeline);
+			Set(d, FinalPipeline, value.FinalPipeline);
+			Set(d, BlocksReadOnly, value.BlocksReadOnly);
+			Set(d, BlocksRead, value.BlocksRead);
+			Set(d, BlocksWrite, value.BlocksWrite);
+			Set(d, BlocksMetadata, value.BlocksMetadata);
+			Set(d, BlocksReadOnlyAllowDelete, value.BlocksReadOnlyAllowDelete);
+			Set(d, Priority, value.Priority);
+			Set(d, UpdatableIndexSettings.AutoExpandReplicas, value.AutoExpandReplicas);
+			Set(d, UpdatableIndexSettings.RecoveryInitialShards, value.RecoveryInitialShards);
+			Set(d, RequestsCacheEnable, value.RequestsCacheEnabled);
+			Set(d, RoutingAllocationTotalShardsPerNode, value.RoutingAllocationTotalShardsPerNode);
+			Set(d, UnassignedNodeLeftDelayedTimeout, value.UnassignedNodeLeftDelayedTimeout);
+
+			var translog = value.Translog;
+			Set(d, TranslogSyncInterval, translog?.SyncInterval);
+			Set(d, UpdatableIndexSettings.TranslogDurability, translog?.Durability);
+
+			var flush = value.Translog?.Flush;
+			Set(d, TranslogFlushThresholdSize, flush?.ThresholdSize);
+			Set(d, TranslogFlushThresholdPeriod, flush?.ThresholdPeriod);
+
+			Set(d, MergePolicyExpungeDeletesAllowed, value.Merge?.Policy?.ExpungeDeletesAllowed);
+			Set(d, MergePolicyFloorSegment, value.Merge?.Policy?.FloorSegment);
+			Set(d, MergePolicyMaxMergeAtOnce, value.Merge?.Policy?.MaxMergeAtOnce);
+			Set(d, MergePolicyMaxMergeAtOnceExplicit, value.Merge?.Policy?.MaxMergeAtOnceExplicit);
+			Set(d, MergePolicyMaxMergedSegment, value.Merge?.Policy?.MaxMergedSegment);
+			Set(d, MergePolicySegmentsPerTier, value.Merge?.Policy?.SegmentsPerTier);
+			Set(d, MergePolicyReclaimDeletesWeight, value.Merge?.Policy?.ReclaimDeletesWeight);
+
+			Set(d, MergeSchedulerMaxThreadCount, value.Merge?.Scheduler?.MaxThreadCount);
+			Set(d, MergeSchedulerAutoThrottle, value.Merge?.Scheduler?.AutoThrottle);
+
+			var log = value.SlowLog;
+			var search = log?.Search;
+			var indexing = log?.Indexing;
+
+			Set(d, SlowlogSearchThresholdQueryWarn, search?.Query?.ThresholdWarn);
+			Set(d, SlowlogSearchThresholdQueryInfo, search?.Query?.ThresholdInfo);
+			Set(d, SlowlogSearchThresholdQueryDebug, search?.Query?.ThresholdDebug);
+			Set(d, SlowlogSearchThresholdQueryTrace, search?.Query?.ThresholdTrace);
+
+			Set(d, SlowlogSearchThresholdFetchWarn, search?.Fetch?.ThresholdWarn);
+			Set(d, SlowlogSearchThresholdFetchInfo, search?.Fetch?.ThresholdInfo);
+			Set(d, SlowlogSearchThresholdFetchDebug, search?.Fetch?.ThresholdDebug);
+			Set(d, SlowlogSearchThresholdFetchTrace, search?.Fetch?.ThresholdTrace);
+			Set(d, SlowlogSearchLevel, search?.LogLevel);
+
+			Set(d, SlowlogIndexingThresholdFetchWarn, indexing?.ThresholdWarn);
+			Set(d, SlowlogIndexingThresholdFetchInfo, indexing?.ThresholdInfo);
+			Set(d, SlowlogIndexingThresholdFetchDebug, indexing?.ThresholdDebug);
+			Set(d, SlowlogIndexingThresholdFetchTrace, indexing?.ThresholdTrace);
+			Set(d, SlowlogIndexingLevel, indexing?.LogLevel);
+			Set(d, SlowlogIndexingSource, indexing?.Source);
+
+			Set(d, UpdatableIndexSettings.Analysis, value.Analysis);
+			Set(d, Similarity, value.Similarity);
+		}
+
+		/// <summary>
+		/// Flushes the typed fixed index setting properties into the backing dictionary.
+		/// </summary>
+		internal static void FlushFixedProperties(IIndexSettings indexSettings, IDictionary<string, object> d)
+		{
+			Set(d, StoreType, indexSettings.FileSystemStorageImplementation);
+			Set(d, QueriesCacheEnabled, indexSettings.Queries?.Cache?.Enabled);
+			Set(d, NumberOfShards, indexSettings.NumberOfShards);
+			Set(d, NumberOfRoutingShards, indexSettings.NumberOfRoutingShards);
+			Set(d, RoutingPartitionSize, indexSettings.RoutingPartitionSize);
+			Set(d, Hidden, indexSettings.Hidden);
+
+			if (indexSettings.SoftDeletes != null)
+			{
+				Set(d, SoftDeletesRetentionOperations, indexSettings.SoftDeletes.Retention?.Operations);
+			}
+
+			if (indexSettings.Sorting != null)
+			{
+				Set(d, IndexSortSettings.Fields, AsArrayOrSingleItem(indexSettings.Sorting.Fields));
+				Set(d, Order, AsArrayOrSingleItem(indexSettings.Sorting.Order));
+				Set(d, Mode, AsArrayOrSingleItem(indexSettings.Sorting.Mode));
+				Set(d, IndexSortSettings.Missing, AsArrayOrSingleItem(indexSettings.Sorting.Missing));
+			}
+		}
+
+		/// <summary>
+		/// Writes the dictionary as a JSON object, skipping null values (except RefreshInterval).
+		/// </summary>
+		internal static void WriteDictionary(Utf8JsonWriter writer, IDictionary<string, object> d, JsonSerializerOptions options)
+		{
+			writer.WriteStartObject();
+
+			foreach (var kvp in d)
+			{
+				// Skip null values except for RefreshInterval (which can legitimately be -1 serialized as a string)
+				if (kvp.Value == null && kvp.Key != RefreshInterval)
+					continue;
+
+				writer.WritePropertyName(kvp.Key);
+				JsonSerializer.Serialize(writer, kvp.Value, kvp.Value?.GetType() ?? typeof(object), options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		/// <summary>
+		/// Reads a JSON object into an <see cref="IIndexSettings"/> instance, extracting known
+		/// settings into typed properties and placing the rest in the backing dictionary.
+		/// </summary>
+		internal static void ReadKnownSettings(ref Utf8JsonReader reader, IIndexSettings s, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+			// Read as a raw dictionary first, then flatten and extract known keys
+			var raw = JsonSerializer.Deserialize<Dictionary<string, object>>(ref reader, options);
+			if (raw == null) return;
+
+			var settings = Flatten(raw);
+			IDictionary<string, object> dict = s;
+
+			// Extract known dynamic index settings
+			SetValue<int?>(settings, NumberOfReplicas, v => s.NumberOfReplicas = v);
+			SetValue<AutoExpandReplicas>(settings, UpdatableIndexSettings.AutoExpandReplicas, v => s.AutoExpandReplicas = v, options);
+			SetValue<Time>(settings, RefreshInterval, v => s.RefreshInterval = v, options);
+			SetValue<string>(settings, DefaultPipeline, v => s.DefaultPipeline = v);
+			SetValue<string>(settings, FinalPipeline, v => s.FinalPipeline = v);
+			SetValue<bool?>(settings, BlocksReadOnly, v => s.BlocksReadOnly = v);
+			SetValue<bool?>(settings, BlocksRead, v => s.BlocksRead = v);
+			SetValue<bool?>(settings, BlocksWrite, v => s.BlocksWrite = v);
+			SetValue<bool?>(settings, BlocksMetadata, v => s.BlocksMetadata = v);
+			SetValue<bool?>(settings, BlocksReadOnlyAllowDelete, v => s.BlocksReadOnlyAllowDelete = v);
+			SetValue<int?>(settings, Priority, v => s.Priority = v);
+			SetValue<bool?>(settings, RequestsCacheEnable, v => s.RequestsCacheEnabled = v);
+			SetValue<int?>(settings, RoutingAllocationTotalShardsPerNode, v => s.RoutingAllocationTotalShardsPerNode = v);
+
+			// Fixed index settings
+			SetValue<int?>(settings, NumberOfShards, v => s.NumberOfShards = v);
+			SetValue<int?>(settings, NumberOfRoutingShards, v => s.NumberOfRoutingShards = v);
+			SetValue<int?>(settings, RoutingPartitionSize, v => s.RoutingPartitionSize = v);
+			SetValue<bool?>(settings, Hidden, v => s.Hidden = v);
+			SetValue<FileSystemStorageImplementation?>(settings, StoreType, v => s.FileSystemStorageImplementation = v, options);
+
+			// Reconstruct the nested settings objects from their flattened dotted keys, mirroring the pre-STJ
+			// IndexSettingsFormatter. The typed extraction is additive (SetValue keeps the entry in the flat
+			// dictionary), so the raw keys still land in the backing dictionary below.
+			var queries = new QueriesSettings();
+			var queriesCache = new QueriesCacheSettings();
+			var queriesCacheSet = false;
+			SetValue<bool?>(settings, QueriesCacheEnabled, v => { queriesCache.Enabled = v; queriesCacheSet = true; });
+			if (queriesCacheSet)
+			{
+				queries.Cache = queriesCache;
+				s.Queries = queries;
+			}
+
+			var softDeletesRetention = new SoftDeleteRetentionSettings();
+			var softDeletesSet = false;
+			SetValue<long?>(settings, SoftDeletesEnabled, v => { softDeletesRetention.Operations = v; softDeletesSet = true; });
+			if (softDeletesSet)
+				s.SoftDeletes = new SoftDeleteSettings { Retention = softDeletesRetention };
+
+			// Extract the analysis and similarity sub-objects into their typed properties. These are left
+			// un-flattened by Flatten (see below) so they arrive as nested objects under either the bare or
+			// the "index."-prefixed key. Remaining entries fall through to the backing dictionary.
+			foreach (var kv in settings)
+			{
+				switch (kv.Key)
+				{
+					case UpdatableIndexSettings.Analysis:
+					case "index.analysis":
+						s.Analysis = ReserializeAndDeserialize<IAnalysis>(kv.Value, options);
+						break;
+					case Similarity:
+					case "index.similarity":
+						s.Similarity = ReserializeAndDeserialize<ISimilarities>(kv.Value, options);
+						break;
+					default:
+						dict[kv.Key] = kv.Value;
+						break;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Reserializes a value that was deserialized to a loosely-typed representation (e.g. a nested
+		/// <see cref="Dictionary{TKey,TValue}"/> or <see cref="JsonElement"/>) and deserializes it into the
+		/// strongly-typed <typeparamref name="T"/> using the same options. Mirrors the Utf8Json
+		/// roundtrip used by the original IndexSettings formatter for the analysis/similarity sub-objects.
+		/// </summary>
+		private static T ReserializeAndDeserialize<T>(object value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				return default;
+
+			var json = JsonSerializer.Serialize(value, value.GetType(), options);
+			return JsonSerializer.Deserialize<T>(json, options);
+		}
+
+		private static void Set(IDictionary<string, object> d, string key, object value)
+		{
+			if (value != null) d[key] = value;
+		}
+
+		private static object AsArrayOrSingleItem<T>(IEnumerable<T> items)
+		{
+			if (items == null || !items.Any())
+				return null;
+
+			if (items.Count() == 1)
+				return items.First();
+
+			return items;
+		}
+
+		private static Dictionary<string, object> Flatten(Dictionary<string, object> original, string prefix = "",
+			Dictionary<string, object> current = null)
+		{
+			current ??= new Dictionary<string, object>();
+			foreach (var property in original)
+			{
+				// The analysis and similarity sub-objects must stay intact (they are extracted into typed
+				// properties later); everything else is flattened into dotted keys (e.g. index.number_of_shards).
+				var isPreserved = property.Key == UpdatableIndexSettings.Analysis
+					|| property.Key == Similarity
+					|| property.Key.EndsWith(".analysis")
+					|| property.Key.EndsWith(".similarity");
+
+				// The value may arrive either as a nested Dictionary<string, object> (from the base
+				// DynamicDictionary/object handling) or as a JsonElement object, depending on the path.
+				if (!isPreserved && TryGetNestedObject(property.Value, out var nested))
+				{
+					Flatten(nested, prefix + property.Key + ".", current);
+				}
+				else
+				{
+					current[prefix + property.Key] = property.Value;
+				}
+			}
+			return current;
+		}
+
+		/// <summary>
+		/// Extracts a nested JSON object as a <see cref="Dictionary{TKey,TValue}"/> when the value is either a
+		/// <see cref="Dictionary{TKey,TValue}"/> (from the base object/DynamicDictionary handling) or a
+		/// <see cref="JsonElement"/> of kind <see cref="JsonValueKind.Object"/>. Returns false otherwise.
+		/// </summary>
+		private static bool TryGetNestedObject(object value, out Dictionary<string, object> nested)
+		{
+			switch (value)
+			{
+				case Dictionary<string, object> dict:
+					nested = dict;
+					return true;
+				case JsonElement element when element.ValueKind == JsonValueKind.Object:
+					nested = JsonSerializer.Deserialize<Dictionary<string, object>>(element.GetRawText());
+					return nested != null;
+				default:
+					nested = null;
+					return false;
+			}
+		}
+
+		private static void SetValue<T>(Dictionary<string, object> settings, string key, Action<T> assign, JsonSerializerOptions settingsOptions = null)
+		{
+			if (!settings.TryGetValue(key, out var raw))
+				return;
+
+			try
+			{
+				T value;
+				if (raw is JsonElement element)
+				{
+					value = element.Deserialize<T>();
+				}
+				else if (raw is T typed)
+				{
+					value = typed;
+				}
+				else if (raw != null && typeof(T) == typeof(int?))
+				{
+					value = (T)(object)Convert.ToInt32(raw);
+				}
+				else if (raw != null && typeof(T) == typeof(bool?))
+				{
+					value = (T)(object)Convert.ToBoolean(raw);
+				}
+				else if (raw != null && settingsOptions != null)
+				{
+					// Round-trip through the options so string/scalar wire values convert to a typed setting
+					// via its registered converter (e.g. "0-all" -> AutoExpandReplicas, "1s" -> Time). STJ
+					// cannot deserialize a bare string token to these types otherwise.
+					var json = JsonSerializer.Serialize(raw, raw.GetType(), settingsOptions);
+					value = JsonSerializer.Deserialize<T>(json, settingsOptions);
+				}
+				else
+				{
+					value = default;
+				}
+
+				assign(value);
+				// Do NOT remove the key: the typed extraction is additive. The original wire entry must
+				// remain in the flattened dictionary so it is copied into the settings backing dictionary
+				// (IIsADictionary), matching the pre-STJ formatter (which both assigned the property and
+				// kept the entry). Otherwise a template whose only setting is e.g. number_of_shards would
+				// deserialize to an empty Settings dictionary.
+			}
+			catch
+			{
+				// If conversion fails, leave it in the dictionary
+			}
+		}
+	}
+
+	/// <summary>
+	/// Handles serialization/deserialization of <see cref="IIndexSettings"/>.
+	/// Delegates to <see cref="DynamicIndexSettingsConverter"/> for the shared properties,
+	/// then adds the fixed index settings.
+	/// </summary>
+	internal class IndexSettingsConverter : JsonConverter<IIndexSettings>
+	{
+		public override IIndexSettings Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var indexSettings = new IndexSettings();
+			DynamicIndexSettingsConverter.ReadKnownSettings(ref reader, indexSettings, options);
+			return indexSettings;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IIndexSettings value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			IDictionary<string, object> d = value;
+
+			// Flush dynamic index settings typed properties into the dictionary
+			DynamicIndexSettingsConverter.FlushDynamicProperties(value, d);
+
+			// Flush fixed index settings typed properties into the dictionary
+			DynamicIndexSettingsConverter.FlushFixedProperties(value, d);
+
+			// Write the full dictionary
+			DynamicIndexSettingsConverter.WriteDictionary(writer, d, options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Indices/IndexSettings/Settings/IndexSettings.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/Settings/IndexSettings.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// The settings for an index
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(IndexSettings))]
 	[JsonFormatter(typeof(IndexSettingsFormatter))]
 	public interface IIndexSettings : IDynamicIndexSettings
 	{

--- a/src/OpenSearch.Client/Indices/IndexSettings/UpdateIndexSettings/UpdateIndexSettingsRequest.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/UpdateIndexSettings/UpdateIndexSettingsRequest.cs
@@ -27,11 +27,13 @@
 */
 
 using System;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[MapsApi("indices.put_settings.json")]
+	[JsonConverter(typeof(UpdateIndexSettingsRequestConverter))]
 	[JsonFormatter(typeof(UpdateIndexSettingsRequestFormatter))]
 	public partial interface IUpdateIndexSettingsRequest
 	{
@@ -74,4 +76,6 @@ namespace OpenSearch.Client
 			DynamicIndexSettingsFormatter.Serialize(ref writer, value.IndexSettings, formatterResolver);
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Indices/IndexSettings/UpdateIndexSettings/UpdateIndexSettingsRequestConverter.cs
+++ b/src/OpenSearch.Client/Indices/IndexSettings/UpdateIndexSettings/UpdateIndexSettingsRequestConverter.cs
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes the body of an update-index-settings request directly as the
+	/// <see cref="IDynamicIndexSettings"/> content (the flattened settings object), rather than
+	/// wrapping it in an <c>{ "indexSettings": { ... } }</c> envelope. Replaces the Utf8Json
+	/// <c>UpdateIndexSettingsRequestFormatter</c>.
+	/// </summary>
+	internal sealed class UpdateIndexSettingsRequestConverter : JsonConverter<IUpdateIndexSettingsRequest>
+	{
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(IUpdateIndexSettingsRequest).IsAssignableFrom(typeToConvert);
+
+		public override IUpdateIndexSettingsRequest Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var settings = JsonSerializer.Deserialize<IDynamicIndexSettings>(ref reader, options);
+			return new UpdateIndexSettingsRequest { IndexSettings = settings };
+		}
+
+		public override void Write(Utf8JsonWriter writer, IUpdateIndexSettingsRequest value, JsonSerializerOptions options)
+		{
+			if (value?.IndexSettings == null)
+			{
+				writer.WriteStartObject();
+				writer.WriteEndObject();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value.IndexSettings, typeof(IDynamicIndexSettings), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Indices/MappingManagement/GetFieldMapping/GetFieldMappingResponse.cs
+++ b/src/OpenSearch.Client/Indices/MappingManagement/GetFieldMapping/GetFieldMappingResponse.cs
@@ -31,8 +31,8 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
 using OpenSearch.Net;
-using OpenSearch.Net.Utf8Json;
 using static OpenSearch.Client.Infer;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {

--- a/src/OpenSearch.Client/Indices/Similarity/BM25Similarity.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/BM25Similarity.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// and Mike Gatford. Okapi at TREC-3. In Proceedings of the Third Text Retrieval Conference (TREC 1994). Gaithersburg,
 	/// USA, November 1994.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IBM25Similarity : ISimilarity
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Indices/Similarity/DFI/DFISimilarity.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/DFI/DFISimilarity.cs
@@ -27,12 +27,14 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// Similarity that implements the divergence from independence model
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IDFISimilarity : ISimilarity
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Indices/Similarity/DFR/DFRSimilarity.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/DFR/DFRSimilarity.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -43,6 +44,7 @@ namespace OpenSearch.Client
 	/// chosen to match the
 	/// names of their counterparts in the Terrier IR engine.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IDFRSimilarity : ISimilarity
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Indices/Similarity/IB/IBSimilarity.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/IB/IBSimilarity.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 // ReSharper disable InconsistentNaming
 
 namespace OpenSearch.Client
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// is primarily determined by the repetitive usage of its basic elements.
 	/// For written texts this challenge would correspond to comparing the writing styles of different authors.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IIBSimilarity : ISimilarity
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Indices/Similarity/LMDirichletSimilarity.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/LMDirichletSimilarity.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A similarity with Bayesian smoothing using Dirichlet priors.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ILMDirichletSimilarity : ISimilarity
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Indices/Similarity/LMJelinekMercerSimilarity.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/LMJelinekMercerSimilarity.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// A similarity that attempts to capture important patterns in the text,
 	/// while leaving out noise.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ILMJelinekMercerSimilarity : ISimilarity
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Indices/Similarity/ScriptedSimilarity.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/ScriptedSimilarity.cs
@@ -28,12 +28,14 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A similarity that allows a script to be used in order to specify how scores should be computed.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IScriptedSimilarity : ISimilarity
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Indices/Similarity/Similarity.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/Similarity.cs
@@ -34,6 +34,8 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A similarity.
 	/// </summary>
+	[InterfaceDataContract]
+	[System.Text.Json.Serialization.JsonConverter(typeof(SimilarityConverter))]
 	[JsonFormatter(typeof(SimilarityFormatter))]
 	public interface ISimilarity
 	{

--- a/src/OpenSearch.Client/Indices/Similarity/SimilarityConverter.cs
+++ b/src/OpenSearch.Client/Indices/Similarity/SimilarityConverter.cs
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using InterfaceDataContractAttribute = OpenSearch.Net.Utf8Json.InterfaceDataContractAttribute;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes <see cref="ISimilarity"/> by dispatching on its <c>type</c> discriminator to the
+	/// matching concrete similarity, falling back to <see cref="CustomSimilarity"/>. Serializes via the
+	/// runtime type so the concrete <see cref="InterfaceDataContractAttribute"/> contract is emitted.
+	/// Replaces the Utf8Json <c>SimilarityFormatter</c>.
+	/// </summary>
+	internal sealed class SimilarityConverter : JsonConverter<ISimilarity>
+	{
+		private static readonly Dictionary<string, Type> SimilarityTypes = new()
+		{
+			["BM25"] = typeof(BM25Similarity),
+			["LMDirichlet"] = typeof(LMDirichletSimilarity),
+			["DFR"] = typeof(DFRSimilarity),
+			["DFI"] = typeof(DFISimilarity),
+			["IB"] = typeof(IBSimilarity),
+			["LMJelinekMercer"] = typeof(LMJelinekMercerSimilarity),
+			["scripted"] = typeof(ScriptedSimilarity),
+		};
+
+		public override ISimilarity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			var targetType = typeof(CustomSimilarity);
+			if (root.TryGetProperty("type", out var typeProp) && typeProp.ValueKind == JsonValueKind.String)
+			{
+				var type = typeProp.GetString();
+				if (type != null && SimilarityTypes.TryGetValue(type, out var mapped))
+					targetType = mapped;
+			}
+
+			return (ISimilarity)JsonSerializer.Deserialize(root.GetRawText(), targetType, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, ISimilarity value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Ingest/Processor.cs
+++ b/src/OpenSearch.Client/Ingest/Processor.cs
@@ -29,12 +29,14 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary> Ingest pipelines are composed of one or more processors </summary>
 	[InterfaceDataContract]
+	[JsonConverter(typeof(ProcessorConverter))]
 	[JsonFormatter(typeof(ProcessorFormatter))]
 	public interface IProcessor
 	{

--- a/src/OpenSearch.Client/Ingest/ProcessorConverter.cs
+++ b/src/OpenSearch.Client/Ingest/ProcessorConverter.cs
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IProcessor"/> that handles
+	/// the single-key object polymorphic dispatch pattern used by OpenSearch ingest pipelines.
+	/// Each processor is serialized as <c>{"processor_name": { ... }}</c>.
+	/// </summary>
+	internal sealed class ProcessorConverter : JsonConverter<IProcessor>
+	{
+		/// <summary>
+		/// Maps JSON processor name → concrete processor type for deserialization.
+		/// </summary>
+		private static readonly Dictionary<string, Type> ProcessorTypes = new(StringComparer.OrdinalIgnoreCase)
+		{
+			["attachment"] = typeof(AttachmentProcessor),
+			["append"] = typeof(AppendProcessor),
+			["convert"] = typeof(ConvertProcessor),
+			["date"] = typeof(DateProcessor),
+			["date_index_name"] = typeof(DateIndexNameProcessor),
+			["dot_expander"] = typeof(DotExpanderProcessor),
+			["fail"] = typeof(FailProcessor),
+			["foreach"] = typeof(ForeachProcessor),
+			["json"] = typeof(JsonProcessor),
+			["user_agent"] = typeof(UserAgentProcessor),
+			["kv"] = typeof(KeyValueProcessor),
+			["geoip"] = typeof(GeoIpProcessor),
+			["grok"] = typeof(GrokProcessor),
+			["gsub"] = typeof(GsubProcessor),
+			["join"] = typeof(JoinProcessor),
+			["lowercase"] = typeof(LowercaseProcessor),
+			["remove"] = typeof(RemoveProcessor),
+			["rename"] = typeof(RenameProcessor),
+			["script"] = typeof(ScriptProcessor),
+			["set"] = typeof(SetProcessor),
+			["sort"] = typeof(SortProcessor),
+			["split"] = typeof(SplitProcessor),
+			["trim"] = typeof(TrimProcessor),
+			["uppercase"] = typeof(UppercaseProcessor),
+			["urldecode"] = typeof(UrlDecodeProcessor),
+			["bytes"] = typeof(BytesProcessor),
+			["dissect"] = typeof(DissectProcessor),
+			["pipeline"] = typeof(PipelineProcessor),
+			["drop"] = typeof(DropProcessor),
+			["csv"] = typeof(CsvProcessor),
+			["uri_parts"] = typeof(UriPartsProcessor),
+			["fingerprint"] = typeof(FingerprintProcessor),
+			["community_id"] = typeof(NetworkCommunityIdProcessor),
+			["network_direction"] = typeof(NetworkDirectionProcessor),
+			["text_embedding"] = typeof(TextEmbeddingProcessor),
+		};
+
+		public override IProcessor Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			// Read the first (and only) property name — this is the processor type key
+			reader.Read();
+			if (reader.TokenType != JsonTokenType.PropertyName)
+				return null;
+
+			var processorName = reader.GetString();
+			reader.Read(); // Move to the value (the processor object)
+
+			IProcessor processor = null;
+
+			if (processorName != null && ProcessorTypes.TryGetValue(processorName, out var processorType))
+			{
+				processor = (IProcessor)JsonSerializer.Deserialize(ref reader, processorType, options);
+			}
+			else
+			{
+				// Unknown processor type — skip the value to maintain forward compatibility
+				reader.Skip();
+			}
+
+			// Read past any additional properties and the end of the outer object
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType == JsonTokenType.PropertyName)
+				{
+					reader.Read();
+					reader.Skip();
+				}
+			}
+
+			return processor;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IProcessor value, JsonSerializerOptions options)
+		{
+			if (value?.Name == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(value.Name);
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Ingest/Processors/AppendProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/AppendProcessor.cs
@@ -37,6 +37,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(AppendProcessor))]
 	public interface IAppendProcessor : IProcessor
 	{
 		[DataMember(Name ="field")]

--- a/src/OpenSearch.Client/Ingest/Processors/BytesProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/BytesProcessor.cs
@@ -39,6 +39,7 @@ namespace OpenSearch.Client
 	/// An error will occur if the field is not a supported format or resultant value exceeds 2^63.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(BytesProcessor))]
 	public interface IBytesProcessor : IProcessor
 	{
 		/// <summary> The field to convert bytes from </summary>

--- a/src/OpenSearch.Client/Ingest/Processors/ConvertProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/ConvertProcessor.cs
@@ -41,6 +41,7 @@ namespace OpenSearch.Client
 	/// If the field value is an array, all members will be converted.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(ConvertProcessor))]
 	public interface IConvertProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/CsvProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/CsvProcessor.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// Any empty field in CSV will be skipped.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(CsvProcessor))]
 	public interface ICsvProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/DateIndexNameProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DateIndexNameProcessor.cs
@@ -41,6 +41,7 @@ namespace OpenSearch.Client
 	/// by using the date math index name support.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DateIndexNameProcessor))]
 	public interface IDateIndexNameProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/DateProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DateProcessor.cs
@@ -35,6 +35,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(DateProcessor))]
 	public interface IDateProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/DissectProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DissectProcessor.cs
@@ -39,6 +39,7 @@ namespace OpenSearch.Client
 	/// This allows dissect’s syntax to be simple and, for some cases faster, than the Grok Processor.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DissectProcessor))]
 	public interface IDissectProcessor : IProcessor
 	{
 		/// <summary> The field to dissect </summary>

--- a/src/OpenSearch.Client/Ingest/Processors/DotExpanderProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DotExpanderProcessor.cs
@@ -39,6 +39,7 @@ namespace OpenSearch.Client
 	/// Otherwise these fields can’t be accessed by any processor.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DotExpanderProcessor))]
 	public interface IDotExpanderProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/DropProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/DropProcessor.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// Drops the document without raising any errors. This is useful to prevent the document from getting indexed based on some condition.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DropProcessor))]
 	public interface IDropProcessor : IProcessor { }
 
 	/// <inheritdoc cref="IDropProcessor"/>

--- a/src/OpenSearch.Client/Ingest/Processors/FailProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/FailProcessor.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// fail and want to relay a specific message to the requester.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(FailProcessor))]
 	public interface IFailProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/FingerprintProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/FingerprintProcessor.cs
@@ -34,6 +34,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(FingerprintProcessor))]
 	public interface IFingerprintProcessor : IProcessor
 	{
 		[DataMember(Name = "fields")]

--- a/src/OpenSearch.Client/Ingest/Processors/ForeachProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/ForeachProcessor.cs
@@ -45,6 +45,7 @@ namespace OpenSearch.Client
 	/// should happen to each element, array fields can easily be preprocessed.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(ForeachProcessor))]
 	public interface IForeachProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/GrokProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/GrokProcessor.cs
@@ -35,6 +35,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(GrokProcessor))]
 	public interface IGrokProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/GsubProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/GsubProcessor.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// If the field is not a string, the processor will throw an exception.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(GsubProcessor))]
 	public interface IGsubProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/JoinProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/JoinProcessor.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// character between each element. Throws an error when the field is not an array.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(JoinProcessor))]
 	public interface IJoinProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/JsonProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/JsonProcessor.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// Converts a JSON string into a structured JSON object.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(JsonProcessor))]
 	public interface IJsonProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/KeyValueProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/KeyValueProcessor.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// Processor to automatically parse messages (or specific event fields) which are of the key=value variety.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(KeyValueProcessor))]
 	public interface IKeyValueProcessor : IProcessor
 	{
 		/// <summary> List of keys to exclude from document </summary>

--- a/src/OpenSearch.Client/Ingest/Processors/LowercaseProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/LowercaseProcessor.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// Converts a string to its lowercase equivalent.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(LowercaseProcessor))]
 	public interface ILowercaseProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/NetworkCommunityIdProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/NetworkCommunityIdProcessor.cs
@@ -34,6 +34,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(NetworkCommunityIdProcessor))]
 	public interface INetworkCommunityIdProcessor : IProcessor
 	{
 		[DataMember(Name = "destination_ip")]

--- a/src/OpenSearch.Client/Ingest/Processors/NetworkDirectionProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/NetworkDirectionProcessor.cs
@@ -35,6 +35,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(NetworkDirectionProcessor))]
 	public interface INetworkDirectionProcessor : IProcessor
 	{
 		[DataMember(Name = "destination_ip")]

--- a/src/OpenSearch.Client/Ingest/Processors/PipelineProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/PipelineProcessor.cs
@@ -33,6 +33,7 @@ namespace OpenSearch.Client
 {
 	/// <summary> Executes another pipeline.</summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(PipelineProcessor))]
 	public interface IPipelineProcessor : IProcessor
 	{
 		/// <summary>The name of the pipeline to execute. </summary>

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/AttachmentProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/AttachmentProcessor.cs
@@ -43,6 +43,7 @@ namespace OpenSearch.Client
 	/// Requires the Ingest Attachment Processor Plugin to be installed on the cluster.
 	/// </remarks>
 	[InterfaceDataContract]
+	[ReadAs(typeof(AttachmentProcessor))]
 	public interface IAttachmentProcessor : IProcessor
 	{
 		/// <summary> The field to get the base64 encoded field from.</summary>

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/GeoIpProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/GeoIpProcessor.cs
@@ -44,6 +44,7 @@ namespace OpenSearch.Client
 	/// Requires the Ingest Geoip Processor Plugin to be installed on the cluster.
 	/// </remarks>
 	[InterfaceDataContract]
+	[ReadAs(typeof(GeoIpProcessor))]
 	public interface IGeoIpProcessor : IProcessor
 	{
 		[DataMember(Name ="database_file")]

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/NeuralSearch/InferenceProcessorBase.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/NeuralSearch/InferenceProcessorBase.cs
@@ -13,6 +13,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client;
 
+[InterfaceDataContract]
 [JsonFormatter(typeof(VerbatimDictionaryKeysFormatter<InferenceFieldMap, IInferenceFieldMap, Field, Field>))]
 public interface IInferenceFieldMap : IIsADictionary<Field, Field> { }
 

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/NeuralSearch/TextEmbeddingProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/NeuralSearch/TextEmbeddingProcessor.cs
@@ -13,6 +13,7 @@ namespace OpenSearch.Client;
 /// The <c>text_embedding</c> processor is used to generate vector embeddings from text fields for <a href="https://opensearch.org/docs/latest/search-plugins/semantic-search/">semantic search</a>.
 /// </summary>
 [InterfaceDataContract]
+[ReadAs(typeof(TextEmbeddingProcessor))]
 public interface ITextEmbeddingProcessor : IInferenceProcessor
 {
 }

--- a/src/OpenSearch.Client/Ingest/Processors/Plugins/UserAgentProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/Plugins/UserAgentProcessor.cs
@@ -44,6 +44,7 @@ namespace OpenSearch.Client
 	/// Requires the UserAgent Processor Plugin to be installed on the cluster.
 	/// </remarks>
 	[InterfaceDataContract]
+	[ReadAs(typeof(UserAgentProcessor))]
 	public interface IUserAgentProcessor : IProcessor
 	{
 		[DataMember(Name ="field")]

--- a/src/OpenSearch.Client/Ingest/Processors/RemoveProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/RemoveProcessor.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// Removes existing fields. If one field doesn't exist, an exception will be thrown.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(RemoveProcessor))]
 	public interface IRemoveProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/RenameProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/RenameProcessor.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// Renames an existing field. If the field doesn't exist or the new name is already used, an exception will be thrown.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(RenameProcessor))]
 	public interface IRenameProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/ScriptProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/ScriptProcessor.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// Allows inline and stored scripts to be executed within ingest pipelines.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(ScriptProcessor))]
 	public interface IScriptProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/SetProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/SetProcessor.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// If the field already exists, its value will be replaced with the provided one.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(SetProcessor))]
 	public interface ISetProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/SortProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/SortProcessor.cs
@@ -40,6 +40,7 @@ namespace OpenSearch.Client
 	///  of strings and numbers will be sorted lexicographically.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(SortProcessor))]
 	public interface ISortProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/SplitProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/SplitProcessor.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// Splits a field into an array using a separator character. Only works on string fields
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(SplitProcessor))]
 	public interface ISplitProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/TrimProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/TrimProcessor.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// Trims whitespace from field. This only works on leading and trailing whitespace
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(TrimProcessor))]
 	public interface ITrimProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/UppercaseProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/UppercaseProcessor.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// Converts a string to its uppercase equivalent.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(UppercaseProcessor))]
 	public interface IUppercaseProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/UriPartsProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/UriPartsProcessor.cs
@@ -34,6 +34,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(UriPartsProcessor))]
 	public interface IUriPartsProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Ingest/Processors/UrlDecodeProcessor.cs
+++ b/src/OpenSearch.Client/Ingest/Processors/UrlDecodeProcessor.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// URL-decodes a string
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(UrlDecodeProcessor))]
 	public interface IUrlDecodeProcessor : IProcessor
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchPropertyAttributeBase.cs
+++ b/src/OpenSearch.Client/Mapping/AttributeBased/OpenSearchPropertyAttributeBase.cs
@@ -37,7 +37,7 @@ namespace OpenSearch.Client
 {
 	[AttributeUsage(AttributeTargets.Property)]
 	[DataContract]
-	public abstract class OpenSearchPropertyAttributeBase : Attribute, IProperty, IPropertyMapping, IJsonProperty
+	public abstract class OpenSearchPropertyAttributeBase : Attribute, IProperty, IPropertyMapping
 	{
 		protected OpenSearchPropertyAttributeBase(FieldType type) => Self.Type = type.GetStringValue();
 

--- a/src/OpenSearch.Client/Mapping/DynamicMapping.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicMapping.cs
@@ -99,4 +99,6 @@ namespace OpenSearch.Client
 			}
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplateContainer.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplateContainer.cs
@@ -32,9 +32,11 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[System.Text.Json.Serialization.JsonConverter(typeof(DynamicTemplatesConverter))]
 	[JsonFormatter(typeof(DynamicTemplatesInterfaceFormatter))]
 	public interface IDynamicTemplateContainer : IIsADictionary<string, IDynamicTemplate> { }
 
+	[System.Text.Json.Serialization.JsonConverter(typeof(DynamicTemplatesConverter))]
 	[JsonFormatter(typeof(DynamicTemplatesFormatter))]
 	public class DynamicTemplateContainer : IsADictionaryBase<string, IDynamicTemplate>, IDynamicTemplateContainer
 	{

--- a/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplatesConverter.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicTemplate/DynamicTemplatesConverter.cs
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IDynamicTemplateContainer"/> that serializes
+	/// the container as a JSON array of single-key objects (<c>[ { "name": { ...template... } } ]</c>),
+	/// matching the OpenSearch dynamic templates wire format, rather than as a plain object.
+	/// </summary>
+	internal sealed class DynamicTemplatesConverter : JsonConverter<IDynamicTemplateContainer>
+	{
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(IDynamicTemplateContainer).IsAssignableFrom(typeToConvert);
+
+		public override IDynamicTemplateContainer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartArray)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var container = new DynamicTemplateContainer();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+			{
+				if (reader.TokenType != JsonTokenType.StartObject)
+					continue;
+
+				// Each array element is a single-key object { "<name>": { ...template... } }
+				reader.Read();
+				while (reader.TokenType != JsonTokenType.EndObject)
+				{
+					var name = reader.GetString();
+					reader.Read();
+					var template = JsonSerializer.Deserialize<IDynamicTemplate>(ref reader, options);
+					if (name != null && template != null)
+						container.Add(name, template);
+					reader.Read();
+				}
+			}
+
+			return container;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IDynamicTemplateContainer value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartArray();
+
+			foreach (var kvp in value)
+			{
+				if (kvp.Value == null)
+					continue;
+
+				writer.WriteStartObject();
+				writer.WritePropertyName(kvp.Key);
+				JsonSerializer.Serialize(writer, kvp.Value, kvp.Value.GetType(), options);
+				writer.WriteEndObject();
+			}
+
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicTemplate/SingleMapping.cs
@@ -153,6 +153,10 @@ namespace OpenSearch.Client
 		public IProperty KnnVector(Func<KnnVectorPropertyDescriptor<T>, IKnnVectorProperty> selector) =>
 			selector?.Invoke(new KnnVectorPropertyDescriptor<T>());
 
+		/// <inheritdoc />
+		public IProperty Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector) =>
+			selector?.Invoke(new WildcardPropertyDescriptor<T>());
+
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public IProperty Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector = null) =>
 			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));

--- a/src/OpenSearch.Client/Mapping/MetaFields/FieldMappingConverter.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/FieldMappingConverter.cs
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IFieldMapping"/> that delegates
+	/// to <see cref="IProperty"/> deserialization since all field mappings are properties.
+	/// </summary>
+	internal sealed class FieldMappingConverter : JsonConverter<IFieldMapping>
+	{
+		public override IFieldMapping Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			// IProperty extends IFieldMapping, and PropertyConverter handles the type discrimination.
+			// Deserialize as IProperty which will trigger PropertyConverter.
+			return JsonSerializer.Deserialize<IProperty>(ref reader, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, IFieldMapping value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// All IFieldMapping implementations are IProperty, delegate to PropertyConverter
+			if (value is IProperty property)
+			{
+				JsonSerializer.Serialize(writer, property, options);
+			}
+			else
+			{
+				// Fallback: serialize using the actual runtime type
+				JsonSerializer.Serialize(writer, value, value.GetType(), options);
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/Mapping/MetaFields/FieldNames/FieldNamesField.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/FieldNames/FieldNamesField.cs
@@ -27,10 +27,12 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(FieldNamesField))]
+	[InterfaceDataContract]
 	public interface IFieldNamesField : IFieldMapping
 	{
 		[DataMember(Name ="enabled")]

--- a/src/OpenSearch.Client/Mapping/MetaFields/IFieldMapping.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/IFieldMapping.cs
@@ -26,10 +26,13 @@
 *  under the License.
 */
 
+using System.Text.Json.Serialization;
+
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A document field mapping in OpenSearch
 	/// </summary>
+	[JsonConverter(typeof(FieldMappingConverter))]
 	public interface IFieldMapping { }
 }

--- a/src/OpenSearch.Client/Mapping/MetaFields/Routing/RoutingField.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/Routing/RoutingField.cs
@@ -27,10 +27,12 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(RoutingField))]
+	[InterfaceDataContract]
 	public interface IRoutingField : IFieldMapping
 	{
 		[DataMember(Name ="required")]

--- a/src/OpenSearch.Client/Mapping/MetaFields/Size/SizeField.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/Size/SizeField.cs
@@ -27,10 +27,12 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(SizeField))]
+	[InterfaceDataContract]
 	public interface ISizeField : IFieldMapping
 	{
 		[DataMember(Name ="enabled")]

--- a/src/OpenSearch.Client/Mapping/MetaFields/Source/SourceField.cs
+++ b/src/OpenSearch.Client/Mapping/MetaFields/Source/SourceField.cs
@@ -28,10 +28,12 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(SourceField))]
+	[InterfaceDataContract]
 	public interface ISourceField : IFieldMapping
 	{
 		[DataMember(Name ="compress")]

--- a/src/OpenSearch.Client/Mapping/Types/Complex/Nested/NestedProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Complex/Nested/NestedProperty.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// and aggregations.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(NestedProperty))]
 	public interface INestedProperty : IObjectProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Complex/Object/ObjectProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Complex/Object/ObjectProperty.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// A mapping for an inner object
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(ObjectProperty))]
 	public interface IObjectProperty : ICoreProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Binary/BinaryProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Binary/BinaryProperty.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// The field is not stored by default and is not searchable
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(BinaryProperty))]
 	public interface IBinaryProperty : IDocValuesProperty { }
 
 	[DebuggerDisplay("{DebugDisplay}")]

--- a/src/OpenSearch.Client/Mapping/Types/Core/Boolean/BooleanProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Boolean/BooleanProperty.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// The boolean fields accepts true and false values
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(BooleanProperty))]
 	public interface IBooleanProperty : IDocValuesProperty
 	{
 		[DataMember(Name = "boost")]

--- a/src/OpenSearch.Client/Mapping/Types/Core/Date/DateProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Date/DateProperty.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// The date datatype maps a field as a date in OpenSearch.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DateProperty))]
 	public interface IDateProperty : IDocValuesProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Core/DateNanos/DateNanosProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/DateNanos/DateNanosProperty.cs
@@ -39,6 +39,7 @@ namespace OpenSearch.Client
 	/// dates from roughly 1970 to 2262.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DateNanosProperty))]
 	public interface IDateNanosProperty : IDocValuesProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/Children.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/Children.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[System.Text.Json.Serialization.JsonConverter(typeof(ChildrenConverter))]
 	[JsonFormatter(typeof(ChildrenFormatter))]
 	public class Children : List<RelationName>
 	{

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/ChildrenConverter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/ChildrenConverter.cs
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="Children"/> that serializes a single
+	/// relation as a scalar string and multiple relations as a JSON array of strings.
+	/// Individual <see cref="RelationName"/> elements are delegated to the options-registered
+	/// <see cref="RelationNameConverter"/> (settings-aware name inference).
+	/// </summary>
+	internal sealed class ChildrenConverter : JsonConverter<Children>
+	{
+		public override Children Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+		{
+			var children = new Children();
+
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return children;
+				case JsonTokenType.String:
+				{
+					var relation = JsonSerializer.Deserialize<RelationName>(ref reader, options);
+					if (relation != null) children.Add(relation);
+					return children;
+				}
+				case JsonTokenType.StartArray:
+				{
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+					{
+						var relation = JsonSerializer.Deserialize<RelationName>(ref reader, options);
+						if (relation != null) children.Add(relation);
+					}
+					return children;
+				}
+				default:
+					reader.Skip();
+					return children;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, Children value, JsonSerializerOptions options)
+		{
+			if (value == null || value.Count == 0)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			if (value.Count == 1)
+			{
+				JsonSerializer.Serialize(writer, value[0], options);
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach (var child in value)
+				JsonSerializer.Serialize(writer, child, options);
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinFieldConverter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinFieldConverter.cs
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	internal sealed class JoinFieldConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public JoinFieldConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(JoinField);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			new JoinFieldConverter(_settings);
+	}
+
+	/// <summary>
+	/// Serializes <see cref="JoinField"/> as either a bare parent relation name string, or a
+	/// <c>{ "name": ..., "parent": ... }</c> object for a child relation. Replaces the Utf8Json
+	/// <c>JoinFieldFormatter</c>.
+	/// </summary>
+	internal sealed class JoinFieldConverter : JsonConverter<JoinField>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public JoinFieldConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override JoinField Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var parent = reader.GetString();
+				return new JoinField(new JoinField.Parent(parent));
+			}
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			Id parentId = null;
+			string name = null;
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var propertyName = reader.GetString();
+				reader.Read();
+
+				switch (propertyName)
+				{
+					case "parent":
+						parentId = JsonSerializer.Deserialize<Id>(ref reader, options);
+						break;
+					case "name":
+						name = reader.GetString();
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			return parentId != null
+				? new JoinField(new JoinField.Child(name, parentId))
+				: new JoinField(new JoinField.Parent(name));
+		}
+
+		public override void Write(Utf8JsonWriter writer, JoinField value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			switch (value.Tag)
+			{
+				case 0:
+					writer.WriteStringValue(_settings.Inferrer.RelationName(value.ParentOption.Name));
+					break;
+				case 1:
+					var child = value.ChildOption;
+					writer.WriteStartObject();
+					writer.WritePropertyName("name");
+					writer.WriteStringValue(_settings.Inferrer.RelationName(child.Name));
+					writer.WritePropertyName("parent");
+					var id = (child.ParentId as IUrlParameter)?.GetString(_settings);
+					writer.WriteStringValue(id);
+					writer.WriteEndObject();
+					break;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Join/JoinProperty.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// The join datatype is a special field that creates parent/child relation within documents of the same index.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(JoinProperty))]
 	public interface IJoinProperty : IProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Keyword/KeywordProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Keyword/KeywordProperty.cs
@@ -39,6 +39,7 @@ namespace OpenSearch.Client
 	/// Keyword fields are only searchable by their exact value.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(KeywordProperty))]
 	public interface IKeywordProperty : IDocValuesProperty
 	{
 		[DataMember(Name ="boost")]

--- a/src/OpenSearch.Client/Mapping/Types/Core/Number/NumberProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Number/NumberProperty.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// A numeric mapping that defaults to <c>float</c>.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(NumberProperty))]
 	public interface INumberProperty : IDocValuesProperty
 	{
 		[DataMember(Name = "coerce")]

--- a/src/OpenSearch.Client/Mapping/Types/Core/Percolator/PercolatorProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Percolator/PercolatorProperty.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// <see cref="IPercolateQuery"/> can use it to match provided documents.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(PercolatorProperty))]
 	public interface IPercolatorProperty : IProperty { }
 
 	/// <inheritdoc cref="IPercolatorProperty"/>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/DateRange/DateRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/DateRange/DateRangeProperty.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// A range of date values represented as unsigned 64-bit integer milliseconds elapsed since system epoch.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DateRangeProperty))]
 	public interface IDateRangeProperty : IRangeProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/DoubleRange/DoubleRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/DoubleRange/DoubleRangeProperty.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// A range of double-precision 64-bit IEEE 754 floating point values.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(DoubleRangeProperty))]
 	public interface IDoubleRangeProperty : IRangeProperty { }
 
 	/// <inheritdoc cref="IDoubleRangeProperty"/>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/FloatRange/FloatRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/FloatRange/FloatRangeProperty.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// A range of single-precision 32-bit IEEE 754 floating point values.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(FloatRangeProperty))]
 	public interface IFloatRangeProperty : IRangeProperty { }
 
 	/// <inheritdoc cref="IFloatRangeProperty"/>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/IntegerRange/IntegerRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/IntegerRange/IntegerRangeProperty.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// A range of signed 32-bit integers with a minimum value of -231 and maximum of 231-1.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(IntegerRangeProperty))]
 	public interface IIntegerRangeProperty : IRangeProperty { }
 
 	/// <inheritdoc cref="IIntegerRangeProperty"/>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/IpRange/IpRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/IpRange/IpRangeProperty.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// A range of ip values supporting either IPv4 or IPv6 (or mixed) addresses.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(IpRangeProperty))]
 	public interface IIpRangeProperty : IRangeProperty { }
 
 	/// <inheritdoc cref="IIpRangeProperty"/>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Range/LongRange/LongRangeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Range/LongRange/LongRangeProperty.cs
@@ -34,6 +34,7 @@ namespace OpenSearch.Client
 	/// A range of signed 64-bit integers with a minimum value of -263 and maximum of 263-1.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(LongRangeProperty))]
 	public interface ILongRangeProperty : IRangeProperty { }
 
 	/// <inheritdoc cref="ILongRangeProperty"/>

--- a/src/OpenSearch.Client/Mapping/Types/Core/RankFeature/RankFeatureProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/RankFeature/RankFeatureProperty.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// to boost documents in queries with a rank_feature query.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(RankFeatureProperty))]
 	public interface IRankFeatureProperty : IProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Core/RankFeatures/RankFeaturesProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/RankFeatures/RankFeaturesProperty.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// wouldn't be reasonable to add one field to the mappings for each of them.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(RankFeaturesProperty))]
 	public interface IRankFeaturesProperty : IProperty
 	{
 	}

--- a/src/OpenSearch.Client/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeProperty.cs
@@ -40,6 +40,7 @@ namespace OpenSearch.Client
 	/// and infix completion (i.e. matching terms at any position within the input) are supported.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(SearchAsYouTypeProperty))]
 	public interface ISearchAsYouTypeProperty : ICoreProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Core/Text/TextProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Core/Text/TextProperty.cs
@@ -41,6 +41,7 @@ namespace OpenSearch.Client
 	/// Text fields are not used for sorting and seldom used for aggregations
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(TextProperty))]
 	public interface ITextProperty : ICoreProperty
 	{
 		[DataMember(Name = "analyzer")]

--- a/src/OpenSearch.Client/Mapping/Types/FieldType.cs
+++ b/src/OpenSearch.Client/Mapping/Types/FieldType.cs
@@ -162,6 +162,12 @@ namespace OpenSearch.Client
 		RankFeatures,
 
 		[EnumMember(Value = "knn_vector")]
-		KnnVector
+		KnnVector,
+
+		/// <summary>
+		/// A wildcard field stores values optimised for wildcard grep-like queries.
+		/// </summary>
+		[EnumMember(Value = "wildcard")]
+		Wildcard
 	}
 }

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoPoint/GeoPointProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoPoint/GeoPointProperty.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// Data type mapping to map a property as a geopoint
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(GeoPointProperty))]
 	public interface IGeoPointProperty : IDocValuesProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -26,15 +26,22 @@
 *  under the License.
 */
 
+using System.Runtime.Serialization;
+using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[StringEnum]
 	public enum GeoOrientation
 	{
+		[EnumMember(Value = "cw")]
 		ClockWise,
+
+		[EnumMember(Value = "ccw")]
 		CounterClockWise
 	}
+
 
 	internal class GeoOrientationFormatter : IJsonFormatter<GeoOrientation>
 	{
@@ -118,4 +125,6 @@ namespace OpenSearch.Client
 			}
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoShapeProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Geo/GeoShape/GeoShapeProperty.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// Maps a property as a geo_shape field
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(GeoShapeProperty))]
 	public interface IGeoShapeProperty : IDocValuesProperty
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Mapping/Types/Properties.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Properties.cs
@@ -160,6 +160,9 @@ namespace OpenSearch.Client
 
 		/// <inheritdoc cref="IKnnVectorProperty" />
 		TReturnType KnnVector(Func<KnnVectorPropertyDescriptor<T>, IKnnVectorProperty> selector);
+
+		/// <inheritdoc cref="IWildcardProperty"/>
+		TReturnType Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector);
 	}
 
 	public partial class PropertiesDescriptor<T> where T : class
@@ -257,6 +260,9 @@ namespace OpenSearch.Client
 
 		/// <inheritdoc cref="IKnnVectorProperty" />
 		public PropertiesDescriptor<T> KnnVector(Func<KnnVectorPropertyDescriptor<T>, IKnnVectorProperty> selector) => SetProperty(selector);
+
+		/// <inheritdoc cref="IWildcardProperty"/>
+		public PropertiesDescriptor<T> Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector) => SetProperty(selector);
 
 		/// <summary>
 		/// Map a custom property.

--- a/src/OpenSearch.Client/Mapping/Types/PropertyBase.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertyBase.cs
@@ -30,8 +30,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Serialization;
-using OpenSearch.Net;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
@@ -39,6 +40,7 @@ namespace OpenSearch.Client
 	/// A mapping for a property type to a document field in OpenSearch
 	/// </summary>
 	[InterfaceDataContract]
+	[JsonConverter(typeof(PropertyConverter))]
 	[JsonFormatter(typeof(PropertyFormatter))]
 	public interface IProperty : IFieldMapping
 	{

--- a/src/OpenSearch.Client/Mapping/Types/PropertyConverter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertyConverter.cs
@@ -1,0 +1,239 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IProperty"/> that handles
+	/// the field-type discriminator pattern used by OpenSearch mappings.
+	/// Each property is serialized as a JSON object with a <c>"type"</c> field
+	/// that determines the concrete property type.
+	/// </summary>
+	internal sealed class PropertyConverter : JsonConverter<IProperty>
+	{
+		// Pre-computed property names for performance (Requirement 8.4)
+		private static readonly JsonEncodedText TypeProp = JsonEncodedText.Encode("type");
+		private static readonly JsonEncodedText PropertiesProp = JsonEncodedText.Encode("properties");
+
+		/// <summary>
+		/// Maps type string values from JSON to their corresponding concrete C# types.
+		/// </summary>
+		private static readonly Dictionary<string, Type> TypeMapping = new(StringComparer.OrdinalIgnoreCase)
+		{
+			["text"] = typeof(TextProperty),
+			["keyword"] = typeof(KeywordProperty),
+			["search_as_you_type"] = typeof(SearchAsYouTypeProperty),
+			["float"] = typeof(NumberProperty),
+			["double"] = typeof(NumberProperty),
+			["byte"] = typeof(NumberProperty),
+			["short"] = typeof(NumberProperty),
+			["integer"] = typeof(NumberProperty),
+			["long"] = typeof(NumberProperty),
+			["scaled_float"] = typeof(NumberProperty),
+			["half_float"] = typeof(NumberProperty),
+			["date"] = typeof(DateProperty),
+			["date_nanos"] = typeof(DateNanosProperty),
+			["boolean"] = typeof(BooleanProperty),
+			["binary"] = typeof(BinaryProperty),
+			["object"] = typeof(ObjectProperty),
+			["nested"] = typeof(NestedProperty),
+			["ip"] = typeof(IpProperty),
+			["geo_point"] = typeof(GeoPointProperty),
+			["geo_shape"] = typeof(GeoShapeProperty),
+			["completion"] = typeof(CompletionProperty),
+			["token_count"] = typeof(TokenCountProperty),
+			["murmur3"] = typeof(Murmur3HashProperty),
+			["percolator"] = typeof(PercolatorProperty),
+			["date_range"] = typeof(DateRangeProperty),
+			["double_range"] = typeof(DoubleRangeProperty),
+			["float_range"] = typeof(FloatRangeProperty),
+			["integer_range"] = typeof(IntegerRangeProperty),
+			["long_range"] = typeof(LongRangeProperty),
+			["ip_range"] = typeof(IpRangeProperty),
+			["join"] = typeof(JoinProperty),
+			["alias"] = typeof(FieldAliasProperty),
+			["rank_feature"] = typeof(RankFeatureProperty),
+			["rank_features"] = typeof(RankFeaturesProperty),
+			["knn_vector"] = typeof(KnnVectorProperty),
+		};
+
+		/// <summary>
+		/// Set of numeric type strings that map to <see cref="NumberProperty"/> and need
+		/// their <c>Type</c> property explicitly set to the original type string.
+		/// </summary>
+		private static readonly HashSet<string> NumericTypes = new(StringComparer.OrdinalIgnoreCase)
+		{
+			"float", "double", "byte", "short", "integer", "long", "scaled_float", "half_float"
+		};
+
+		public override IProperty Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			// Buffer the entire JSON object so we can peek at the "type" property
+			// and then deserialize the full object as the correct concrete type.
+			using var document = JsonDocument.ParseValue(ref reader);
+			var root = document.RootElement;
+
+			string typeString = null;
+
+			// Check for explicit "type" property
+			if (root.TryGetProperty("type", out var typeProp) && typeProp.ValueKind == JsonValueKind.String)
+			{
+				typeString = typeProp.GetString();
+			}
+			// If no "type" property but "properties" exists, infer as Object type
+			else if (root.TryGetProperty("properties", out _))
+			{
+				typeString = "object";
+			}
+
+			// Determine concrete type from type string
+			Type concreteType;
+			if (typeString != null && TypeMapping.TryGetValue(typeString, out var mappedType))
+			{
+				concreteType = mappedType;
+			}
+			else
+			{
+				// Default to ObjectProperty for unknown or missing type
+				concreteType = typeof(ObjectProperty);
+			}
+
+			// Deserialize the buffered JSON as the concrete type
+			var rawJson = root.GetRawText();
+			var property = (IProperty)JsonSerializer.Deserialize(rawJson, concreteType, options);
+
+			// For NumberProperty, ensure the type string is preserved exactly
+			// (e.g., "integer", "float", etc.) since multiple type strings map to NumberProperty
+			if (property != null && typeString != null && NumericTypes.Contains(typeString))
+			{
+				property.Type = typeString;
+			}
+
+			return property;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IProperty value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Serialize using the actual runtime type to ensure all properties are written
+			// including the "type" discriminator property
+			switch (value)
+			{
+				case ITextProperty textProperty:
+					JsonSerializer.Serialize(writer, textProperty, options);
+					break;
+				case IKeywordProperty keywordProperty:
+					JsonSerializer.Serialize(writer, keywordProperty, options);
+					break;
+				case INumberProperty numberProperty:
+					JsonSerializer.Serialize(writer, numberProperty, options);
+					break;
+				case IDateProperty dateProperty:
+					JsonSerializer.Serialize(writer, dateProperty, options);
+					break;
+				case IBooleanProperty booleanProperty:
+					JsonSerializer.Serialize(writer, booleanProperty, options);
+					break;
+				case INestedProperty nestedProperty:
+					JsonSerializer.Serialize(writer, nestedProperty, options);
+					break;
+				case IObjectProperty objectProperty:
+					JsonSerializer.Serialize(writer, objectProperty, options);
+					break;
+				case ISearchAsYouTypeProperty searchAsYouTypeProperty:
+					JsonSerializer.Serialize(writer, searchAsYouTypeProperty, options);
+					break;
+				case IDateNanosProperty dateNanosProperty:
+					JsonSerializer.Serialize(writer, dateNanosProperty, options);
+					break;
+				case IBinaryProperty binaryProperty:
+					JsonSerializer.Serialize(writer, binaryProperty, options);
+					break;
+				case IIpProperty ipProperty:
+					JsonSerializer.Serialize(writer, ipProperty, options);
+					break;
+				case IGeoPointProperty geoPointProperty:
+					JsonSerializer.Serialize(writer, geoPointProperty, options);
+					break;
+				case IGeoShapeProperty geoShapeProperty:
+					JsonSerializer.Serialize(writer, geoShapeProperty, options);
+					break;
+				case ICompletionProperty completionProperty:
+					JsonSerializer.Serialize(writer, completionProperty, options);
+					break;
+				case ITokenCountProperty tokenCountProperty:
+					JsonSerializer.Serialize(writer, tokenCountProperty, options);
+					break;
+				case IMurmur3HashProperty murmur3HashProperty:
+					JsonSerializer.Serialize(writer, murmur3HashProperty, options);
+					break;
+				case IPercolatorProperty percolatorProperty:
+					JsonSerializer.Serialize(writer, percolatorProperty, options);
+					break;
+				case IDateRangeProperty dateRangeProperty:
+					JsonSerializer.Serialize(writer, dateRangeProperty, options);
+					break;
+				case IDoubleRangeProperty doubleRangeProperty:
+					JsonSerializer.Serialize(writer, doubleRangeProperty, options);
+					break;
+				case IFloatRangeProperty floatRangeProperty:
+					JsonSerializer.Serialize(writer, floatRangeProperty, options);
+					break;
+				case IIntegerRangeProperty integerRangeProperty:
+					JsonSerializer.Serialize(writer, integerRangeProperty, options);
+					break;
+				case ILongRangeProperty longRangeProperty:
+					JsonSerializer.Serialize(writer, longRangeProperty, options);
+					break;
+				case IIpRangeProperty ipRangeProperty:
+					JsonSerializer.Serialize(writer, ipRangeProperty, options);
+					break;
+				case IJoinProperty joinProperty:
+					JsonSerializer.Serialize(writer, joinProperty, options);
+					break;
+				case IFieldAliasProperty fieldAliasProperty:
+					JsonSerializer.Serialize(writer, fieldAliasProperty, options);
+					break;
+				case IRankFeatureProperty rankFeatureProperty:
+					JsonSerializer.Serialize(writer, rankFeatureProperty, options);
+					break;
+				case IRankFeaturesProperty rankFeaturesProperty:
+					JsonSerializer.Serialize(writer, rankFeaturesProperty, options);
+					break;
+				case IKnnVectorProperty knnVectorProperty:
+					JsonSerializer.Serialize(writer, knnVectorProperty, options);
+					break;
+				case IGenericProperty genericProperty:
+					JsonSerializer.Serialize(writer, genericProperty, options);
+					break;
+				default:
+					// Fallback: serialize using the actual runtime type
+					JsonSerializer.Serialize(writer, value, value.GetType(), options);
+					break;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/Mapping/Types/PropertyFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertyFormatter.cs
@@ -119,6 +119,7 @@ namespace OpenSearch.Client
 				case FieldType.RankFeature: return Deserialize<RankFeatureProperty>(ref segmentReader, formatterResolver);
 				case FieldType.RankFeatures: return Deserialize<RankFeaturesProperty>(ref segmentReader, formatterResolver);
 				case FieldType.KnnVector: return Deserialize<KnnVectorProperty>(ref segmentReader, formatterResolver);
+				case FieldType.Wildcard: return Deserialize<WildcardProperty>(ref segmentReader, formatterResolver);
 				case FieldType.None:
 					// no "type" field in the property mapping, or FieldType enum could not be parsed from typeString
 					return Deserialize<ObjectProperty>(ref segmentReader, formatterResolver);
@@ -220,6 +221,9 @@ namespace OpenSearch.Client
 					break;
 				case IKnnVectorProperty knnVectorProperty:
 					Serialize(ref writer, knnVectorProperty, formatterResolver);
+					break;
+				case IWildcardProperty wildcardProperty:
+					Serialize(ref writer, wildcardProperty, formatterResolver);
 					break;
 				case IGenericProperty genericProperty:
 					Serialize(ref writer, genericProperty, formatterResolver);

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Attachment/Attachment.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Attachment/Attachment.cs
@@ -28,10 +28,10 @@
 
 using System;
 using System.Runtime.Serialization;
+
+
 using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
-
-
 namespace OpenSearch.Client
 {
 	/// <summary>
@@ -308,4 +308,6 @@ namespace OpenSearch.Client
 			}
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/CompletionProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/CompletionProperty.cs
@@ -35,6 +35,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(CompletionProperty))]
 	public interface ICompletionProperty : IDocValuesProperty
 	{
 		[DataMember(Name ="analyzer")]

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/GeoSuggestContext.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/GeoSuggestContext.cs
@@ -29,19 +29,22 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(GeoSuggestContext))]
 	public interface IGeoSuggestContext : ISuggestContext
 	{
 		/// <summary>
 		/// The precision of the geohash to encode the query geo point.
 		/// Only the first value will be serialized.
 		/// </summary>
-		[JsonFormatter(typeof(SerializeAsSingleFormatter<string>))]
 		[DataMember(Name = "precision")]
+		[JsonConverter(typeof(SingleOrEnumerableStringConverter))]
+		[JsonFormatter(typeof(SerializeAsSingleFormatter<string>))]
 		IEnumerable<string> Precision { get; set; }
 	}
 

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/ISuggestContext.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/ISuggestContext.cs
@@ -29,11 +29,13 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[JsonConverter(typeof(ISuggestContextConverter))]
 	[JsonFormatter(typeof(SuggestContextFormatter))]
 	public interface ISuggestContext
 	{

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/ISuggestContextConverter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/ISuggestContextConverter.cs
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Polymorphic converter for <see cref="ISuggestContext"/> that discriminates
+	/// on the "type" JSON field to deserialize as either <see cref="CategorySuggestContext"/>
+	/// or <see cref="GeoSuggestContext"/>.
+	/// </summary>
+	internal sealed class ISuggestContextConverter : JsonConverter<ISuggestContext>
+	{
+		public override ISuggestContext Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			// Clone the reader to peek at the "type" field without consuming the object
+			var readerClone = reader;
+
+			if (readerClone.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Expected StartObject token, got {readerClone.TokenType}");
+
+			string type = null;
+			while (readerClone.Read())
+			{
+				if (readerClone.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (readerClone.TokenType == JsonTokenType.PropertyName)
+				{
+					var propertyName = readerClone.GetString();
+					readerClone.Read(); // advance to value
+
+					if (string.Equals(propertyName, "type", StringComparison.OrdinalIgnoreCase))
+					{
+						type = readerClone.GetString();
+						break;
+					}
+
+					// Skip the value if it's not the "type" field
+					readerClone.Skip();
+				}
+			}
+
+			switch (type)
+			{
+				case "category":
+					return JsonSerializer.Deserialize<CategorySuggestContext>(ref reader, options);
+				case "geo":
+					return JsonSerializer.Deserialize<GeoSuggestContext>(ref reader, options);
+				default:
+					// Fallback: deserialize as CategorySuggestContext for unknown types
+					return JsonSerializer.Deserialize<CategorySuggestContext>(ref reader, options);
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, ISuggestContext value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Serialize using the runtime type to include all properties
+			JsonSerializer.Serialize(writer, value, value.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/SingleOrEnumerableStringConverter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Completion/SingleOrEnumerableStringConverter.cs
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Reads a JSON value that may be either a single string/number or an array into an
+	/// <see cref="IEnumerable{String}"/>, and writes a single-element collection as a scalar
+	/// string (not wrapped in an array). This matches the Utf8Json
+	/// <c>SingleOrEnumerableFormatter&lt;string&gt;</c> write behavior used by
+	/// GeoSuggestContext.Precision and similar fields.
+	/// </summary>
+	internal sealed class SingleOrEnumerableStringConverter : JsonConverter<IEnumerable<string>>
+	{
+		public override IEnumerable<string> Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.String:
+					return new[] { reader.GetString() };
+				case JsonTokenType.Number:
+					return new[] { reader.GetInt64().ToString() };
+				case JsonTokenType.StartArray:
+				{
+					var list = new List<string>();
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+					{
+						switch (reader.TokenType)
+						{
+							case JsonTokenType.Null:
+								list.Add(null);
+								break;
+							case JsonTokenType.String:
+								list.Add(reader.GetString());
+								break;
+							case JsonTokenType.Number:
+								list.Add(reader.GetInt64().ToString());
+								break;
+							default:
+								reader.Skip();
+								break;
+						}
+					}
+					return list;
+				}
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, IEnumerable<string> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var list = value as IList<string> ?? value.ToList();
+
+			if (list.Count == 1)
+			{
+				// Single element: write as scalar (matching Utf8Json SingleOrEnumerableFormatter behavior)
+				writer.WriteStringValue(list[0]);
+			}
+			else
+			{
+				writer.WriteStartArray();
+				foreach (var s in list)
+				{
+					if (s == null)
+						writer.WriteNullValue();
+					else
+						writer.WriteStringValue(s);
+				}
+				writer.WriteEndArray();
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/FieldAlias/FieldAliasProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/FieldAlias/FieldAliasProperty.cs
@@ -39,6 +39,7 @@ namespace OpenSearch.Client
 	/// of the target field in search requests, and selected other APIs like field capabilities.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(FieldAliasProperty))]
 	public interface IFieldAliasProperty : IProperty
 	{
 		/// <summary> The full path to alias </summary>

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Generic/GenericProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Generic/GenericProperty.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// Not all methods are valid for all types.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(GenericProperty))]
 	public interface IGenericProperty : IDocValuesProperty
 	{
 		[DataMember(Name ="analyzer")]

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Ip/IpProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Ip/IpProperty.cs
@@ -37,6 +37,7 @@ namespace OpenSearch.Client
 	/// An ip field can index/store either IPv4 or IPv6 addresses.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(IpProperty))]
 	public interface IIpProperty : IDocValuesProperty
 	{
 		[DataMember(Name ="index")]

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Knn/KnnVectorProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Knn/KnnVectorProperty.cs
@@ -78,6 +78,7 @@ public class KnnMethod : IKnnMethod
 }
 
 [InterfaceDataContract]
+[ReadAs(typeof(KnnMethodParameters))]
 [JsonFormatter(typeof(VerbatimDictionaryKeysFormatter<KnnMethodParameters, IKnnMethodParameters, string, object>))]
 public interface IKnnMethodParameters : IIsADictionary<string, object> { }
 

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Murmur3Hash/Murmur3HashProperty.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(Murmur3HashProperty))]
 	public interface IMurmur3HashProperty : IDocValuesProperty { }
 
 	[DebuggerDisplay("{DebugDisplay}")]

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Shape/ShapeOrientation.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Shape/ShapeOrientation.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 		CounterClockWise
 	}
 
+
 	internal class ShapeOrientationFormatter : IJsonFormatter<ShapeOrientation>
 	{
 		public void Serialize(ref JsonWriter writer, ShapeOrientation value, IJsonFormatterResolver formatterResolver)
@@ -118,4 +119,6 @@ namespace OpenSearch.Client
 			}
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// analyzes them, then indexes the number of tokens in the string.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(TokenCountProperty))]
 	public interface ITokenCountProperty : IDocValuesProperty
 	{
 		[DataMember(Name ="analyzer")]

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardAttribute.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+namespace OpenSearch.Client
+{
+	public class WildcardAttribute : OpenSearchDocValuesPropertyAttributeBase, IWildcardProperty
+	{
+		public WildcardAttribute() : base(FieldType.Wildcard) { }
+
+		public string NullValue
+		{
+			get => Self.NullValue;
+			set => Self.NullValue = value;
+		}
+
+		public string Normalizer
+		{
+			get => Self.Normalizer;
+			set => Self.Normalizer = value;
+		}
+
+		string IWildcardProperty.NullValue { get; set; }
+		string IWildcardProperty.Normalizer { get; set; }
+		private IWildcardProperty Self => this;
+	}
+}

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardProperty.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A wildcard field stores values optimised for wildcard grep-like queries.
+	/// </summary>
+	[InterfaceDataContract]
+	[ReadAs(typeof(WildcardProperty))]
+	public interface IWildcardProperty : IDocValuesProperty
+	{
+		/// <summary>
+		/// Accepts a string value which is substituted for any explicit null values.
+		/// </summary>
+		[DataMember(Name = "null_value")]
+		string NullValue { get; set; }
+
+		/// <summary>
+		/// The name of the normalizer to use for normalizing the wildcard value.
+		/// </summary>
+		[DataMember(Name = "normalizer")]
+		string Normalizer { get; set; }
+	}
+
+	/// <inheritdoc cref="IWildcardProperty"/>
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class WildcardProperty : DocValuesPropertyBase, IWildcardProperty
+	{
+		public WildcardProperty() : base(FieldType.Wildcard) { }
+
+		/// <inheritdoc />
+		public string NullValue { get; set; }
+
+		/// <inheritdoc />
+		public string Normalizer { get; set; }
+	}
+
+	/// <inheritdoc cref="IWildcardProperty"/>
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class WildcardPropertyDescriptor<T>
+		: DocValuesPropertyDescriptorBase<WildcardPropertyDescriptor<T>, IWildcardProperty, T>, IWildcardProperty
+		where T : class
+	{
+		public WildcardPropertyDescriptor() : base(FieldType.Wildcard) { }
+
+		string IWildcardProperty.NullValue { get; set; }
+		string IWildcardProperty.Normalizer { get; set; }
+
+		/// <inheritdoc cref="IWildcardProperty.NullValue"/>
+		public WildcardPropertyDescriptor<T> NullValue(string nullValue) =>
+			Assign(nullValue, (a, v) => a.NullValue = v);
+
+		/// <inheritdoc cref="IWildcardProperty.Normalizer"/>
+		public WildcardPropertyDescriptor<T> Normalizer(string normalizer) =>
+			Assign(normalizer, (a, v) => a.Normalizer = v);
+	}
+}

--- a/src/OpenSearch.Client/Modules/Scripting/ExecutePainlessScript/PainlessContextSetup.cs
+++ b/src/OpenSearch.Client/Modules/Scripting/ExecutePainlessScript/PainlessContextSetup.cs
@@ -28,12 +28,14 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// Sets up contextual scope for the painless script the execute under.
 	/// </summary>
+	[InterfaceDataContract]
 	[ReadAs(typeof(PainlessContextSetup))]
 	public interface IPainlessContextSetup
 	{

--- a/src/OpenSearch.Client/Nodes/NodesStats/NodeStats.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/NodeStats.cs
@@ -28,8 +28,9 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using OpenSearch.Net;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
@@ -58,6 +59,7 @@ namespace OpenSearch.Client
 		public NodeIngestStats Ingest { get; internal set; }
 
 		[DataMember(Name = "ip")]
+		[JsonConverter(typeof(SingleOrManyStringConverter))]
 		[JsonFormatter(typeof(SingleOrEnumerableFormatter<string>))]
 		public IEnumerable<string> Ip { get; internal set; }
 

--- a/src/OpenSearch.Client/Nodes/NodesStats/Statistics/IngestStats.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/Statistics/IngestStats.cs
@@ -28,8 +28,9 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using OpenSearch.Net;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
@@ -65,6 +66,7 @@ namespace OpenSearch.Client
 			EmptyReadOnly<KeyedProcessorStats>.Collection;
 	}
 
+	[JsonConverter(typeof(KeyedProcessorStatsConverter))]
 	[JsonFormatter(typeof(KeyedProcessorStatsFormatter))]
 	public class KeyedProcessorStats
 	{
@@ -75,6 +77,25 @@ namespace OpenSearch.Client
 		public ProcessStats Statistics { get; set; }
 	}
 
+
+	public class ProcessorStats
+	{
+		/// <summary> The total number of document ingested during the lifetime of this node </summary>
+		[DataMember(Name = "count")]
+		public long Count { get; internal set; }
+
+		/// <summary> The total number of documents currently being ingested. </summary>
+		[DataMember(Name = "current")]
+		public long Current { get; internal set; }
+
+		/// <summary> The total number ingest preprocessing operations failed during the lifetime of this node </summary>
+		[DataMember(Name = "failed")]
+		public long Failed { get; internal set; }
+
+		/// <summary> The total time spent on ingest preprocessing documents during the lifetime of this node </summary>
+		[DataMember(Name = "time_in_millis")]
+		public long TimeInMilliseconds { get; internal set; }
+	}
 	internal class KeyedProcessorStatsFormatter : IJsonFormatter<KeyedProcessorStats>
 	{
 		public KeyedProcessorStats Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
@@ -109,22 +130,5 @@ namespace OpenSearch.Client
 		}
 	}
 
-	public class ProcessorStats
-	{
-		/// <summary> The total number of document ingested during the lifetime of this node </summary>
-		[DataMember(Name = "count")]
-		public long Count { get; internal set; }
 
-		/// <summary> The total number of documents currently being ingested. </summary>
-		[DataMember(Name = "current")]
-		public long Current { get; internal set; }
-
-		/// <summary> The total number ingest preprocessing operations failed during the lifetime of this node </summary>
-		[DataMember(Name = "failed")]
-		public long Failed { get; internal set; }
-
-		/// <summary> The total time spent on ingest preprocessing documents during the lifetime of this node </summary>
-		[DataMember(Name = "time_in_millis")]
-		public long TimeInMilliseconds { get; internal set; }
-	}
 }

--- a/src/OpenSearch.Client/Nodes/NodesStats/Statistics/KeyedProcessorStatsConverter.cs
+++ b/src/OpenSearch.Client/Nodes/NodesStats/Statistics/KeyedProcessorStatsConverter.cs
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Reads/writes the single-key wrapper object <c>{ "&lt;type&gt;": { ...stats... } }</c> used for each
+	/// processor entry in node ingest stats. The property name is the processor <see cref="KeyedProcessorStats.Type"/>
+	/// and the value deserializes into <see cref="KeyedProcessorStats.Statistics"/>. Replaces the pre-STJ
+	/// <c>KeyedProcessorStatsFormatter</c>; without it the JSON shape is not mapped and <c>Type</c> stays null.
+	/// </summary>
+	internal sealed class KeyedProcessorStatsConverter : JsonConverter<KeyedProcessorStats>
+	{
+		public override KeyedProcessorStats Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var stats = new KeyedProcessorStats();
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				stats.Type = reader.GetString();
+				reader.Read();
+				stats.Statistics = JsonSerializer.Deserialize<ProcessStats>(ref reader, options);
+			}
+
+			return stats;
+		}
+
+		public override void Write(Utf8JsonWriter writer, KeyedProcessorStats value, JsonSerializerOptions options)
+		{
+			if (value?.Type == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(value.Type);
+			JsonSerializer.Serialize(writer, value.Statistics, options);
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Nodes/NodesUsage/NodeUsageInformation.cs
+++ b/src/OpenSearch.Client/Nodes/NodesUsage/NodeUsageInformation.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -45,10 +46,12 @@ namespace OpenSearch.Client
 		public IReadOnlyDictionary<string, int> RestActions { get; internal set; }
 
 		[DataMember(Name ="since")]
+		[JsonConverter(typeof(EpochMillisecondsDateTimeOffsetConverter))]
 		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
 		public DateTimeOffset Since { get; internal set; }
 
 		[DataMember(Name ="timestamp")]
+		[JsonConverter(typeof(EpochMillisecondsDateTimeOffsetConverter))]
 		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
 		public DateTimeOffset Timestamp { get; internal set; }
 	}

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/IQueryContainer.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/IQueryContainer.cs
@@ -41,6 +41,9 @@ namespace OpenSearch.Client
 		[DataMember(Name ="boosting")]
 		IBoostingQuery Boosting { get; set; }
 
+		[DataMember(Name ="combined_fields")]
+		ICombinedFieldsQuery CombinedFields { get; set; }
+
 		[DataMember(Name ="constant_score")]
 		IConstantScoreQuery ConstantScore { get; set; }
 

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	{
 		private IBoolQuery _bool;
 		private IBoostingQuery _boosting;
+		private ICombinedFieldsQuery _combinedFields;
 		private IConstantScoreQuery _constantScore;
 		private IDisMaxQuery _disMax;
 		private IDistanceFeatureQuery _distanceFeature;
@@ -104,6 +105,12 @@ namespace OpenSearch.Client
 		{
 			get => _boosting;
 			set => _boosting = Set(value);
+		}
+
+		ICombinedFieldsQuery IQueryContainer.CombinedFields
+		{
+			get => _combinedFields;
+			set => _combinedFields = Set(value);
 		}
 
 		IConstantScoreQuery IQueryContainer.ConstantScore

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainer-Dsl.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainer-Dsl.cs
@@ -130,7 +130,13 @@ namespace OpenSearch.Client
 		public static bool operator true(QueryContainer a) => false;
 
 		// ReSharper disable once UnusedMember.Global
-		internal bool ShouldSerialize(IJsonFormatterResolver formatterResolver) => IsWritable;
+		internal bool ShouldSerialize() => IsWritable;
+
+		// Utf8Json discovers a type-level ShouldSerialize hook by looking for a method taking a single
+		// IJsonFormatterResolver parameter (see ReflectionExtensions.GetShouldSerializeMethod). Provide that
+		// overload so a conditionless QueryContainer (e.g. an empty bool query) is omitted on the Utf8Json
+		// path rather than emitted as an empty object.
+		internal bool ShouldSerialize(OpenSearch.Net.Utf8Json.IJsonFormatterResolver formatterResolver) => IsWritable;
 
 		/// <summary>
 		/// Assigns a name to the contained query.

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainerConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainerConverter.cs
@@ -1,0 +1,667 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IQueryContainer"/> that handles
+	/// the single-key object pattern used by OpenSearch Query DSL.
+	/// Each query is serialized as <c>{"query_type": { ... }}</c>.
+	/// </summary>
+	internal sealed class QueryContainerConverter : JsonConverter<IQueryContainer>
+	{
+		// Pre-computed property names for frequently used query types
+		private static readonly JsonEncodedText BoolProp = JsonEncodedText.Encode("bool");
+		private static readonly JsonEncodedText MatchProp = JsonEncodedText.Encode("match");
+		private static readonly JsonEncodedText TermProp = JsonEncodedText.Encode("term");
+		private static readonly JsonEncodedText TermsProp = JsonEncodedText.Encode("terms");
+		private static readonly JsonEncodedText RangeProp = JsonEncodedText.Encode("range");
+		private static readonly JsonEncodedText MatchAllProp = JsonEncodedText.Encode("match_all");
+		private static readonly JsonEncodedText MatchNoneProp = JsonEncodedText.Encode("match_none");
+		private static readonly JsonEncodedText ExistsProp = JsonEncodedText.Encode("exists");
+		private static readonly JsonEncodedText NestedProp = JsonEncodedText.Encode("nested");
+		private static readonly JsonEncodedText WildcardProp = JsonEncodedText.Encode("wildcard");
+		private static readonly JsonEncodedText PrefixProp = JsonEncodedText.Encode("prefix");
+		private static readonly JsonEncodedText QueryStringProp = JsonEncodedText.Encode("query_string");
+		private static readonly JsonEncodedText FuzzyProp = JsonEncodedText.Encode("fuzzy");
+		private static readonly JsonEncodedText RegexpProp = JsonEncodedText.Encode("regexp");
+		private static readonly JsonEncodedText IdsProp = JsonEncodedText.Encode("ids");
+		private static readonly JsonEncodedText BoostingProp = JsonEncodedText.Encode("boosting");
+		private static readonly JsonEncodedText ConstantScoreProp = JsonEncodedText.Encode("constant_score");
+		private static readonly JsonEncodedText DisMaxProp = JsonEncodedText.Encode("dis_max");
+		private static readonly JsonEncodedText FunctionScoreProp = JsonEncodedText.Encode("function_score");
+		private static readonly JsonEncodedText MultiMatchProp = JsonEncodedText.Encode("multi_match");
+		private static readonly JsonEncodedText CombinedFieldsProp = JsonEncodedText.Encode("combined_fields");
+		private static readonly JsonEncodedText MatchPhraseProp = JsonEncodedText.Encode("match_phrase");
+		private static readonly JsonEncodedText MatchPhrasePrefixProp = JsonEncodedText.Encode("match_phrase_prefix");
+		private static readonly JsonEncodedText MatchBoolPrefixProp = JsonEncodedText.Encode("match_bool_prefix");
+		private static readonly JsonEncodedText MoreLikeThisProp = JsonEncodedText.Encode("more_like_this");
+		private static readonly JsonEncodedText SimpleQueryStringProp = JsonEncodedText.Encode("simple_query_string");
+		private static readonly JsonEncodedText GeoBoundingBoxProp = JsonEncodedText.Encode("geo_bounding_box");
+		private static readonly JsonEncodedText GeoDistanceProp = JsonEncodedText.Encode("geo_distance");
+		private static readonly JsonEncodedText GeoPolygonProp = JsonEncodedText.Encode("geo_polygon");
+		private static readonly JsonEncodedText GeoShapeProp = JsonEncodedText.Encode("geo_shape");
+		private static readonly JsonEncodedText ShapeProp = JsonEncodedText.Encode("shape");
+		private static readonly JsonEncodedText HasChildProp = JsonEncodedText.Encode("has_child");
+		private static readonly JsonEncodedText HasParentProp = JsonEncodedText.Encode("has_parent");
+		private static readonly JsonEncodedText ParentIdProp = JsonEncodedText.Encode("parent_id");
+		private static readonly JsonEncodedText PercolateProp = JsonEncodedText.Encode("percolate");
+		private static readonly JsonEncodedText ScriptProp = JsonEncodedText.Encode("script");
+		private static readonly JsonEncodedText ScriptScoreProp = JsonEncodedText.Encode("script_score");
+		private static readonly JsonEncodedText SpanContainingProp = JsonEncodedText.Encode("span_containing");
+		private static readonly JsonEncodedText FieldMaskingSpanProp = JsonEncodedText.Encode("field_masking_span");
+		private static readonly JsonEncodedText SpanFirstProp = JsonEncodedText.Encode("span_first");
+		private static readonly JsonEncodedText SpanMultiProp = JsonEncodedText.Encode("span_multi");
+		private static readonly JsonEncodedText SpanNearProp = JsonEncodedText.Encode("span_near");
+		private static readonly JsonEncodedText SpanNotProp = JsonEncodedText.Encode("span_not");
+		private static readonly JsonEncodedText SpanOrProp = JsonEncodedText.Encode("span_or");
+		private static readonly JsonEncodedText SpanTermProp = JsonEncodedText.Encode("span_term");
+		private static readonly JsonEncodedText SpanWithinProp = JsonEncodedText.Encode("span_within");
+		private static readonly JsonEncodedText TermsSetProp = JsonEncodedText.Encode("terms_set");
+		private static readonly JsonEncodedText IntervalsProp = JsonEncodedText.Encode("intervals");
+		private static readonly JsonEncodedText RankFeatureProp = JsonEncodedText.Encode("rank_feature");
+		private static readonly JsonEncodedText DistanceFeatureProp = JsonEncodedText.Encode("distance_feature");
+		private static readonly JsonEncodedText KnnProp = JsonEncodedText.Encode("knn");
+		private static readonly JsonEncodedText NeuralProp = JsonEncodedText.Encode("neural");
+		private static readonly JsonEncodedText HybridProp = JsonEncodedText.Encode("hybrid");
+
+		public override IQueryContainer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				// Handle string-encoded query (raw JSON string containing a query object)
+				var raw = reader.GetString();
+				var innerReader = new Utf8JsonReader(Encoding.UTF8.GetBytes(raw));
+				innerReader.Read();
+				return ReadObject(ref innerReader, options);
+			}
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			return ReadObject(ref reader, options);
+		}
+
+		private static IQueryContainer ReadObject(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			var container = new QueryContainer();
+
+			// Expect StartObject
+			if (reader.TokenType != JsonTokenType.StartObject)
+				return container;
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to the value
+
+				ReadQueryProperty(container, propertyName, ref reader, options);
+			}
+
+			return container;
+		}
+
+		private static void ReadQueryProperty(QueryContainer container, string propertyName, ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			switch (propertyName)
+			{
+				case "bool":
+					((IQueryContainer)container).Bool = JsonSerializer.Deserialize<IBoolQuery>(ref reader, options);
+					break;
+				case "boosting":
+					((IQueryContainer)container).Boosting = JsonSerializer.Deserialize<IBoostingQuery>(ref reader, options);
+					break;
+				case "constant_score":
+					((IQueryContainer)container).ConstantScore = JsonSerializer.Deserialize<IConstantScoreQuery>(ref reader, options);
+					break;
+				case "dis_max":
+					((IQueryContainer)container).DisMax = JsonSerializer.Deserialize<IDisMaxQuery>(ref reader, options);
+					break;
+				case "exists":
+					((IQueryContainer)container).Exists = JsonSerializer.Deserialize<IExistsQuery>(ref reader, options);
+					break;
+				case "function_score":
+					((IQueryContainer)container).FunctionScore = JsonSerializer.Deserialize<IFunctionScoreQuery>(ref reader, options);
+					break;
+				case "fuzzy":
+					((IQueryContainer)container).Fuzzy = JsonSerializer.Deserialize<IFuzzyQuery>(ref reader, options);
+					break;
+				case "geo_bounding_box":
+					((IQueryContainer)container).GeoBoundingBox = JsonSerializer.Deserialize<IGeoBoundingBoxQuery>(ref reader, options);
+					break;
+				case "geo_distance":
+					((IQueryContainer)container).GeoDistance = JsonSerializer.Deserialize<IGeoDistanceQuery>(ref reader, options);
+					break;
+				case "geo_polygon":
+					((IQueryContainer)container).GeoPolygon = JsonSerializer.Deserialize<IGeoPolygonQuery>(ref reader, options);
+					break;
+				case "geo_shape":
+					((IQueryContainer)container).GeoShape = JsonSerializer.Deserialize<IGeoShapeQuery>(ref reader, options);
+					break;
+				case "shape":
+					((IQueryContainer)container).Shape = JsonSerializer.Deserialize<IShapeQuery>(ref reader, options);
+					break;
+				case "has_child":
+					((IQueryContainer)container).HasChild = JsonSerializer.Deserialize<IHasChildQuery>(ref reader, options);
+					break;
+				case "has_parent":
+					((IQueryContainer)container).HasParent = JsonSerializer.Deserialize<IHasParentQuery>(ref reader, options);
+					break;
+				case "ids":
+					((IQueryContainer)container).Ids = JsonSerializer.Deserialize<IIdsQuery>(ref reader, options);
+					break;
+				case "intervals":
+					((IQueryContainer)container).Intervals = JsonSerializer.Deserialize<IIntervalsQuery>(ref reader, options);
+					break;
+				case "match":
+					((IQueryContainer)container).Match = JsonSerializer.Deserialize<IMatchQuery>(ref reader, options);
+					break;
+				case "match_all":
+					((IQueryContainer)container).MatchAll = JsonSerializer.Deserialize<IMatchAllQuery>(ref reader, options);
+					break;
+				case "match_bool_prefix":
+					((IQueryContainer)container).MatchBoolPrefix = JsonSerializer.Deserialize<IMatchBoolPrefixQuery>(ref reader, options);
+					break;
+				case "match_none":
+					((IQueryContainer)container).MatchNone = JsonSerializer.Deserialize<IMatchNoneQuery>(ref reader, options);
+					break;
+				case "match_phrase":
+					((IQueryContainer)container).MatchPhrase = JsonSerializer.Deserialize<IMatchPhraseQuery>(ref reader, options);
+					break;
+				case "match_phrase_prefix":
+					((IQueryContainer)container).MatchPhrasePrefix = JsonSerializer.Deserialize<IMatchPhrasePrefixQuery>(ref reader, options);
+					break;
+				case "more_like_this":
+					((IQueryContainer)container).MoreLikeThis = JsonSerializer.Deserialize<IMoreLikeThisQuery>(ref reader, options);
+					break;
+				case "multi_match":
+					((IQueryContainer)container).MultiMatch = JsonSerializer.Deserialize<IMultiMatchQuery>(ref reader, options);
+					break;
+				case "combined_fields":
+					((IQueryContainer)container).CombinedFields = JsonSerializer.Deserialize<ICombinedFieldsQuery>(ref reader, options);
+					break;
+				case "nested":
+					((IQueryContainer)container).Nested = JsonSerializer.Deserialize<INestedQuery>(ref reader, options);
+					break;
+				case "parent_id":
+					((IQueryContainer)container).ParentId = JsonSerializer.Deserialize<IParentIdQuery>(ref reader, options);
+					break;
+				case "percolate":
+					((IQueryContainer)container).Percolate = JsonSerializer.Deserialize<IPercolateQuery>(ref reader, options);
+					break;
+				case "prefix":
+					((IQueryContainer)container).Prefix = JsonSerializer.Deserialize<IPrefixQuery>(ref reader, options);
+					break;
+				case "query_string":
+					((IQueryContainer)container).QueryString = JsonSerializer.Deserialize<IQueryStringQuery>(ref reader, options);
+					break;
+				case "range":
+					((IQueryContainer)container).Range = JsonSerializer.Deserialize<IRangeQuery>(ref reader, options);
+					break;
+				case "regexp":
+					((IQueryContainer)container).Regexp = JsonSerializer.Deserialize<IRegexpQuery>(ref reader, options);
+					break;
+				case "script":
+					((IQueryContainer)container).Script = JsonSerializer.Deserialize<IScriptQuery>(ref reader, options);
+					break;
+				case "script_score":
+					((IQueryContainer)container).ScriptScore = JsonSerializer.Deserialize<IScriptScoreQuery>(ref reader, options);
+					break;
+				case "simple_query_string":
+					((IQueryContainer)container).SimpleQueryString = JsonSerializer.Deserialize<ISimpleQueryStringQuery>(ref reader, options);
+					break;
+				case "span_containing":
+					((IQueryContainer)container).SpanContaining = JsonSerializer.Deserialize<ISpanContainingQuery>(ref reader, options);
+					break;
+				case "field_masking_span":
+					((IQueryContainer)container).SpanFieldMasking = JsonSerializer.Deserialize<ISpanFieldMaskingQuery>(ref reader, options);
+					break;
+				case "span_first":
+					((IQueryContainer)container).SpanFirst = JsonSerializer.Deserialize<ISpanFirstQuery>(ref reader, options);
+					break;
+				case "span_multi":
+					((IQueryContainer)container).SpanMultiTerm = JsonSerializer.Deserialize<ISpanMultiTermQuery>(ref reader, options);
+					break;
+				case "span_near":
+					((IQueryContainer)container).SpanNear = JsonSerializer.Deserialize<ISpanNearQuery>(ref reader, options);
+					break;
+				case "span_not":
+					((IQueryContainer)container).SpanNot = JsonSerializer.Deserialize<ISpanNotQuery>(ref reader, options);
+					break;
+				case "span_or":
+					((IQueryContainer)container).SpanOr = JsonSerializer.Deserialize<ISpanOrQuery>(ref reader, options);
+					break;
+				case "span_term":
+					((IQueryContainer)container).SpanTerm = JsonSerializer.Deserialize<ISpanTermQuery>(ref reader, options);
+					break;
+				case "span_within":
+					((IQueryContainer)container).SpanWithin = JsonSerializer.Deserialize<ISpanWithinQuery>(ref reader, options);
+					break;
+				case "term":
+					((IQueryContainer)container).Term = JsonSerializer.Deserialize<ITermQuery>(ref reader, options);
+					break;
+				case "terms":
+					((IQueryContainer)container).Terms = JsonSerializer.Deserialize<ITermsQuery>(ref reader, options);
+					break;
+				case "terms_set":
+					((IQueryContainer)container).TermsSet = JsonSerializer.Deserialize<ITermsSetQuery>(ref reader, options);
+					break;
+				case "wildcard":
+					((IQueryContainer)container).Wildcard = JsonSerializer.Deserialize<IWildcardQuery>(ref reader, options);
+					break;
+				case "rank_feature":
+					((IQueryContainer)container).RankFeature = JsonSerializer.Deserialize<IRankFeatureQuery>(ref reader, options);
+					break;
+				case "distance_feature":
+					((IQueryContainer)container).DistanceFeature = JsonSerializer.Deserialize<IDistanceFeatureQuery>(ref reader, options);
+					break;
+				case "knn":
+					((IQueryContainer)container).Knn = JsonSerializer.Deserialize<IKnnQuery>(ref reader, options);
+					break;
+				case "neural":
+					((IQueryContainer)container).Neural = JsonSerializer.Deserialize<INeuralQuery>(ref reader, options);
+					break;
+				case "hybrid":
+					((IQueryContainer)container).Hybrid = JsonSerializer.Deserialize<IHybridQuery>(ref reader, options);
+					break;
+				default:
+					// Unknown query type — skip the value to maintain forward compatibility
+					reader.Skip();
+					break;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, IQueryContainer value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Handle raw query — write the raw JSON directly
+			var rawQuery = value.RawQuery;
+			if (rawQuery?.Raw != null && !rawQuery.Raw.IsNullOrEmpty() && value.IsWritable)
+			{
+				writer.WriteRawValue(rawQuery.Raw);
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			// Write the single query property that is non-null.
+			// The QueryContainer can only hold one query at a time.
+			if (value.Bool != null)
+			{
+				writer.WritePropertyName(BoolProp);
+				JsonSerializer.Serialize(writer, value.Bool, options);
+			}
+			else if (value.Boosting != null)
+			{
+				writer.WritePropertyName(BoostingProp);
+				JsonSerializer.Serialize(writer, value.Boosting, options);
+			}
+			else if (value.ConstantScore != null)
+			{
+				writer.WritePropertyName(ConstantScoreProp);
+				JsonSerializer.Serialize(writer, value.ConstantScore, options);
+			}
+			else if (value.DisMax != null)
+			{
+				writer.WritePropertyName(DisMaxProp);
+				JsonSerializer.Serialize(writer, value.DisMax, options);
+			}
+			else if (value.Exists != null)
+			{
+				writer.WritePropertyName(ExistsProp);
+				JsonSerializer.Serialize(writer, value.Exists, options);
+			}
+			else if (value.FunctionScore != null)
+			{
+				writer.WritePropertyName(FunctionScoreProp);
+				JsonSerializer.Serialize(writer, value.FunctionScore, options);
+			}
+			else if (value.Fuzzy != null)
+			{
+				writer.WritePropertyName(FuzzyProp);
+				JsonSerializer.Serialize(writer, value.Fuzzy, options);
+			}
+			else if (value.GeoBoundingBox != null)
+			{
+				writer.WritePropertyName(GeoBoundingBoxProp);
+				JsonSerializer.Serialize(writer, value.GeoBoundingBox, options);
+			}
+			else if (value.GeoDistance != null)
+			{
+				writer.WritePropertyName(GeoDistanceProp);
+				JsonSerializer.Serialize(writer, value.GeoDistance, options);
+			}
+			else if (value.GeoPolygon != null)
+			{
+				writer.WritePropertyName(GeoPolygonProp);
+				JsonSerializer.Serialize(writer, value.GeoPolygon, options);
+			}
+			else if (value.GeoShape != null)
+			{
+				writer.WritePropertyName(GeoShapeProp);
+				JsonSerializer.Serialize(writer, value.GeoShape, options);
+			}
+			else if (value.Shape != null)
+			{
+				writer.WritePropertyName(ShapeProp);
+				JsonSerializer.Serialize(writer, value.Shape, options);
+			}
+			else if (value.HasChild != null)
+			{
+				writer.WritePropertyName(HasChildProp);
+				JsonSerializer.Serialize(writer, value.HasChild, options);
+			}
+			else if (value.HasParent != null)
+			{
+				writer.WritePropertyName(HasParentProp);
+				JsonSerializer.Serialize(writer, value.HasParent, options);
+			}
+			else if (value.Ids != null)
+			{
+				writer.WritePropertyName(IdsProp);
+				JsonSerializer.Serialize(writer, value.Ids, options);
+			}
+			else if (value.Intervals != null)
+			{
+				writer.WritePropertyName(IntervalsProp);
+				JsonSerializer.Serialize(writer, value.Intervals, options);
+			}
+			else if (value.Match != null)
+			{
+				writer.WritePropertyName(MatchProp);
+				JsonSerializer.Serialize(writer, value.Match, options);
+			}
+			else if (value.MatchAll != null)
+			{
+				writer.WritePropertyName(MatchAllProp);
+				JsonSerializer.Serialize(writer, value.MatchAll, options);
+			}
+			else if (value.MatchBoolPrefix != null)
+			{
+				writer.WritePropertyName(MatchBoolPrefixProp);
+				JsonSerializer.Serialize(writer, value.MatchBoolPrefix, options);
+			}
+			else if (value.MatchNone != null)
+			{
+				writer.WritePropertyName(MatchNoneProp);
+				JsonSerializer.Serialize(writer, value.MatchNone, options);
+			}
+			else if (value.MatchPhrase != null)
+			{
+				writer.WritePropertyName(MatchPhraseProp);
+				JsonSerializer.Serialize(writer, value.MatchPhrase, options);
+			}
+			else if (value.MatchPhrasePrefix != null)
+			{
+				writer.WritePropertyName(MatchPhrasePrefixProp);
+				JsonSerializer.Serialize(writer, value.MatchPhrasePrefix, options);
+			}
+			else if (value.MoreLikeThis != null)
+			{
+				writer.WritePropertyName(MoreLikeThisProp);
+				JsonSerializer.Serialize(writer, value.MoreLikeThis, options);
+			}
+			else if (value.MultiMatch != null)
+			{
+				writer.WritePropertyName(MultiMatchProp);
+				JsonSerializer.Serialize(writer, value.MultiMatch, options);
+			}
+			else if (value.CombinedFields != null)
+			{
+				writer.WritePropertyName(CombinedFieldsProp);
+				JsonSerializer.Serialize(writer, value.CombinedFields, options);
+			}
+			else if (value.Nested != null)
+			{
+				writer.WritePropertyName(NestedProp);
+				JsonSerializer.Serialize(writer, value.Nested, options);
+			}
+			else if (value.ParentId != null)
+			{
+				writer.WritePropertyName(ParentIdProp);
+				JsonSerializer.Serialize(writer, value.ParentId, options);
+			}
+			else if (value.Percolate != null)
+			{
+				writer.WritePropertyName(PercolateProp);
+				JsonSerializer.Serialize(writer, value.Percolate, options);
+			}
+			else if (value.Prefix != null)
+			{
+				writer.WritePropertyName(PrefixProp);
+				JsonSerializer.Serialize(writer, value.Prefix, options);
+			}
+			else if (value.QueryString != null)
+			{
+				writer.WritePropertyName(QueryStringProp);
+				JsonSerializer.Serialize(writer, value.QueryString, options);
+			}
+			else if (value.Range != null)
+			{
+				writer.WritePropertyName(RangeProp);
+				JsonSerializer.Serialize(writer, value.Range, options);
+			}
+			else if (value.Regexp != null)
+			{
+				writer.WritePropertyName(RegexpProp);
+				JsonSerializer.Serialize(writer, value.Regexp, options);
+			}
+			else if (value.Script != null)
+			{
+				writer.WritePropertyName(ScriptProp);
+				JsonSerializer.Serialize(writer, value.Script, options);
+			}
+			else if (value.ScriptScore != null)
+			{
+				writer.WritePropertyName(ScriptScoreProp);
+				JsonSerializer.Serialize(writer, value.ScriptScore, options);
+			}
+			else if (value.SimpleQueryString != null)
+			{
+				writer.WritePropertyName(SimpleQueryStringProp);
+				JsonSerializer.Serialize(writer, value.SimpleQueryString, options);
+			}
+			else if (value.SpanContaining != null)
+			{
+				writer.WritePropertyName(SpanContainingProp);
+				JsonSerializer.Serialize(writer, value.SpanContaining, options);
+			}
+			else if (value.SpanFieldMasking != null)
+			{
+				writer.WritePropertyName(FieldMaskingSpanProp);
+				JsonSerializer.Serialize(writer, value.SpanFieldMasking, options);
+			}
+			else if (value.SpanFirst != null)
+			{
+				writer.WritePropertyName(SpanFirstProp);
+				JsonSerializer.Serialize(writer, value.SpanFirst, options);
+			}
+			else if (value.SpanMultiTerm != null)
+			{
+				writer.WritePropertyName(SpanMultiProp);
+				JsonSerializer.Serialize(writer, value.SpanMultiTerm, options);
+			}
+			else if (value.SpanNear != null)
+			{
+				writer.WritePropertyName(SpanNearProp);
+				JsonSerializer.Serialize(writer, value.SpanNear, options);
+			}
+			else if (value.SpanNot != null)
+			{
+				writer.WritePropertyName(SpanNotProp);
+				JsonSerializer.Serialize(writer, value.SpanNot, options);
+			}
+			else if (value.SpanOr != null)
+			{
+				writer.WritePropertyName(SpanOrProp);
+				JsonSerializer.Serialize(writer, value.SpanOr, options);
+			}
+			else if (value.SpanTerm != null)
+			{
+				writer.WritePropertyName(SpanTermProp);
+				JsonSerializer.Serialize(writer, value.SpanTerm, options);
+			}
+			else if (value.SpanWithin != null)
+			{
+				writer.WritePropertyName(SpanWithinProp);
+				JsonSerializer.Serialize(writer, value.SpanWithin, options);
+			}
+			else if (value.Term != null)
+			{
+				writer.WritePropertyName(TermProp);
+				JsonSerializer.Serialize(writer, value.Term, options);
+			}
+			else if (value.Terms != null)
+			{
+				writer.WritePropertyName(TermsProp);
+				JsonSerializer.Serialize(writer, value.Terms, options);
+			}
+			else if (value.TermsSet != null)
+			{
+				writer.WritePropertyName(TermsSetProp);
+				JsonSerializer.Serialize(writer, value.TermsSet, options);
+			}
+			else if (value.Wildcard != null)
+			{
+				writer.WritePropertyName(WildcardProp);
+				JsonSerializer.Serialize(writer, value.Wildcard, options);
+			}
+			else if (value.RankFeature != null)
+			{
+				writer.WritePropertyName(RankFeatureProp);
+				JsonSerializer.Serialize(writer, value.RankFeature, options);
+			}
+			else if (value.DistanceFeature != null)
+			{
+				writer.WritePropertyName(DistanceFeatureProp);
+				JsonSerializer.Serialize(writer, value.DistanceFeature, options);
+			}
+			else if (value.Knn != null)
+			{
+				writer.WritePropertyName(KnnProp);
+				JsonSerializer.Serialize(writer, value.Knn, options);
+			}
+			else if (value.Neural != null)
+			{
+				writer.WritePropertyName(NeuralProp);
+				JsonSerializer.Serialize(writer, value.Neural, options);
+			}
+			else if (value.Hybrid != null)
+			{
+				writer.WritePropertyName(HybridProp);
+				JsonSerializer.Serialize(writer, value.Hybrid, options);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="QueryContainer"/> that delegates
+	/// to the <see cref="QueryContainerConverter"/> for interface-based serialization
+	/// and handles string-encoded queries during deserialization.
+	/// </summary>
+	internal sealed class QueryContainerConcretConverter : JsonConverter<QueryContainer>
+	{
+		private static readonly QueryContainerConverter InterfaceConverter = new();
+
+		public override QueryContainer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var result = InterfaceConverter.Read(ref reader, typeof(IQueryContainer), options);
+			return result as QueryContainer;
+		}
+
+		public override void Write(Utf8JsonWriter writer, QueryContainer value, JsonSerializerOptions options)
+		{
+			if (value == null || !value.IsWritable)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			InterfaceConverter.Write(writer, value, options);
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for collections of <see cref="QueryContainer"/>
+	/// that handles both array and single-object input forms, and filters out non-writable
+	/// containers during serialization.
+	/// </summary>
+	internal sealed class QueryContainerCollectionConverter : JsonConverter<IEnumerable<QueryContainer>>
+	{
+		private static readonly QueryContainerConverter InterfaceConverter = new();
+
+		public override IEnumerable<QueryContainer> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType == JsonTokenType.StartArray)
+			{
+				var list = new List<QueryContainer>();
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+				{
+					var container = InterfaceConverter.Read(ref reader, typeof(IQueryContainer), options) as QueryContainer;
+					if (container != null)
+						list.Add(container);
+				}
+				return list;
+			}
+
+			if (reader.TokenType == JsonTokenType.StartObject)
+			{
+				// Single object form — wrap in a list
+				var container = InterfaceConverter.Read(ref reader, typeof(IQueryContainer), options) as QueryContainer;
+				return container != null ? new List<QueryContainer> { container } : new List<QueryContainer>();
+			}
+
+			reader.Skip();
+			return null;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IEnumerable<QueryContainer> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach (var container in value)
+			{
+				if (container != null && container.IsWritable)
+					InterfaceConverter.Write(writer, container, options);
+			}
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -145,6 +145,14 @@ namespace OpenSearch.Client
             WrapInContainer(selector, (query, container) => container.MultiMatch = query);
 
         /// <summary>
+        /// The combined_fields query supports searching multiple text fields as if their contents had been indexed
+        /// into one combined field. It analyzes the query text and scores documents using a term-centric approach.
+        /// All queried fields must share the same search analyzer, and only text fields are supported.
+        /// </summary>
+        public QueryContainer CombinedFields(Func<CombinedFieldsQueryDescriptor<T>, ICombinedFieldsQuery> selector) =>
+            WrapInContainer(selector, (query, container) => container.CombinedFields = query);
+
+        /// <summary>
         /// Nested query allows to query nested objects / docs (see nested mapping). The query is executed against the
         /// nested objects / docs as if they were indexed as separate docs (they are, internally) and resulting in the
         /// root parent doc (or parent nested mapping).

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/FieldLookup/FieldLookup.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/FieldLookup/FieldLookup.cs
@@ -29,10 +29,12 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(FieldLookup))]
+	[InterfaceDataContract]
 	public interface IFieldLookup
 	{
 		[DataMember(Name ="id")]

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/FieldName/FieldNameQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/FieldName/FieldNameQueryConverter.cs
@@ -1,0 +1,236 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> that adds the field-name wrapping to
+	/// field-name queries (term, match, prefix, wildcard, fuzzy, regexp, span_term,
+	/// intervals, knn, neural, terms_set, etc.).
+	/// <para>
+	/// The OpenSearch JSON shape for these queries is:
+	/// <code>{ "&lt;resolved-field&gt;": { ...body... } }</code>
+	/// The body itself is produced by the standard <see cref="InterfaceDataContractModifier"/>
+	/// (the <c>Field</c> property is <c>[IgnoreDataMember]</c> so it is excluded from the body);
+	/// this converter only adds the outer <c>{ field: {body} }</c> wrapping.
+	/// </para>
+	/// <para>
+	/// This is the System.Text.Json equivalent of the Utf8Json <c>FieldNameQueryFormatter</c>.
+	/// It targets the query <em>interfaces</em> (e.g. <see cref="ITermQuery"/>), because
+	/// System.Text.Json resolves the contract from the static (interface) type used by
+	/// <see cref="QueryContainerConverter"/> and never dispatches to a concrete-type converter
+	/// in that scenario. Interfaces that already carry a dedicated <see cref="JsonConverterAttribute"/>
+	/// (range, terms, geo_shape, geo_distance, etc.) are excluded so their converters keep precedence.
+	/// </para>
+	/// </summary>
+	internal sealed class FieldNameQueryConverterFactory : JsonConverterFactory
+	{
+		private static readonly ConcurrentDictionary<Type, Type> ConcreteTypeCache = new();
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public FieldNameQueryConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) => ResolveConcreteType(typeToConvert) != null;
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var concreteType = ResolveConcreteType(typeToConvert);
+			var converterType = typeof(FieldNameQueryConverter<,>).MakeGenericType(typeToConvert, concreteType);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+
+		/// <summary>
+		/// Resolves the concrete implementation type for a field-name query interface, or
+		/// <c>null</c> if <paramref name="typeToConvert"/> is not a field-name query interface
+		/// this factory should handle.
+		/// </summary>
+		private static Type ResolveConcreteType(Type typeToConvert) =>
+			ConcreteTypeCache.GetOrAdd(typeToConvert, static type =>
+			{
+				// Only handle interfaces — see class remarks. Concrete types are (de)serialized
+				// directly by the dedicated converters or the InterfaceDataContractModifier.
+				if (!type.IsInterface)
+					return null;
+
+				if (!typeof(IFieldNameQuery).IsAssignableFrom(type) || type == typeof(IFieldNameQuery))
+					return null;
+
+				// Interfaces with a dedicated converter (range, terms, geo_shape, geo_distance,
+				// geo_polygon, geo_bounding_box, distance_feature, rank_feature, shape) already
+				// handle field-name wrapping themselves.
+				if (type.GetCustomAttribute<JsonConverterAttribute>() != null)
+					return null;
+
+				// Convention: interface "IXxxQuery" maps to concrete "XxxQuery" in the same namespace.
+				var name = type.Name;
+				if (name.Length < 2 || name[0] != 'I')
+					return null;
+
+				var concreteName = (type.Namespace == null ? "" : type.Namespace + ".") + name.Substring(1);
+				var concrete = type.Assembly.GetType(concreteName);
+
+				if (concrete == null || concrete.IsAbstract || concrete.IsInterface)
+					return null;
+
+				if (!type.IsAssignableFrom(concrete))
+					return null;
+
+				return concrete;
+			});
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for a field-name query interface <typeparamref name="TInterface"/>
+	/// backed by the concrete implementation <typeparamref name="TConcrete"/>.
+	/// Handles serialization (adding the <c>{ field: {body} }</c> wrapping) and deserialization
+	/// (reading the field-name property and the body, including scalar shorthand forms).
+	/// </summary>
+	internal sealed class FieldNameQueryConverter<TInterface, TConcrete> : JsonConverter<TInterface>
+		where TInterface : class, IFieldNameQuery
+		where TConcrete : class, TInterface, new()
+	{
+		// Cache of "body" options (a clone of the original options without the
+		// FieldNameQueryConverterFactory), keyed by the original options instance,
+		// so the body can be (de)serialized without re-entering this converter.
+		private static readonly ConditionalWeakTable<JsonSerializerOptions, JsonSerializerOptions> BodyOptionsCache = new();
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public FieldNameQueryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		private static JsonSerializerOptions GetBodyOptions(JsonSerializerOptions options) =>
+			BodyOptionsCache.GetValue(options, static o =>
+			{
+				var clone = new JsonSerializerOptions(o);
+				for (var i = clone.Converters.Count - 1; i >= 0; i--)
+				{
+					if (clone.Converters[i] is FieldNameQueryConverterFactory)
+						clone.Converters.RemoveAt(i);
+				}
+				return clone;
+			});
+
+		public override void Write(Utf8JsonWriter writer, TInterface value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var field = value.Field;
+			var resolvedField = field == null ? null : _settings.Inferrer.Field(field);
+			if (string.IsNullOrEmpty(resolvedField))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(resolvedField);
+
+			// Serialize the body using the actual runtime type so that all body properties are
+			// emitted (works for both concrete queries and descriptors), but with the body options
+			// that exclude this converter (avoids recursion).
+			JsonSerializer.Serialize(writer, value, value.GetType(), GetBodyOptions(options));
+
+			writer.WriteEndObject();
+		}
+
+		public override TInterface Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			reader.Read(); // move to first token inside the object
+
+			if (reader.TokenType == JsonTokenType.EndObject)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.PropertyName)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var fieldName = reader.GetString();
+			reader.Read(); // move to the value
+
+			TConcrete query;
+
+			if (reader.TokenType == JsonTokenType.StartObject)
+			{
+				query = JsonSerializer.Deserialize<TConcrete>(ref reader, GetBodyOptions(options));
+			}
+			else if (reader.TokenType == JsonTokenType.Null)
+			{
+				query = null;
+			}
+			else
+			{
+				// Scalar shorthand: the body is a bare scalar rather than an object.
+				query = new TConcrete();
+				AssignScalarShorthand(query, ref reader);
+			}
+
+			// Consume the closing EndObject of the outer wrapper.
+			reader.Read();
+
+			if (query == null)
+				return null;
+
+			query.Field = fieldName;
+			return query;
+		}
+
+		private static void AssignScalarShorthand(TConcrete query, ref Utf8JsonReader reader)
+		{
+			object scalar = reader.TokenType switch
+			{
+				JsonTokenType.String => reader.GetString(),
+				JsonTokenType.Number => reader.TryGetInt64(out var l) ? l : reader.GetDouble(),
+				JsonTokenType.True => true,
+				JsonTokenType.False => false,
+				_ => null
+			};
+
+			switch (query)
+			{
+				case ITermQuery termQuery:
+					termQuery.Value = scalar;
+					break;
+				case IMatchQuery matchQuery:
+					matchQuery.Query = scalar?.ToString();
+					break;
+				case IMatchPhraseQuery matchPhraseQuery:
+					matchPhraseQuery.Query = scalar?.ToString();
+					break;
+				case IMatchPhrasePrefixQuery matchPhrasePrefixQuery:
+					matchPhrasePrefixQuery.Query = scalar?.ToString();
+					break;
+				case IMatchBoolPrefixQuery matchBoolPrefixQuery:
+					matchBoolPrefixQuery.Query = scalar?.ToString();
+					break;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Abstractions/Query/QueryBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Abstractions/Query/QueryBase.cs
@@ -28,9 +28,11 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IQuery
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/Compound/Bool/BoolQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/Bool/BoolQuery.cs
@@ -30,12 +30,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
 	[ReadAs(typeof(BoolQuery))]
+	[JsonConverter(typeof(BoolQueryConverter))]
 	public interface IBoolQuery : IQuery
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/Compound/Bool/BoolQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/Bool/BoolQueryConverter.cs
@@ -1,0 +1,155 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IBoolQuery"/> that handles
+	/// the bool query structure with must, must_not, should, filter clauses and
+	/// minimum_should_match.
+	/// <para>
+	/// Example JSON shape:
+	/// <code>
+	/// {
+	///   "_name": "named_query",
+	///   "boost": 1.1,
+	///   "must": [ { ... } ],
+	///   "must_not": [ { ... } ],
+	///   "should": [ { ... } ],
+	///   "filter": [ { ... } ],
+	///   "minimum_should_match": 1
+	/// }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class BoolQueryConverter : JsonConverter<IBoolQuery>
+	{
+		private static readonly JsonEncodedText MustProp = JsonEncodedText.Encode("must");
+		private static readonly JsonEncodedText MustNotProp = JsonEncodedText.Encode("must_not");
+		private static readonly JsonEncodedText ShouldProp = JsonEncodedText.Encode("should");
+		private static readonly JsonEncodedText FilterProp = JsonEncodedText.Encode("filter");
+		private static readonly JsonEncodedText MinimumShouldMatchProp = JsonEncodedText.Encode("minimum_should_match");
+		private static readonly JsonEncodedText BoostProp = JsonEncodedText.Encode("boost");
+		private static readonly JsonEncodedText NameProp = JsonEncodedText.Encode("_name");
+
+		public override IBoolQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var query = new BoolQuery();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "_name":
+						query.Name = reader.GetString();
+						break;
+					case "boost":
+						query.Boost = reader.GetDouble();
+						break;
+					case "must":
+						query.Must = JsonSerializer.Deserialize<IEnumerable<QueryContainer>>(ref reader, options);
+						break;
+					case "must_not":
+						query.MustNot = JsonSerializer.Deserialize<IEnumerable<QueryContainer>>(ref reader, options);
+						break;
+					case "should":
+						query.Should = JsonSerializer.Deserialize<IEnumerable<QueryContainer>>(ref reader, options);
+						break;
+					case "filter":
+						query.Filter = JsonSerializer.Deserialize<IEnumerable<QueryContainer>>(ref reader, options);
+						break;
+					case "minimum_should_match":
+						query.MinimumShouldMatch = JsonSerializer.Deserialize<MinimumShouldMatch>(ref reader, options);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IBoolQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName(NameProp);
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName(BoostProp);
+				JsonSerializer.Serialize(writer, value.Boost.Value, options);
+			}
+
+			if (value.ShouldSerializeMust())
+			{
+				writer.WritePropertyName(MustProp);
+				JsonSerializer.Serialize(writer, value.Must, options);
+			}
+
+			if (value.ShouldSerializeMustNot())
+			{
+				writer.WritePropertyName(MustNotProp);
+				JsonSerializer.Serialize(writer, value.MustNot, options);
+			}
+
+			if (value.ShouldSerializeShould())
+			{
+				writer.WritePropertyName(ShouldProp);
+				JsonSerializer.Serialize(writer, value.Should, options);
+			}
+
+			if (value.ShouldSerializeFilter())
+			{
+				writer.WritePropertyName(FilterProp);
+				JsonSerializer.Serialize(writer, value.Filter, options);
+			}
+
+			if (value.MinimumShouldMatch != null)
+			{
+				writer.WritePropertyName(MinimumShouldMatchProp);
+				JsonSerializer.Serialize(writer, value.MinimumShouldMatch, options);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/DecayFunctionBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Decay/DecayFunctionBase.cs
@@ -29,9 +29,11 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IDecayFunction : IScoreFunction
 	{
 		[DataMember(Name ="decay")]
@@ -45,6 +47,7 @@ namespace OpenSearch.Client
 		MultiValueMode? MultiValueMode { get; set; }
 	}
 
+	[InterfaceDataContract]
 	public interface IDecayFunction<TOrigin, TScale> : IDecayFunction
 	{
 		[DataMember(Name ="offset")]

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FieldValue/FieldValueFactorFunction.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/FieldValue/FieldValueFactorFunction.cs
@@ -35,6 +35,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(FieldValueFactorFunction))]
 	public interface IFieldValueFactorFunction : IScoreFunction
 	{
 		[DataMember(Name ="factor")]

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctionConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctionConverter.cs
@@ -1,0 +1,354 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IScoreFunction"/> that handles the
+	/// polymorphic function_score function shape (decay: exp/gauss/linear, field_value_factor,
+	/// random_score, script_score, weight) plus the shared <c>filter</c>/<c>weight</c> members.
+	/// <para>
+	/// This is the System.Text.Json equivalent of the Utf8Json <c>ScoreFunctionJsonFormatter</c>.
+	/// </para>
+	/// </summary>
+	internal sealed class ScoreFunctionConverter : JsonConverter<IScoreFunction>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public ScoreFunctionConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IScoreFunction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			QueryContainer filter = null;
+			double? weight = null;
+			IScoreFunction function = null;
+
+			foreach (var prop in root.EnumerateObject())
+			{
+				switch (prop.Name)
+				{
+					case "filter":
+						filter = prop.Value.Deserialize<QueryContainer>(options);
+						break;
+					case "weight":
+						weight = prop.Value.GetDouble();
+						break;
+					case "exp":
+					case "gauss":
+					case "linear":
+						function = ReadDecay(prop.Name, prop.Value, options);
+						break;
+					case "random_score":
+						function = prop.Value.Deserialize<RandomScoreFunction>(options);
+						break;
+					case "field_value_factor":
+						function = prop.Value.Deserialize<FieldValueFactorFunction>(options);
+						break;
+					case "script_score":
+						function = prop.Value.Deserialize<ScriptScoreFunction>(options);
+						break;
+				}
+			}
+
+			if (function == null)
+			{
+				if (weight.HasValue)
+					function = new WeightFunction();
+				else
+					return null;
+			}
+
+			function.Weight = weight;
+			function.Filter = filter;
+			return function;
+		}
+
+		private static IScoreFunction ReadDecay(string type, JsonElement body, JsonSerializerOptions options)
+		{
+			MultiValueMode? multiValueMode = null;
+			JsonElement fieldBody = default;
+			string fieldName = null;
+
+			foreach (var prop in body.EnumerateObject())
+			{
+				if (prop.Name == "multi_value_mode")
+					multiValueMode = prop.Value.Deserialize<MultiValueMode>(options);
+				else
+				{
+					fieldName = prop.Name;
+					fieldBody = prop.Value;
+				}
+			}
+
+			if (fieldName == null)
+				return null;
+
+			// Determine the origin/scale sub-type from the "origin" value shape.
+			var subType = "numeric";
+			if (fieldBody.ValueKind == JsonValueKind.Object && fieldBody.TryGetProperty("origin", out var origin))
+			{
+				subType = origin.ValueKind switch
+				{
+					JsonValueKind.String => "date",
+					JsonValueKind.Object => "geo",
+					_ => "numeric"
+				};
+			}
+
+			var raw = fieldBody.GetRawText();
+			IDecayFunction decay = type switch
+			{
+				"exp" => subType switch
+				{
+					"date" => JsonSerializer.Deserialize<ExponentialDateDecayFunction>(raw, options),
+					"geo" => JsonSerializer.Deserialize<ExponentialGeoDecayFunction>(raw, options),
+					_ => JsonSerializer.Deserialize<ExponentialDecayFunction>(raw, options)
+				},
+				"gauss" => subType switch
+				{
+					"date" => JsonSerializer.Deserialize<GaussDateDecayFunction>(raw, options),
+					"geo" => JsonSerializer.Deserialize<GaussGeoDecayFunction>(raw, options),
+					_ => JsonSerializer.Deserialize<GaussDecayFunction>(raw, options)
+				},
+				"linear" => subType switch
+				{
+					"date" => JsonSerializer.Deserialize<LinearDateDecayFunction>(raw, options),
+					"geo" => JsonSerializer.Deserialize<LinearGeoDecayFunction>(raw, options),
+					_ => JsonSerializer.Deserialize<LinearDecayFunction>(raw, options)
+				},
+				_ => null
+			};
+
+			if (decay != null)
+			{
+				decay.Field = fieldName;
+				decay.MultiValueMode = multiValueMode;
+			}
+
+			return decay;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IScoreFunction value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (value.Filter != null)
+			{
+				writer.WritePropertyName("filter");
+				JsonSerializer.Serialize(writer, value.Filter, options);
+			}
+
+			switch (value)
+			{
+				case IDecayFunction decayFunction:
+					WriteDecay(writer, decayFunction, options);
+					break;
+				case IFieldValueFactorFunction fieldValueFactorFunction:
+					WriteFieldValueFactor(writer, fieldValueFactorFunction, options);
+					break;
+				case IRandomScoreFunction randomScoreFunction:
+					WriteRandomScore(writer, randomScoreFunction, options);
+					break;
+				case IScriptScoreFunction scriptScoreFunction:
+					WriteScriptScore(writer, scriptScoreFunction, options);
+					break;
+				case IWeightFunction _:
+					break;
+				default:
+					throw new JsonException($"Can not write function score json for {value.GetType().Name}");
+			}
+
+			if (value.Weight.HasValue)
+			{
+				writer.WritePropertyName("weight");
+				JsonSerializer.Serialize(writer, value.Weight.Value, options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private void WriteScriptScore(Utf8JsonWriter writer, IScriptScoreFunction value, JsonSerializerOptions options)
+		{
+			writer.WritePropertyName("script_score");
+			writer.WriteStartObject();
+			writer.WritePropertyName("script");
+			JsonSerializer.Serialize(writer, value?.Script, options);
+			writer.WriteEndObject();
+		}
+
+		private void WriteRandomScore(Utf8JsonWriter writer, IRandomScoreFunction value, JsonSerializerOptions options)
+		{
+			writer.WritePropertyName("random_score");
+			writer.WriteStartObject();
+
+			if (value.Seed != null)
+			{
+				writer.WritePropertyName("seed");
+				JsonSerializer.Serialize(writer, value.Seed, options);
+			}
+
+			if (value.Field != null)
+			{
+				writer.WritePropertyName("field");
+				JsonSerializer.Serialize(writer, value.Field, options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private void WriteFieldValueFactor(Utf8JsonWriter writer, IFieldValueFactorFunction value, JsonSerializerOptions options)
+		{
+			writer.WritePropertyName("field_value_factor");
+			writer.WriteStartObject();
+
+			writer.WritePropertyName("field");
+			writer.WriteStringValue(_settings.Inferrer.Field(value.Field));
+
+			if (value.Factor.HasValue)
+			{
+				writer.WritePropertyName("factor");
+				JsonSerializer.Serialize(writer, value.Factor.Value, options);
+			}
+
+			if (value.Modifier.HasValue)
+			{
+				writer.WritePropertyName("modifier");
+				JsonSerializer.Serialize(writer, value.Modifier.Value, options);
+			}
+
+			if (value.Missing.HasValue)
+			{
+				writer.WritePropertyName("missing");
+				JsonSerializer.Serialize(writer, value.Missing.Value, options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private void WriteDecay(Utf8JsonWriter writer, IDecayFunction decay, JsonSerializerOptions options)
+		{
+			writer.WritePropertyName(decay.DecayType);
+			writer.WriteStartObject();
+
+			writer.WritePropertyName(_settings.Inferrer.Field(decay.Field));
+			writer.WriteStartObject();
+
+			switch (decay)
+			{
+				case IDecayFunction<double?, double?> numericDecay:
+					WriteNumericDecay(writer, numericDecay, options);
+					break;
+				case IDecayFunction<DateMath, Time> dateDecay:
+					WriteDateDecay(writer, dateDecay, options);
+					break;
+				case IDecayFunction<GeoLocation, Distance> geoDecay:
+					WriteGeoDecay(writer, geoDecay, options);
+					break;
+				default:
+					throw new JsonException($"Can not write decay function json for {decay.GetType().Name}");
+			}
+
+			if (decay.Decay.HasValue)
+			{
+				writer.WritePropertyName("decay");
+				JsonSerializer.Serialize(writer, decay.Decay.Value, options);
+			}
+
+			writer.WriteEndObject(); // end field body
+
+			if (decay.MultiValueMode.HasValue)
+			{
+				writer.WritePropertyName("multi_value_mode");
+				JsonSerializer.Serialize(writer, decay.MultiValueMode.Value, options);
+			}
+
+			writer.WriteEndObject(); // end decay type object
+		}
+
+		private static void WriteNumericDecay(Utf8JsonWriter writer, IDecayFunction<double?, double?> value, JsonSerializerOptions options)
+		{
+			if (value.Origin.HasValue)
+			{
+				writer.WritePropertyName("origin");
+				JsonSerializer.Serialize(writer, value.Origin.Value, options);
+			}
+
+			if (value.Scale.HasValue)
+			{
+				writer.WritePropertyName("scale");
+				JsonSerializer.Serialize(writer, value.Scale.Value, options);
+			}
+
+			if (value.Offset != null)
+			{
+				writer.WritePropertyName("offset");
+				JsonSerializer.Serialize(writer, value.Offset.Value, options);
+			}
+		}
+
+		private static void WriteDateDecay(Utf8JsonWriter writer, IDecayFunction<DateMath, Time> value, JsonSerializerOptions options)
+		{
+			if (value == null || value.Field.IsConditionless())
+				return;
+
+			if (value.Origin != null)
+			{
+				writer.WritePropertyName("origin");
+				JsonSerializer.Serialize(writer, value.Origin, options);
+			}
+
+			writer.WritePropertyName("scale");
+			JsonSerializer.Serialize(writer, value.Scale, options);
+
+			if (value.Offset != null)
+			{
+				writer.WritePropertyName("offset");
+				JsonSerializer.Serialize(writer, value.Offset, options);
+			}
+		}
+
+		private static void WriteGeoDecay(Utf8JsonWriter writer, IDecayFunction<GeoLocation, Distance> value, JsonSerializerOptions options)
+		{
+			if (value == null || value.Field.IsConditionless())
+				return;
+
+			writer.WritePropertyName("origin");
+			JsonSerializer.Serialize(writer, value.Origin, options);
+
+			writer.WritePropertyName("scale");
+			JsonSerializer.Serialize(writer, value.Scale, options);
+
+			if (value.Offset != null)
+			{
+				writer.WritePropertyName("offset");
+				JsonSerializer.Serialize(writer, value.Offset, options);
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScriptScore/ScriptScoreFunction.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/ScriptScore/ScriptScoreFunction.cs
@@ -38,6 +38,7 @@ namespace OpenSearch.Client
 	/// field values in the doc using a script expression.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(ScriptScoreFunction))]
 	public interface IScriptScoreFunction : IScoreFunction
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Weight/WeightFunction.cs
+++ b/src/OpenSearch.Client/QueryDsl/Compound/FunctionScore/Functions/Weight/WeightFunction.cs
@@ -31,6 +31,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(WeightFunction))]
 	public interface IWeightFunction : IScoreFunction { }
 
 	public class WeightFunction : FunctionScoreFunctionBase, IWeightFunction { }

--- a/src/OpenSearch.Client/QueryDsl/FullText/CombinedFields/CombinedFieldsQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/CombinedFields/CombinedFieldsQuery.cs
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// The combined_fields query supports searching multiple text fields as if their contents had been indexed
+	/// into one combined field. The query analyzes the provided text before performing a search, and it scores
+	/// documents using a term-centric approach that treats the matched fields as a single field.
+	/// <para />
+	/// All queried fields must have the same search analyzer. Only <c>text</c> fields are supported.
+	/// </summary>
+	[InterfaceDataContract]
+	[ReadAs(typeof(CombinedFieldsQuery))]
+	public interface ICombinedFieldsQuery : IQuery
+	{
+		/// <summary>
+		/// The list of fields to search. Field wildcard patterns are allowed. Only <c>text</c> fields are supported,
+		/// and they must all share the same search analyzer.
+		/// </summary>
+		[DataMember(Name = "fields")]
+		Fields Fields { get; set; }
+
+		/// <summary>
+		/// A value controlling how many "should" clauses in the resulting boolean query should match.
+		/// It can be an absolute value, a percentage or a combination of both.
+		/// </summary>
+		[DataMember(Name = "minimum_should_match")]
+		MinimumShouldMatch MinimumShouldMatch { get; set; }
+
+		/// <summary>
+		/// The operator used to combine the analyzed terms of the query value.
+		/// The default operator is <see cref="Client.Operator.Or" />.
+		/// </summary>
+		[DataMember(Name = "operator")]
+		Operator? Operator { get; set; }
+
+		/// <summary>
+		/// The text to search for in the provided <see cref="Fields" />.
+		/// The combined_fields query analyzes the provided text before performing a search.
+		/// </summary>
+		[DataMember(Name = "query")]
+		string Query { get; set; }
+	}
+
+	/// <inheritdoc cref="ICombinedFieldsQuery" />
+	public class CombinedFieldsQuery : QueryBase, ICombinedFieldsQuery
+	{
+		/// <inheritdoc />
+		public Fields Fields { get; set; }
+
+		/// <inheritdoc />
+		public MinimumShouldMatch MinimumShouldMatch { get; set; }
+
+		/// <inheritdoc />
+		public Operator? Operator { get; set; }
+
+		/// <inheritdoc />
+		public string Query { get; set; }
+
+		protected override bool Conditionless => IsConditionless(this);
+
+		internal override void InternalWrapInContainer(IQueryContainer c) => c.CombinedFields = this;
+
+		internal static bool IsConditionless(ICombinedFieldsQuery q) => q.Query.IsNullOrEmpty();
+	}
+
+	/// <inheritdoc cref="ICombinedFieldsQuery" />
+	[DataContract]
+	public class CombinedFieldsQueryDescriptor<T>
+		: QueryDescriptorBase<CombinedFieldsQueryDescriptor<T>, ICombinedFieldsQuery>
+			, ICombinedFieldsQuery where T : class
+	{
+		protected override bool Conditionless => CombinedFieldsQuery.IsConditionless(this);
+		Fields ICombinedFieldsQuery.Fields { get; set; }
+		MinimumShouldMatch ICombinedFieldsQuery.MinimumShouldMatch { get; set; }
+		Operator? ICombinedFieldsQuery.Operator { get; set; }
+		string ICombinedFieldsQuery.Query { get; set; }
+
+		/// <inheritdoc cref="ICombinedFieldsQuery.Fields" />
+		public CombinedFieldsQueryDescriptor<T> Fields(Func<FieldsDescriptor<T>, IPromise<Fields>> fields) =>
+			Assign(fields, (a, v) => a.Fields = v?.Invoke(new FieldsDescriptor<T>())?.Value);
+
+		/// <inheritdoc cref="ICombinedFieldsQuery.Fields" />
+		public CombinedFieldsQueryDescriptor<T> Fields(Fields fields) => Assign(fields, (a, v) => a.Fields = v);
+
+		/// <inheritdoc cref="ICombinedFieldsQuery.Query" />
+		public CombinedFieldsQueryDescriptor<T> Query(string query) => Assign(query, (a, v) => a.Query = v);
+
+		/// <inheritdoc cref="ICombinedFieldsQuery.Operator" />
+		public CombinedFieldsQueryDescriptor<T> Operator(Operator? op) => Assign(op, (a, v) => a.Operator = v);
+
+		/// <inheritdoc cref="ICombinedFieldsQuery.MinimumShouldMatch" />
+		public CombinedFieldsQueryDescriptor<T> MinimumShouldMatch(MinimumShouldMatch minimumShouldMatch)
+			=> Assign(minimumShouldMatch, (a, v) => a.MinimumShouldMatch = v);
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsAllOf.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsAllOf.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -36,6 +37,7 @@ namespace OpenSearch.Client
 	/// A rule that returns matches that span a combination of other rules.
 	/// </summary>
 	[ReadAs(typeof(IntervalsAllOf))]
+	[InterfaceDataContract]
 	public interface IIntervalsAllOf : IIntervals
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsAnyOf.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsAnyOf.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -36,6 +37,7 @@ namespace OpenSearch.Client
 	/// A rule that emits intervals produced by any of its sub-rules.
 	/// </summary>
 	[ReadAs(typeof(IntervalsAnyOf))]
+	[InterfaceDataContract]
 	public interface IIntervalsAnyOf : IIntervals
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsFilter.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsFilter.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// Filters intervals produced by any rules by their relation to the intervals produced by another rule
 	/// </summary>
 	[ReadAs(typeof(IntervalsFilter))]
+	[InterfaceDataContract]
 	public interface IIntervalsFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsFuzzy.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsFuzzy.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// If the fuzzy expansion matches more than 128 terms, OpenSearch returns an error.
 	/// </summary>
 	[ReadAs(typeof(IntervalsFuzzy))]
+	[InterfaceDataContract]
 	public interface IIntervalsFuzzy : IIntervalsNoFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsMatch.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsMatch.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -36,6 +37,7 @@ namespace OpenSearch.Client
 	/// Matches the analyzed text
 	/// </summary>
 	[ReadAs(typeof(IntervalsMatch))]
+	[InterfaceDataContract]
 	public interface IIntervalsMatch : IIntervals
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -38,6 +39,7 @@ namespace OpenSearch.Client
 	/// You can use the index-prefixes option in the field mapping to avoid this limit.
 	/// </summary>
 	[ReadAs(typeof(IntervalsPrefix))]
+	[InterfaceDataContract]
 	public interface IIntervalsPrefix : IIntervalsNoFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsQuery.cs
@@ -41,6 +41,7 @@ namespace OpenSearch.Client
 	/// These intervals can be further combined and filtered by parent sources.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(IntervalsQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<IntervalsQuery, IIntervalsQuery>))]
 	public interface IIntervalsQuery : IFieldNameQuery, IIntervalsContainer { }
 
@@ -114,6 +115,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Container for an <see cref="IIntervalsQuery" /> rule
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IIntervalsContainer
 	{
 		/// <inheritdoc cref="IIntervalsAllOf" />
@@ -210,6 +212,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// An <see cref="IIntervalsQuery" /> rule with an optional filter
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IIntervals
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// If the pattern matches more than 128 terms, OpenSearch returns an error.
 	/// </summary>
 	[ReadAs(typeof(IntervalsWildcard))]
+	[InterfaceDataContract]
 	public interface IIntervalsWildcard : IIntervalsNoFilter
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/QueryDsl/FullText/Match/MatchQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/Match/MatchQuery.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// A match query for a single field
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(MatchQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<MatchQuery, IMatchQuery>))]
 	public interface IMatchQuery : IFieldNameQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/FullText/MatchBoolPrefix/MatchBoolPrefixQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MatchBoolPrefix/MatchBoolPrefixQuery.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// Each term except the last is used in a term query. The last term is used in a prefix query.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(MatchBoolPrefixQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<MatchBoolPrefixQuery, IMatchBoolPrefixQuery>))]
 	public interface IMatchBoolPrefixQuery : IFieldNameQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/FullText/MatchPhrase/MatchPhraseQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MatchPhrase/MatchPhraseQuery.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(MatchPhraseQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<MatchPhraseQuery, IMatchPhraseQuery>))]
 	public interface IMatchPhraseQuery : IFieldNameQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/FullText/MatchPhrasePrefix/MatchPhrasePrefixQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/MatchPhrasePrefix/MatchPhrasePrefixQuery.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(MatchPhrasePrefixQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<MatchPhrasePrefixQuery, IMatchPhrasePrefixQuery>))]
 	public interface IMatchPhrasePrefixQuery : IFieldNameQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringFlags.cs
+++ b/src/OpenSearch.Client/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringFlags.cs
@@ -30,11 +30,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using OpenSearch.Net;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[Flags]
+	[StringEnum]
 	public enum SimpleQueryStringFlags
 	{
 		[EnumMember(Value = "NONE")]
@@ -115,4 +117,6 @@ namespace OpenSearch.Client
 				.Aggregate(default(SimpleQueryStringFlags), (current, s) => current | s.Value);
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/BoundingBox.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/BoundingBox.cs
@@ -27,9 +27,11 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[ReadAs(typeof(BoundingBox))]
 	public interface IBoundingBox
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryConverter.cs
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IGeoBoundingBoxQuery"/> that handles
+	/// the field-name-wrapping pattern with bounding box coordinates.
+	/// <para>
+	/// The OpenSearch geo_bounding_box query JSON shape is:
+	/// <code>
+	/// {
+	///   "_name": "...",
+	///   "boost": 1.0,
+	///   "validation_method": "...",
+	///   "type": "...",
+	///   "field_name": { "top_left": {...}, "bottom_right": {...} }
+	/// }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class GeoBoundingBoxQueryConverter : JsonConverter<IGeoBoundingBoxQuery>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public GeoBoundingBoxQueryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IGeoBoundingBoxQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var query = new GeoBoundingBoxQuery();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "_name":
+						query.Name = reader.GetString();
+						break;
+					case "boost":
+						query.Boost = reader.GetDouble();
+						break;
+					case "validation_method":
+						query.ValidationMethod = JsonSerializer.Deserialize<GeoValidationMethod>(ref reader, options);
+						break;
+					case "type":
+						query.Type = JsonSerializer.Deserialize<GeoExecution>(ref reader, options);
+						break;
+					default:
+						// This is the field name — its value is the bounding box object
+						query.Field = propertyName;
+						query.BoundingBox = JsonSerializer.Deserialize<IBoundingBox>(ref reader, options);
+						break;
+				}
+			}
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IGeoBoundingBoxQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var fieldName = _settings.Inferrer.Field(value.Field);
+			if (string.IsNullOrEmpty(fieldName))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				writer.WriteNumberValue(value.Boost.Value);
+			}
+
+			if (value.ValidationMethod.HasValue)
+			{
+				writer.WritePropertyName("validation_method");
+				JsonSerializer.Serialize(writer, value.ValidationMethod.Value, options);
+			}
+
+			if (value.Type.HasValue)
+			{
+				writer.WritePropertyName("type");
+				JsonSerializer.Serialize(writer, value.Type.Value, options);
+			}
+
+			writer.WritePropertyName(fieldName);
+			JsonSerializer.Serialize(writer, value.BoundingBox, options);
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Geo/Distance/GeoDistanceQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Distance/GeoDistanceQueryConverter.cs
@@ -1,0 +1,142 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IGeoDistanceQuery"/> that handles
+	/// the field-name-wrapping pattern with distance and location parameters.
+	/// <para>
+	/// The OpenSearch geo_distance query JSON shape is:
+	/// <code>
+	/// {
+	///   "_name": "...",
+	///   "boost": 1.0,
+	///   "validation_method": "...",
+	///   "distance": "12km",
+	///   "distance_type": "arc",
+	///   "field_name": { "lat": 40, "lon": -70 }
+	/// }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class GeoDistanceQueryConverter : JsonConverter<IGeoDistanceQuery>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public GeoDistanceQueryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IGeoDistanceQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var query = new GeoDistanceQuery();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "_name":
+						query.Name = reader.GetString();
+						break;
+					case "boost":
+						query.Boost = reader.GetDouble();
+						break;
+					case "validation_method":
+						query.ValidationMethod = JsonSerializer.Deserialize<GeoValidationMethod>(ref reader, options);
+						break;
+					case "distance":
+						query.Distance = JsonSerializer.Deserialize<Distance>(ref reader, options);
+						break;
+					case "distance_type":
+						query.DistanceType = JsonSerializer.Deserialize<GeoDistanceType>(ref reader, options);
+						break;
+					default:
+						// This is the field name — its value is the geo location
+						query.Field = propertyName;
+						query.Location = JsonSerializer.Deserialize<GeoLocation>(ref reader, options);
+						break;
+				}
+			}
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IGeoDistanceQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var fieldName = _settings.Inferrer.Field(value.Field);
+			if (string.IsNullOrEmpty(fieldName))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				writer.WriteNumberValue(value.Boost.Value);
+			}
+
+			if (value.ValidationMethod.HasValue)
+			{
+				writer.WritePropertyName("validation_method");
+				JsonSerializer.Serialize(writer, value.ValidationMethod.Value, options);
+			}
+
+			if (value.Distance != null)
+			{
+				writer.WritePropertyName("distance");
+				JsonSerializer.Serialize(writer, value.Distance, options);
+			}
+
+			if (value.DistanceType.HasValue)
+			{
+				writer.WritePropertyName("distance_type");
+				JsonSerializer.Serialize(writer, value.DistanceType.Value, options);
+			}
+
+			writer.WritePropertyName(fieldName);
+			JsonSerializer.Serialize(writer, value.Location, options);
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Geo/GeoCoordinateConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/GeoCoordinateConverter.cs
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="GeoCoordinate"/> as a coordinate array <c>[lon, lat, [z]]</c> and
+	/// deserializes the same, matching the historical (Utf8Json) <c>GeoCoordinateFormatter</c>.
+	/// This differs from the base <see cref="GeoLocation"/> which serializes as <c>{ "lat": .., "lon": .. }</c>.
+	/// </summary>
+	internal sealed class GeoCoordinateConverter : JsonConverter<GeoCoordinate>
+	{
+		public override GeoCoordinate Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartArray)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var doubles = new List<double>(3);
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+			{
+				if (reader.TokenType == JsonTokenType.Number)
+					doubles.Add(reader.GetDouble());
+			}
+
+			switch (doubles.Count)
+			{
+				case 2:
+					return new GeoCoordinate(doubles[1], doubles[0]);
+				case 3:
+					return new GeoCoordinate(doubles[1], doubles[0], doubles[2]);
+				default:
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, GeoCoordinate value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartArray();
+			WriteDouble(writer, value.Longitude);
+			WriteDouble(writer, value.Latitude);
+			if (value.Z.HasValue)
+				WriteDouble(writer, value.Z.Value);
+			writer.WriteEndArray();
+		}
+
+		// Emits integral values with a trailing ".0" (e.g. 10.0 rather than 10), matching the
+		// client's historical wire format. The options-registered DoubleConverter is bypassed for
+		// values written from within a converter, so the same formatting is applied here directly.
+		private static void WriteDouble(Utf8JsonWriter writer, double value)
+		{
+			if (!double.IsNaN(value) && !double.IsInfinity(value)
+				&& Math.Floor(value) == value && Math.Abs(value) < 1e16)
+			{
+				writer.WriteRawValue(
+					value.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture),
+					skipInputValidation: true);
+				return;
+			}
+
+			writer.WriteNumberValue(value);
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Geo/GeoLocation.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/GeoLocation.cs
@@ -29,8 +29,8 @@
 using System;
 using System.Globalization;
 using System.Runtime.Serialization;
-using OpenSearch.Net.Utf8Json;
 
+using OpenSearch.Net.Utf8Json;
 /*
  * Taken from SolrNet https://github.com/mausch/SolrNet/blob/master/SolrNet/Location.cs
  */
@@ -40,6 +40,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Represents a Latitude/Longitude as a 2 dimensional point that gets serialized as { lat, lon }
 	/// </summary>
+	[System.Text.Json.Serialization.JsonConverter(typeof(GeoLocationConverter))]
 	[JsonFormatter(typeof(GeoLocationFormatter))]
 	public class GeoLocation : IEquatable<GeoLocation>, IFormattable
 	{
@@ -144,6 +145,7 @@ namespace OpenSearch.Client
 	/// Represents a Latitude/Longitude and optional Z value as a 2 or 3 dimensional point
 	/// that gets serialized as new [] { lon, lat, [z] }
 	/// </summary>
+	[System.Text.Json.Serialization.JsonConverter(typeof(GeoCoordinateConverter))]
 	[JsonFormatter(typeof(GeoCoordinateFormatter))]
 	public class GeoCoordinate : GeoLocation
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/GeoLocationConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/GeoLocationConverter.cs
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes <see cref="GeoLocation"/> as either a <c>{ "lat": .., "lon": .. }</c> object
+	/// (<see cref="GeoFormat.GeoJson"/>) or a Well-Known-Text <c>"POINT (lon lat)"</c> string
+	/// (<see cref="GeoFormat.WellKnownText"/>), and deserializes either form. Replaces the Utf8Json
+	/// <c>GeoLocationFormatter</c>.
+	/// </summary>
+	internal sealed class GeoLocationConverter : JsonConverter<GeoLocation>
+	{
+		public override GeoLocation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.String:
+				{
+					var wkt = reader.GetString();
+					if (string.IsNullOrEmpty(wkt))
+						return null;
+
+					// Parse the WKT point via the shared reader and project onto a GeoLocation.
+					if (GeoWKTReader.Read(wkt) is IPointGeoShape point && point.Coordinates != null)
+						return new GeoLocation(point.Coordinates.Latitude, point.Coordinates.Longitude)
+						{
+							Format = GeoFormat.WellKnownText
+						};
+					return null;
+				}
+				case JsonTokenType.StartObject:
+				{
+					double lat = 0, lon = 0;
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+					{
+						if (reader.TokenType != JsonTokenType.PropertyName)
+							continue;
+
+						var propertyName = reader.GetString();
+						reader.Read();
+						switch (propertyName)
+						{
+							case "lat":
+								lat = reader.GetDouble();
+								break;
+							case "lon":
+								lon = reader.GetDouble();
+								break;
+							default:
+								reader.Skip();
+								break;
+						}
+					}
+					return new GeoLocation(lat, lon) { Format = GeoFormat.GeoJson };
+				}
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, GeoLocation value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			switch (value.Format)
+			{
+				case GeoFormat.WellKnownText:
+					var lon = value.Longitude.ToString(CultureInfo.InvariantCulture);
+					var lat = value.Latitude.ToString(CultureInfo.InvariantCulture);
+					writer.WriteStringValue($"POINT ({lon} {lat})");
+					break;
+				default:
+					// Route lat/lon through the registered double converter so integral values keep
+					// their trailing ".0" (e.g. 34.0), matching the base serializer's number formatting.
+					var doubleConverter = (JsonConverter<double>)options.GetConverter(typeof(double));
+					writer.WriteStartObject();
+					writer.WritePropertyName("lat");
+					doubleConverter.Write(writer, value.Latitude, options);
+					writer.WritePropertyName("lon");
+					doubleConverter.Write(writer, value.Longitude, options);
+					writer.WriteEndObject();
+					break;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Geo/Polygon/GeoPolygonQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Polygon/GeoPolygonQueryConverter.cs
@@ -1,0 +1,157 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IGeoPolygonQuery"/> that handles
+	/// the field-name-wrapping pattern with polygon points.
+	/// <para>
+	/// The OpenSearch geo_polygon query JSON shape is:
+	/// <code>
+	/// {
+	///   "_name": "...",
+	///   "boost": 1.0,
+	///   "validation_method": "...",
+	///   "field_name": { "points": [ {...}, {...} ] }
+	/// }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class GeoPolygonQueryConverter : JsonConverter<IGeoPolygonQuery>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public GeoPolygonQueryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IGeoPolygonQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var query = new GeoPolygonQuery();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "_name":
+						query.Name = reader.GetString();
+						break;
+					case "boost":
+						query.Boost = reader.GetDouble();
+						break;
+					case "validation_method":
+						query.ValidationMethod = JsonSerializer.Deserialize<GeoValidationMethod>(ref reader, options);
+						break;
+					default:
+						// This is the field name — its value is the points object
+						query.Field = propertyName;
+						ReadPointsBody(ref reader, query, options);
+						break;
+				}
+			}
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IGeoPolygonQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var fieldName = _settings.Inferrer.Field(value.Field);
+			if (string.IsNullOrEmpty(fieldName))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				writer.WriteNumberValue(value.Boost.Value);
+			}
+
+			if (value.ValidationMethod.HasValue)
+			{
+				writer.WritePropertyName("validation_method");
+				JsonSerializer.Serialize(writer, value.ValidationMethod.Value, options);
+			}
+
+			writer.WritePropertyName(fieldName);
+			writer.WriteStartObject();
+			writer.WritePropertyName("points");
+			JsonSerializer.Serialize(writer, value.Points, options);
+			writer.WriteEndObject();
+
+			writer.WriteEndObject();
+		}
+
+		private static void ReadPointsBody(ref Utf8JsonReader reader, GeoPolygonQuery query, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return;
+			}
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var prop = reader.GetString();
+				reader.Read();
+
+				switch (prop)
+				{
+					case "points":
+						query.Points = JsonSerializer.Deserialize<IEnumerable<GeoLocation>>(ref reader, options);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/CircleGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/CircleGeoShape.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<ICircleGeoShape>))]
 	public interface ICircleGeoShape : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/EnvelopeGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/EnvelopeGeoShape.cs
@@ -33,6 +33,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<IEnvelopeGeoShape>))]
 	public interface IEnvelopeGeoShape : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeBase.cs
@@ -30,11 +30,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using OpenSearch.Net.Extensions;
+
 using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
-
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
+	[System.Text.Json.Serialization.JsonConverter(typeof(GeoShapeConverter))]
 	[JsonFormatter(typeof(GeoShapeFormatter))]
 	public interface IGeoShape
 	{
@@ -78,6 +80,7 @@ namespace OpenSearch.Client
 
 		internal GeoFormat Format { get; set; }
 	}
+
 
 	internal class GeoShapeFormatter<TShape> : IJsonFormatter<TShape>
 		where TShape : IGeoShape
@@ -344,4 +347,6 @@ namespace OpenSearch.Client
 			return coordinates;
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeConverter.cs
@@ -1,0 +1,148 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A polymorphic <see cref="JsonConverter{T}"/> for <see cref="IGeoShape"/> that emits/reads the
+	/// GeoJSON <c>{ "type": ..., "coordinates": ... }</c> shape (or a WKT string when the shape's
+	/// <see cref="GeoFormat"/> is <see cref="GeoFormat.WellKnownText"/>). Replaces the Utf8Json
+	/// <c>GeoShapeFormatter</c>.
+	/// </summary>
+	internal sealed class GeoShapeConverter : JsonConverter<IGeoShape>
+	{
+		public override bool CanConvert(Type typeToConvert) => typeof(IGeoShape).IsAssignableFrom(typeToConvert);
+
+		public override IGeoShape Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.String:
+					return GeoWKTReader.Read(reader.GetString());
+				case JsonTokenType.StartObject:
+					break;
+				default:
+					reader.Skip();
+					return null;
+			}
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			if (!root.TryGetProperty("type", out var typeElement) || typeElement.ValueKind != JsonValueKind.String)
+				return null;
+
+			var typeName = typeElement.GetString()?.ToUpperInvariant();
+
+			switch (typeName)
+			{
+				case GeoShapeType.Circle:
+					return new CircleGeoShape
+					{
+						Coordinates = GetCoordinates<GeoCoordinate>(root, options),
+						Radius = root.TryGetProperty("radius", out var r) ? r.GetString() : null
+					};
+				case GeoShapeType.Envelope:
+					return new EnvelopeGeoShape { Coordinates = GetCoordinates<IEnumerable<GeoCoordinate>>(root, options) };
+				case GeoShapeType.LineString:
+					return new LineStringGeoShape { Coordinates = GetCoordinates<IEnumerable<GeoCoordinate>>(root, options) };
+				case GeoShapeType.MultiLineString:
+					return new MultiLineStringGeoShape { Coordinates = GetCoordinates<IEnumerable<IEnumerable<GeoCoordinate>>>(root, options) };
+				case GeoShapeType.Point:
+					return new PointGeoShape { Coordinates = GetCoordinates<GeoCoordinate>(root, options) };
+				case GeoShapeType.MultiPoint:
+					return new MultiPointGeoShape { Coordinates = GetCoordinates<IEnumerable<GeoCoordinate>>(root, options) };
+				case GeoShapeType.Polygon:
+					return new PolygonGeoShape { Coordinates = GetCoordinates<IEnumerable<IEnumerable<GeoCoordinate>>>(root, options) };
+				case GeoShapeType.MultiPolygon:
+					return new MultiPolygonGeoShape { Coordinates = GetCoordinates<IEnumerable<IEnumerable<IEnumerable<GeoCoordinate>>>>(root, options) };
+				case GeoShapeType.GeometryCollection:
+					return new GeometryCollection
+					{
+						Geometries = root.TryGetProperty("geometries", out var g)
+							? g.Deserialize<IEnumerable<IGeoShape>>(options)
+							: null
+					};
+				default:
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, IGeoShape value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			if (value is GeoShapeBase shapeBase && shapeBase.Format == GeoFormat.WellKnownText)
+			{
+				writer.WriteStringValue(GeoWKTWriter.Write(shapeBase));
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName("type");
+			writer.WriteStringValue(value.Type);
+
+			switch (value)
+			{
+				case IPointGeoShape point:
+					writer.WritePropertyName("coordinates");
+					JsonSerializer.Serialize(writer, point.Coordinates, options);
+					break;
+				case IMultiPointGeoShape multiPoint:
+					writer.WritePropertyName("coordinates");
+					JsonSerializer.Serialize(writer, multiPoint.Coordinates, options);
+					break;
+				case ILineStringGeoShape lineString:
+					writer.WritePropertyName("coordinates");
+					JsonSerializer.Serialize(writer, lineString.Coordinates, options);
+					break;
+				case IMultiLineStringGeoShape multiLineString:
+					writer.WritePropertyName("coordinates");
+					JsonSerializer.Serialize(writer, multiLineString.Coordinates, options);
+					break;
+				case IPolygonGeoShape polygon:
+					writer.WritePropertyName("coordinates");
+					JsonSerializer.Serialize(writer, polygon.Coordinates, options);
+					break;
+				case IMultiPolygonGeoShape multiPolygon:
+					writer.WritePropertyName("coordinates");
+					JsonSerializer.Serialize(writer, multiPolygon.Coordinates, options);
+					break;
+				case IEnvelopeGeoShape envelope:
+					writer.WritePropertyName("coordinates");
+					JsonSerializer.Serialize(writer, envelope.Coordinates, options);
+					break;
+				case ICircleGeoShape circle:
+					writer.WritePropertyName("coordinates");
+					JsonSerializer.Serialize(writer, circle.Coordinates, options);
+					writer.WritePropertyName("radius");
+					writer.WriteStringValue(circle.Radius);
+					break;
+				case IGeometryCollection collection:
+					writer.WritePropertyName("geometries");
+					JsonSerializer.Serialize(writer, collection.Geometries, options);
+					break;
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static T GetCoordinates<T>(JsonElement root, JsonSerializerOptions options) =>
+			root.TryGetProperty("coordinates", out var coords) ? coords.Deserialize<T>(options) : default;
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeoShapeQueryConverter.cs
@@ -1,0 +1,212 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IGeoShapeQuery"/> that handles
+	/// the field-name-wrapping pattern with nested shape/indexed_shape properties.
+	/// <para>
+	/// The OpenSearch geo_shape query JSON shape is:
+	/// <code>
+	/// {
+	///   "_name": "...",
+	///   "boost": 1.0,
+	///   "ignore_unmapped": false,
+	///   "field_name": {
+	///     "shape": { "type": "...", "coordinates": [...] },
+	///     "relation": "intersects"
+	///   }
+	/// }
+	/// </code>
+	/// or with indexed shape:
+	/// <code>
+	/// {
+	///   "field_name": {
+	///     "indexed_shape": { "id": "...", "index": "...", "path": "..." },
+	///     "relation": "intersects"
+	///   }
+	/// }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class GeoShapeQueryConverter : JsonConverter<IGeoShapeQuery>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public GeoShapeQueryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IGeoShapeQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			string fieldName = null;
+			double? boost = null;
+			string name = null;
+			bool? ignoreUnmapped = null;
+			IGeoShape shape = null;
+			IFieldLookup indexedShape = null;
+			GeoShapeRelation? relation = null;
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "boost":
+						boost = reader.GetDouble();
+						break;
+					case "_name":
+						name = reader.GetString();
+						break;
+					case "ignore_unmapped":
+						ignoreUnmapped = reader.GetBoolean();
+						break;
+					default:
+						// This is the field name — its value is the shape parameters object
+						fieldName = propertyName;
+						ReadShapeBody(ref reader, options, out shape, out indexedShape, out relation);
+						break;
+				}
+			}
+
+			if (fieldName == null)
+				return null;
+
+			return new GeoShapeQuery
+			{
+				Field = fieldName,
+				Boost = boost,
+				Name = name,
+				IgnoreUnmapped = ignoreUnmapped,
+				Shape = shape,
+				IndexedShape = indexedShape,
+				Relation = relation
+			};
+		}
+
+		public override void Write(Utf8JsonWriter writer, IGeoShapeQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var fieldName = _settings.Inferrer.Field(value.Field);
+			if (string.IsNullOrEmpty(fieldName))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				writer.WriteNumberValue(value.Boost.Value);
+			}
+
+			if (value.IgnoreUnmapped.HasValue)
+			{
+				writer.WritePropertyName("ignore_unmapped");
+				writer.WriteBooleanValue(value.IgnoreUnmapped.Value);
+			}
+
+			writer.WritePropertyName(fieldName);
+			writer.WriteStartObject();
+
+			if (value.Shape != null)
+			{
+				writer.WritePropertyName("shape");
+				JsonSerializer.Serialize(writer, value.Shape, options);
+			}
+			else if (value.IndexedShape != null)
+			{
+				writer.WritePropertyName("indexed_shape");
+				JsonSerializer.Serialize(writer, value.IndexedShape, options);
+			}
+
+			if (value.Relation.HasValue)
+			{
+				writer.WritePropertyName("relation");
+				JsonSerializer.Serialize(writer, value.Relation.Value, options);
+			}
+
+			writer.WriteEndObject(); // end field body
+			writer.WriteEndObject(); // end outer
+		}
+
+		private static void ReadShapeBody(ref Utf8JsonReader reader, JsonSerializerOptions options,
+			out IGeoShape shape, out IFieldLookup indexedShape, out GeoShapeRelation? relation)
+		{
+			shape = null;
+			indexedShape = null;
+			relation = null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return;
+			}
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var prop = reader.GetString();
+				reader.Read();
+
+				switch (prop)
+				{
+					case "shape":
+						shape = JsonSerializer.Deserialize<IGeoShape>(ref reader, options);
+						break;
+					case "indexed_shape":
+						indexedShape = JsonSerializer.Deserialize<IFieldLookup>(ref reader, options);
+						break;
+					case "relation":
+						relation = JsonSerializer.Deserialize<GeoShapeRelation>(ref reader, options);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeometryCollection.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/GeometryCollection.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A geo shape representing a collection of <see cref="IGeoShape" /> geometries
 	/// </summary>
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<IGeometryCollection>))]
 	public interface IGeometryCollection : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/LineStringGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/LineStringGeoShape.cs
@@ -33,6 +33,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<ILineStringGeoShape>))]
 	public interface ILineStringGeoShape : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiLineStringGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiLineStringGeoShape.cs
@@ -33,6 +33,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<IMultiLineStringGeoShape>))]
 	public interface IMultiLineStringGeoShape : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiPointGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiPointGeoShape.cs
@@ -33,6 +33,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<IMultiPointGeoShape>))]
 	public interface IMultiPointGeoShape : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiPolygonGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/MultiPolygonGeoShape.cs
@@ -33,6 +33,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<IMultiPolygonGeoShape>))]
 	public interface IMultiPolygonGeoShape : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/PointGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/PointGeoShape.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<IPointGeoShape>))]
 	public interface IPointGeoShape : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/Geo/Shape/PolygonGeoShape.cs
+++ b/src/OpenSearch.Client/QueryDsl/Geo/Shape/PolygonGeoShape.cs
@@ -33,6 +33,7 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	[JsonFormatter(typeof(GeoShapeFormatter<IPolygonGeoShape>))]
 	public interface IPolygonGeoShape : IGeoShape
 	{

--- a/src/OpenSearch.Client/QueryDsl/MultiTermQueryRewrite/MultiTermQueryRewriteConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/MultiTermQueryRewrite/MultiTermQueryRewriteConverter.cs
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="MultiTermQueryRewrite"/> that handles
+	/// string-based serialization/deserialization of rewrite parameter values.
+	/// <para>
+	/// Example JSON values: <c>"constant_score"</c>, <c>"scoring_boolean"</c>,
+	/// <c>"top_terms_boost_N"</c>, <c>"top_terms_N"</c>
+	/// </para>
+	/// </summary>
+	internal sealed class MultiTermQueryRewriteConverter : JsonConverter<MultiTermQueryRewrite>
+	{
+		public override MultiTermQueryRewrite Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.String)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var value = reader.GetString();
+			return MultiTermQueryRewrite.Create(value);
+		}
+
+		public override void Write(Utf8JsonWriter writer, MultiTermQueryRewrite value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				writer.WriteStringValue(value.ToString());
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/MultiTermQueryRewrite/RewriteMultiTerm.cs
+++ b/src/OpenSearch.Client/QueryDsl/MultiTermQueryRewrite/RewriteMultiTerm.cs
@@ -28,8 +28,9 @@
 
 using System;
 using System.Runtime.Serialization;
-using OpenSearch.Net;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
@@ -93,6 +94,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Controls how a multi term query such as a wildcard or prefix query, is rewritten.
 	/// </summary>
+	[JsonConverter(typeof(MultiTermQueryRewriteConverter))]
 	[JsonFormatter(typeof(MultiTermQueryRewriteFormatter))]
 	public class MultiTermQueryRewrite : IEquatable<MultiTermQueryRewrite>
 	{

--- a/src/OpenSearch.Client/QueryDsl/Query.cs
+++ b/src/OpenSearch.Client/QueryDsl/Query.cs
@@ -123,6 +123,9 @@ namespace OpenSearch.Client
 		public static QueryContainer MultiMatch(Func<MultiMatchQueryDescriptor<T>, IMultiMatchQuery> selector) =>
 			new QueryContainerDescriptor<T>().MultiMatch(selector);
 
+		public static QueryContainer CombinedFields(Func<CombinedFieldsQueryDescriptor<T>, ICombinedFieldsQuery> selector) =>
+			new QueryContainerDescriptor<T>().CombinedFields(selector);
+
 		public static QueryContainer Nested(Func<NestedQueryDescriptor<T>, INestedQuery> selector) =>
 			new QueryContainerDescriptor<T>().Nested(selector);
 

--- a/src/OpenSearch.Client/QueryDsl/Span/Gap/SpanGapQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Gap/SpanGapQuery.cs
@@ -29,11 +29,13 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[JsonConverter(typeof(SpanGapQueryConverter))]
 	[JsonFormatter(typeof(SpanGapQueryFormatter))]
 	public interface ISpanGapQuery : ISpanSubQuery
 	{
@@ -111,4 +113,6 @@ namespace OpenSearch.Client
 			return query;
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/QueryDsl/Span/Gap/SpanGapQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Gap/SpanGapQueryConverter.cs
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="ISpanGapQuery"/> that handles
+	/// the simple single-key object pattern where the key is the field name and the
+	/// value is the gap width.
+	/// <para>
+	/// Example JSON shape:
+	/// <code>
+	/// { "field_name": 3 }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class SpanGapQueryConverter : JsonConverter<ISpanGapQuery>
+	{
+		public override ISpanGapQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var query = new SpanGapQuery();
+
+			if (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+			{
+				query.Field = reader.GetString();
+				reader.Read(); // Move to value
+				query.Width = reader.GetInt32();
+			}
+
+			// Read to end of object
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+			}
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, ISpanGapQuery value, JsonSerializerOptions options)
+		{
+			if (value == null || SpanGapQuery.IsConditionless(value))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var fieldName = value.Field?.ToString();
+			if (string.IsNullOrEmpty(fieldName))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(fieldName);
+			writer.WriteNumberValue(value.Width.Value);
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Span/Term/SpanTermQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Span/Term/SpanTermQuery.cs
@@ -27,15 +27,18 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(SpanTermQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<SpanTermQuery, ISpanTermQuery>))]
 	public interface ISpanTermQuery : ISpanSubQuery, IFieldNameQuery
 	{
 		[DataMember(Name = "value")]
+		[JsonConverter(typeof(SourceValueWriteConverter))]
 		[JsonFormatter(typeof(SourceWriteFormatter<object>))]
 		object Value { get; set; }
 	}

--- a/src/OpenSearch.Client/QueryDsl/Specialized/DistanceFeature/DistanceFeatureQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/DistanceFeature/DistanceFeatureQuery.cs
@@ -27,9 +27,10 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
 using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
-
 namespace OpenSearch.Client
 {
 	/// <summary>
@@ -38,8 +39,9 @@ namespace OpenSearch.Client
 	/// You can use the distance_feature query to find the nearest neighbors to a location. You can also use the query in a bool
 	/// search’s should filter to add boosted relevance scores to the bool query’s scores.
 	/// </summary>
-	[JsonFormatter(typeof(DistanceFeatureQueryFormatter))]
+	[JsonConverter(typeof(DistanceFeatureQueryConverter))]
 	[InterfaceDataContract]
+	[JsonFormatter(typeof(DistanceFeatureQueryFormatter))]
 	public interface IDistanceFeatureQuery : IFieldNameQuery
 	{
 		/// <summary>
@@ -192,4 +194,6 @@ namespace OpenSearch.Client
 			return query;
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/QueryDsl/Specialized/DistanceFeature/DistanceFeatureQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/DistanceFeature/DistanceFeatureQueryConverter.cs
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IDistanceFeatureQuery"/> that handles
+	/// the distance_feature query with its field, origin, and pivot parameters.
+	/// <para>
+	/// Example JSON shape:
+	/// <code>
+	/// {
+	///   "_name": "...",
+	///   "boost": 1.0,
+	///   "field": "production_date",
+	///   "origin": "now",
+	///   "pivot": "7d"
+	/// }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class DistanceFeatureQueryConverter : JsonConverter<IDistanceFeatureQuery>
+	{
+		public override IDistanceFeatureQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var query = new DistanceFeatureQuery();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "_name":
+						query.Name = reader.GetString();
+						break;
+					case "boost":
+						query.Boost = reader.GetDouble();
+						break;
+					case "field":
+						query.Field = JsonSerializer.Deserialize<Field>(ref reader, options);
+						break;
+					case "origin":
+						query.Origin = JsonSerializer.Deserialize<Union<GeoCoordinate, DateMath>>(ref reader, options);
+						break;
+					case "pivot":
+						query.Pivot = JsonSerializer.Deserialize<Union<Distance, Time>>(ref reader, options);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IDistanceFeatureQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				writer.WriteNumberValue(value.Boost.Value);
+			}
+
+			if (value.Field != null)
+			{
+				writer.WritePropertyName("field");
+				JsonSerializer.Serialize(writer, value.Field, options);
+			}
+
+			if (value.Origin != null)
+			{
+				writer.WritePropertyName("origin");
+				JsonSerializer.Serialize(writer, value.Origin, options);
+			}
+
+			if (value.Pivot != null)
+			{
+				writer.WritePropertyName("pivot");
+				JsonSerializer.Serialize(writer, value.Pivot, options);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Hybrid/HybridQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Hybrid/HybridQuery.cs
@@ -21,7 +21,7 @@ namespace OpenSearch.Client;
 public interface IHybridQuery : IQuery
 {
 	[DataMember(Name = "pagination_depth")]
-    int? PaginationDepth { get; set; }
+	int? PaginationDepth { get; set; }
 
     [DataMember(Name = "queries")]
     IEnumerable<QueryContainer> Queries { get; set; }

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Knn/KnnQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Knn/KnnQuery.cs
@@ -15,6 +15,7 @@ namespace OpenSearch.Client;
 /// An approximate k-NN query.
 /// </summary>
 [InterfaceDataContract]
+[ReadAs(typeof(KnnQuery))]
 [JsonFormatter(typeof(FieldNameQueryFormatter<KnnQuery, IKnnQuery>))]
 public interface IKnnQuery : IFieldNameQuery
 {

--- a/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/Like/Like.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/Like/Like.cs
@@ -86,4 +86,6 @@ namespace OpenSearch.Client
 		public void Serialize(ref JsonWriter writer, Like value, IJsonFormatterResolver formatterResolver) =>
 			UnionFormatter.Serialize(ref writer, value, formatterResolver);
 	}
+
+
 }

--- a/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
@@ -43,6 +43,7 @@ namespace OpenSearch.Client
 		/// A document to find other documents like
 		/// </summary>
 		[DataMember(Name = "doc")]
+		[SourceSerialization]
 		[JsonFormatter(typeof(SourceFormatter<object>))]
 		object Document { get; set; }
 

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Neural/NeuralQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Neural/NeuralQuery.cs
@@ -14,6 +14,7 @@ namespace OpenSearch.Client;
 /// A neural query.
 /// </summary>
 [InterfaceDataContract]
+[ReadAs(typeof(NeuralQuery))]
 [JsonFormatter(typeof(FieldNameQueryFormatter<NeuralQuery, INeuralQuery>))]
 public interface INeuralQuery : IFieldNameQuery
 {

--- a/src/OpenSearch.Client/QueryDsl/Specialized/RankFeature/RankFeatureQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/RankFeature/RankFeatureQuery.cs
@@ -28,9 +28,10 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
 using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
-
 namespace OpenSearch.Client
 {
 	/// <summary>
@@ -41,8 +42,9 @@ namespace OpenSearch.Client
 	/// Compared to using function_score or other ways to modify the score, this query has the benefit of being able to efficiently
 	/// skip non-competitive hits when track_total_hits is not set to true. Speedups may be spectacular.
 	/// </summary>
-	[JsonFormatter(typeof(RankFeatureQueryFormatter))]
+	[JsonConverter(typeof(RankFeatureQueryConverter))]
 	[InterfaceDataContract]
+	[JsonFormatter(typeof(RankFeatureQueryFormatter))]
 	public interface IRankFeatureQuery : IFieldNameQuery
 	{
 		/// <inheritdoc cref="IRankFeatureFunction"/>
@@ -92,6 +94,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A function to boost scores in a rank_feature query, using the values of rank features.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IRankFeatureFunction { }
 
 	/// <summary>
@@ -99,6 +102,7 @@ namespace OpenSearch.Client
 	/// scaling factor. Scores are unbounded.
 	/// This function only supports rank features that have a positive score impact.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IRankFeatureLogarithmFunction : IRankFeatureFunction
 	{
 		/// <summary>
@@ -131,6 +135,7 @@ namespace OpenSearch.Client
 	/// so that the result will be less than 0.5 if S is less than pivot and greater than 0.5 otherwise. Scores are always is (0, 1).
 	/// If the rank feature has a negative score impact then the function will be computed as pivot / (S + pivot), which decreases when S increases.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IRankFeatureSaturationFunction : IRankFeatureFunction
 	{
 		[DataMember(Name = "pivot")]
@@ -160,6 +165,7 @@ namespace OpenSearch.Client
 	/// exponent must be positive, but is typically in [0.5, 1]. A good value should be computed via training. If you don’t have the opportunity
 	/// to do so, we recommend that you stick to the saturation function instead.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IRankFeatureSigmoidFunction : IRankFeatureFunction
 	{
 		[DataMember(Name = "pivot")]
@@ -333,4 +339,6 @@ namespace OpenSearch.Client
 			return query;
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/QueryDsl/Specialized/RankFeature/RankFeatureQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/RankFeature/RankFeatureQueryConverter.cs
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IRankFeatureQuery"/> that handles
+	/// the rank_feature query with its various score function types (saturation, log, sigmoid, linear).
+	/// <para>
+	/// Example JSON shape:
+	/// <code>
+	/// {
+	///   "_name": "...",
+	///   "boost": 1.0,
+	///   "field": "pagerank",
+	///   "saturation": { "pivot": 8 }
+	/// }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class RankFeatureQueryConverter : JsonConverter<IRankFeatureQuery>
+	{
+		public override IRankFeatureQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var query = new RankFeatureQuery();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "_name":
+						query.Name = reader.GetString();
+						break;
+					case "boost":
+						query.Boost = reader.GetDouble();
+						break;
+					case "field":
+						query.Field = JsonSerializer.Deserialize<Field>(ref reader, options);
+						break;
+					case "saturation":
+						query.Function = JsonSerializer.Deserialize<RankFeatureSaturationFunction>(ref reader, options);
+						break;
+					case "log":
+						query.Function = JsonSerializer.Deserialize<RankFeatureLogarithmFunction>(ref reader, options);
+						break;
+					case "sigmoid":
+						query.Function = JsonSerializer.Deserialize<RankFeatureSigmoidFunction>(ref reader, options);
+						break;
+					case "linear":
+						query.Function = JsonSerializer.Deserialize<RankFeatureLinearFunction>(ref reader, options);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IRankFeatureQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				writer.WriteNumberValue(value.Boost.Value);
+			}
+
+			if (value.Field != null)
+			{
+				writer.WritePropertyName("field");
+				JsonSerializer.Serialize(writer, value.Field, options);
+			}
+
+			if (value.Function != null)
+			{
+				switch (value.Function)
+				{
+					case IRankFeatureSigmoidFunction sigmoid:
+						writer.WritePropertyName("sigmoid");
+						JsonSerializer.Serialize(writer, sigmoid, options);
+						break;
+					case IRankFeatureSaturationFunction saturation:
+						writer.WritePropertyName("saturation");
+						JsonSerializer.Serialize(writer, saturation, options);
+						break;
+					case IRankFeatureLogarithmFunction log:
+						writer.WritePropertyName("log");
+						JsonSerializer.Serialize(writer, log, options);
+						break;
+					case IRankFeatureLinearFunction linear:
+						writer.WritePropertyName("linear");
+						JsonSerializer.Serialize(writer, linear, options);
+						break;
+				}
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
@@ -57,7 +57,7 @@ namespace OpenSearch.Client
 		/// The score above which documents will be returned
 		/// </summary>
 		[DataMember(Name = "min_score")]
-        double? MinScore { get; set; }
+		double? MinScore { get; set; }
 	}
 
 	/// <inheritdoc cref="IScriptScoreQuery" />

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Shape/CartesianPoint.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Shape/CartesianPoint.cs
@@ -29,11 +29,11 @@
 using System;
 using System.IO;
 using System.Text;
-using OpenSearch.Net.Utf8Json;
-using OpenSearch.Net.Utf8Json.Internal;
 using OpenSearch.Client;
 using OpenSearch.Net.Extensions;
 
+using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net.Utf8Json.Internal;
 namespace OpenSearch.Client
 {
 	internal enum ShapeFormat
@@ -285,4 +285,6 @@ namespace OpenSearch.Client
 			}
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Shape/IShapeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Shape/IShapeQuery.cs
@@ -28,11 +28,13 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[JsonConverter(typeof(ShapeQueryConverter))]
 	[JsonFormatter(typeof(CompositeFormatter<IShapeQuery, ShapeQueryFormatter, ShapeQueryFieldNameFormatter>))]
 	public interface IShapeQuery : IFieldNameQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/Specialized/Shape/ShapeQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/Specialized/Shape/ShapeQueryConverter.cs
@@ -1,0 +1,208 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IShapeQuery"/> that handles
+	/// the field-name-wrapping pattern with nested shape/indexed_shape properties.
+	/// <para>
+	/// The OpenSearch shape query JSON shape is:
+	/// <code>
+	/// {
+	///   "_name": "...",
+	///   "boost": 1.0,
+	///   "ignore_unmapped": false,
+	///   "field_name": {
+	///     "shape": { "type": "...", "coordinates": [...] },
+	///     "relation": "intersects"
+	///   }
+	/// }
+	/// </code>
+	/// or with indexed shape:
+	/// <code>
+	/// {
+	///   "field_name": {
+	///     "indexed_shape": { "id": "...", "index": "...", "path": "..." },
+	///     "relation": "intersects"
+	///   }
+	/// }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class ShapeQueryConverter : JsonConverter<IShapeQuery>
+	{
+		public override IShapeQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			string fieldName = null;
+			double? boost = null;
+			string name = null;
+			bool? ignoreUnmapped = null;
+			IGeoShape shape = null;
+			IFieldLookup indexedShape = null;
+			ShapeRelation? relation = null;
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "boost":
+						boost = reader.GetDouble();
+						break;
+					case "_name":
+						name = reader.GetString();
+						break;
+					case "ignore_unmapped":
+						ignoreUnmapped = reader.GetBoolean();
+						break;
+					default:
+						// This is the field name — its value is the shape parameters object
+						fieldName = propertyName;
+						ReadShapeBody(ref reader, options, out shape, out indexedShape, out relation);
+						break;
+				}
+			}
+
+			if (fieldName == null)
+				return null;
+
+			return new ShapeQuery
+			{
+				Field = fieldName,
+				Boost = boost,
+				Name = name,
+				IgnoreUnmapped = ignoreUnmapped,
+				Shape = shape,
+				IndexedShape = indexedShape,
+				Relation = relation
+			};
+		}
+
+		public override void Write(Utf8JsonWriter writer, IShapeQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var fieldName = value.Field?.ToString();
+			if (string.IsNullOrEmpty(fieldName))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				writer.WriteNumberValue(value.Boost.Value);
+			}
+
+			if (value.IgnoreUnmapped.HasValue)
+			{
+				writer.WritePropertyName("ignore_unmapped");
+				writer.WriteBooleanValue(value.IgnoreUnmapped.Value);
+			}
+
+			writer.WritePropertyName(fieldName);
+			writer.WriteStartObject();
+
+			if (value.Shape != null)
+			{
+				writer.WritePropertyName("shape");
+				JsonSerializer.Serialize(writer, value.Shape, options);
+			}
+			else if (value.IndexedShape != null)
+			{
+				writer.WritePropertyName("indexed_shape");
+				JsonSerializer.Serialize(writer, value.IndexedShape, options);
+			}
+
+			if (value.Relation.HasValue)
+			{
+				writer.WritePropertyName("relation");
+				JsonSerializer.Serialize(writer, value.Relation.Value, options);
+			}
+
+			writer.WriteEndObject(); // end field body
+			writer.WriteEndObject(); // end outer
+		}
+
+		private static void ReadShapeBody(ref Utf8JsonReader reader, JsonSerializerOptions options,
+			out IGeoShape shape, out IFieldLookup indexedShape, out ShapeRelation? relation)
+		{
+			shape = null;
+			indexedShape = null;
+			relation = null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return;
+			}
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var prop = reader.GetString();
+				reader.Read();
+
+				switch (prop)
+				{
+					case "shape":
+						shape = JsonSerializer.Deserialize<IGeoShape>(ref reader, options);
+						break;
+					case "indexed_shape":
+						indexedShape = JsonSerializer.Deserialize<IFieldLookup>(ref reader, options);
+						break;
+					case "relation":
+						relation = JsonSerializer.Deserialize<ShapeRelation>(ref reader, options);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueryBase.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueryBase.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(FuzzyQuery))]
 	[JsonFormatter(typeof(FuzzyQueryFormatter))]
 	public interface IFuzzyQuery : IFieldNameQuery
 	{
@@ -48,6 +49,7 @@ namespace OpenSearch.Client
 		bool? Transpositions { get; set; }
 	}
 
+	[InterfaceDataContract]
 	public interface IFuzzyQuery<TValue, TFuzziness> : IFuzzyQuery
 	{
 		[DataMember(Name ="fuzziness")]

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Fuzzy/FuzzyQueryConverter.cs
@@ -1,0 +1,159 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IFuzzyQuery"/> that handles the
+	/// field-name-wrapping pattern and polymorphic dispatch to the correct fuzzy query
+	/// subtype (string, numeric, date) based on the JSON shape of the <c>value</c> property.
+	/// <para>
+	/// The OpenSearch fuzzy query JSON shape is:
+	/// <code>{ "field_name": { "value": ..., "fuzziness": ..., ... } }</code>
+	/// A numeric <c>value</c> indicates <see cref="FuzzyNumericQuery"/>; a date-like string
+	/// value indicates <see cref="FuzzyDateQuery"/>; any other string indicates <see cref="FuzzyQuery"/>.
+	/// </para>
+	/// <para>
+	/// This is the System.Text.Json equivalent of the Utf8Json <c>FuzzyQueryFormatter</c>.
+	/// </para>
+	/// </summary>
+	internal sealed class FuzzyQueryConverter : JsonConverter<IFuzzyQuery>
+	{
+		private static readonly ConditionalWeakTable<JsonSerializerOptions, JsonSerializerOptions> BodyOptionsCache = new();
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public FuzzyQueryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		private static JsonSerializerOptions GetBodyOptions(JsonSerializerOptions options) =>
+			BodyOptionsCache.GetValue(options, static o =>
+			{
+				var clone = new JsonSerializerOptions(o);
+				for (var i = clone.Converters.Count - 1; i >= 0; i--)
+				{
+					if (clone.Converters[i] is FuzzyQueryConverter)
+						clone.Converters.RemoveAt(i);
+				}
+				return clone;
+			});
+
+		public override IFuzzyQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			reader.Read(); // move to first token inside the outer object
+
+			if (reader.TokenType == JsonTokenType.EndObject)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.PropertyName)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var fieldName = reader.GetString();
+			reader.Read(); // move to the body value
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				reader.Read(); // consume outer EndObject
+				return null;
+			}
+
+			// Buffer the body so we can inspect the "value" token to determine the concrete type.
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var body = doc.RootElement;
+
+			IFuzzyQuery query;
+			if (body.TryGetProperty("value", out var valueElement))
+			{
+				switch (valueElement.ValueKind)
+				{
+					case JsonValueKind.Number:
+						query = JsonSerializer.Deserialize<FuzzyNumericQuery>(body.GetRawText(), GetBodyOptions(options));
+						break;
+					case JsonValueKind.String when IsDateValue(valueElement.GetString()):
+						query = JsonSerializer.Deserialize<FuzzyDateQuery>(body.GetRawText(), GetBodyOptions(options));
+						break;
+					default:
+						query = JsonSerializer.Deserialize<FuzzyQuery>(body.GetRawText(), GetBodyOptions(options));
+						break;
+				}
+			}
+			else
+			{
+				query = JsonSerializer.Deserialize<FuzzyQuery>(body.GetRawText(), GetBodyOptions(options));
+			}
+
+			reader.Read(); // consume outer EndObject
+
+			if (query is FieldNameQueryBase fnq)
+				fnq.Field = fieldName;
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IFuzzyQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var field = (value as IFieldNameQuery)?.Field;
+			var resolvedField = field == null ? null : _settings.Inferrer.Field(field);
+			if (string.IsNullOrEmpty(resolvedField))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(resolvedField);
+
+			// Serialize the body using the actual runtime type so all properties (including the
+			// concrete Value/Fuzziness) are emitted, using the body options that exclude this
+			// converter (avoids recursion).
+			JsonSerializer.Serialize(writer, value, value.GetType(), GetBodyOptions(options));
+
+			writer.WriteEndObject();
+		}
+
+		private static bool IsDateValue(string value)
+		{
+			if (string.IsNullOrEmpty(value))
+				return false;
+
+			if (value.Contains("||"))
+				return true;
+
+			if (value.Length >= 10 && value[4] == '-' && value[7] == '-')
+				return true;
+
+			if (value.StartsWith("now", StringComparison.OrdinalIgnoreCase))
+				return true;
+
+			return false;
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(PrefixQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<PrefixQuery, IPrefixQuery>))]
 	public interface IPrefixQuery : ITermQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/DateRangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/DateRangeQuery.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(DateRangeQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<DateRangeQuery, IDateRangeQuery>))]
 	public interface IDateRangeQuery : IRangeQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/LongRangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/LongRangeQuery.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(LongRangeQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<LongRangeQuery, ILongRangeQuery>))]
 	public interface ILongRangeQuery : IRangeQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/NumericRangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/NumericRangeQuery.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(NumericRangeQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<NumericRangeQuery, INumericRangeQuery>))]
 	public interface INumericRangeQuery : IRangeQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeQuery.cs
@@ -26,11 +26,13 @@
 *  under the License.
 */
 
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[JsonConverter(typeof(RangeQueryConverter))]
 	[JsonFormatter(typeof(RangeQueryFormatter))]
 	public interface IRangeQuery : IFieldNameQuery { }
 }

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/RangeQueryConverter.cs
@@ -1,0 +1,349 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IRangeQuery"/> that handles
+	/// the field-name-wrapping pattern and polymorphic dispatch to the correct range
+	/// query subtype (Date, Numeric, Long, Term).
+	/// <para>
+	/// The OpenSearch range query JSON shape is:
+	/// <code>
+	/// { "field_name": { "gte": ..., "lte": ..., "format": "...", ... } }
+	/// </code>
+	/// The presence of <c>format</c> or <c>time_zone</c> indicates a date range;
+	/// a decimal number indicates numeric; an integer indicates long; otherwise term range.
+	/// </para>
+	/// </summary>
+	internal sealed class RangeQueryConverter : JsonConverter<IRangeQuery>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public RangeQueryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IRangeQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			// We need to buffer the entire value to inspect it and determine the concrete type
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			string fieldName = null;
+			JsonElement fieldBody = default;
+
+			// The range query is { "field_name": { range params } }
+			foreach (var property in root.EnumerateObject())
+			{
+				fieldName = property.Name;
+				fieldBody = property.Value;
+				break; // Only one property expected (the field name)
+			}
+
+			if (fieldName == null || fieldBody.ValueKind != JsonValueKind.Object)
+				return null;
+
+			// Determine the range type by inspecting the field body
+			var isDate = false;
+			var isDouble = false;
+			var isLong = false;
+
+			foreach (var prop in fieldBody.EnumerateObject())
+			{
+				switch (prop.Name)
+				{
+					case "format":
+					case "time_zone":
+						isDate = true;
+						break;
+					case "gt":
+					case "gte":
+					case "lt":
+					case "lte":
+						if (!isDate)
+						{
+							switch (prop.Value.ValueKind)
+							{
+								case JsonValueKind.String:
+									var strValue = prop.Value.GetString();
+									if (IsDateValue(strValue))
+										isDate = true;
+									break;
+								case JsonValueKind.Number:
+									if (!isDouble)
+									{
+										if (prop.Value.TryGetInt64(out _))
+											isLong = true;
+										else
+											isDouble = true;
+									}
+									break;
+							}
+						}
+						break;
+				}
+
+				if (isDate || isDouble)
+					break;
+			}
+
+			// Deserialize the field body into the appropriate range query type
+			var fieldBodyJson = fieldBody.GetRawText();
+			IRangeQuery result;
+
+			if (isDate)
+				result = JsonSerializer.Deserialize<DateRangeQuery>(fieldBodyJson, options);
+			else if (isDouble)
+				result = JsonSerializer.Deserialize<NumericRangeQuery>(fieldBodyJson, options);
+			else if (isLong)
+				result = JsonSerializer.Deserialize<LongRangeQuery>(fieldBodyJson, options);
+			else
+				result = JsonSerializer.Deserialize<TermRangeQuery>(fieldBodyJson, options);
+
+			if (result is FieldNameQueryBase fnq)
+				fnq.Field = fieldName;
+
+			return result;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IRangeQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// The range query is wrapped in a field name object:
+			// { "field_name": { "gte": ..., "lte": ..., ... } }
+			var field = (value as IFieldNameQuery)?.Field;
+			var fieldName = field == null ? null : _settings.Inferrer.Field(field);
+			if (string.IsNullOrEmpty(fieldName))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WritePropertyName(fieldName);
+
+			// Write the inner range parameters based on the concrete type
+			switch (value)
+			{
+				case IDateRangeQuery dateRange:
+					WriteRangeBody(writer, dateRange, options);
+					break;
+				case INumericRangeQuery numericRange:
+					WriteRangeBody(writer, numericRange, options);
+					break;
+				case ILongRangeQuery longRange:
+					WriteRangeBody(writer, longRange, options);
+					break;
+				case ITermRangeQuery termRange:
+					WriteRangeBody(writer, termRange, options);
+					break;
+				default:
+					writer.WriteStartObject();
+					writer.WriteEndObject();
+					break;
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static void WriteRangeBody(Utf8JsonWriter writer, IDateRangeQuery value, JsonSerializerOptions options)
+		{
+			writer.WriteStartObject();
+
+			WriteQueryMeta(writer, value, options);
+
+			if (value.GreaterThan != null)
+			{
+				writer.WritePropertyName("gt");
+				JsonSerializer.Serialize(writer, value.GreaterThan, options);
+			}
+			if (value.GreaterThanOrEqualTo != null)
+			{
+				writer.WritePropertyName("gte");
+				JsonSerializer.Serialize(writer, value.GreaterThanOrEqualTo, options);
+			}
+			if (value.LessThan != null)
+			{
+				writer.WritePropertyName("lt");
+				JsonSerializer.Serialize(writer, value.LessThan, options);
+			}
+			if (value.LessThanOrEqualTo != null)
+			{
+				writer.WritePropertyName("lte");
+				JsonSerializer.Serialize(writer, value.LessThanOrEqualTo, options);
+			}
+			if (!string.IsNullOrEmpty(value.Format))
+			{
+				writer.WritePropertyName("format");
+				writer.WriteStringValue(value.Format);
+			}
+			if (!string.IsNullOrEmpty(value.TimeZone))
+			{
+				writer.WritePropertyName("time_zone");
+				writer.WriteStringValue(value.TimeZone);
+			}
+			if (value.Relation.HasValue)
+			{
+				writer.WritePropertyName("relation");
+				JsonSerializer.Serialize(writer, value.Relation.Value, options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static void WriteRangeBody(Utf8JsonWriter writer, INumericRangeQuery value, JsonSerializerOptions options)
+		{
+			writer.WriteStartObject();
+
+			WriteQueryMeta(writer, value, options);
+
+			if (value.GreaterThan.HasValue)
+			{
+				writer.WritePropertyName("gt");
+				JsonSerializer.Serialize(writer, value.GreaterThan.Value, options);
+			}
+			if (value.GreaterThanOrEqualTo.HasValue)
+			{
+				writer.WritePropertyName("gte");
+				JsonSerializer.Serialize(writer, value.GreaterThanOrEqualTo.Value, options);
+			}
+			if (value.LessThan.HasValue)
+			{
+				writer.WritePropertyName("lt");
+				JsonSerializer.Serialize(writer, value.LessThan.Value, options);
+			}
+			if (value.LessThanOrEqualTo.HasValue)
+			{
+				writer.WritePropertyName("lte");
+				JsonSerializer.Serialize(writer, value.LessThanOrEqualTo.Value, options);
+			}
+			if (value.Relation.HasValue)
+			{
+				writer.WritePropertyName("relation");
+				JsonSerializer.Serialize(writer, value.Relation.Value, options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static void WriteRangeBody(Utf8JsonWriter writer, ILongRangeQuery value, JsonSerializerOptions options)
+		{
+			writer.WriteStartObject();
+
+			WriteQueryMeta(writer, value, options);
+
+			if (value.GreaterThan.HasValue)
+			{
+				writer.WritePropertyName("gt");
+				writer.WriteNumberValue(value.GreaterThan.Value);
+			}
+			if (value.GreaterThanOrEqualTo.HasValue)
+			{
+				writer.WritePropertyName("gte");
+				writer.WriteNumberValue(value.GreaterThanOrEqualTo.Value);
+			}
+			if (value.LessThan.HasValue)
+			{
+				writer.WritePropertyName("lt");
+				writer.WriteNumberValue(value.LessThan.Value);
+			}
+			if (value.LessThanOrEqualTo.HasValue)
+			{
+				writer.WritePropertyName("lte");
+				writer.WriteNumberValue(value.LessThanOrEqualTo.Value);
+			}
+			if (value.Relation.HasValue)
+			{
+				writer.WritePropertyName("relation");
+				JsonSerializer.Serialize(writer, value.Relation.Value, options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static void WriteRangeBody(Utf8JsonWriter writer, ITermRangeQuery value, JsonSerializerOptions options)
+		{
+			writer.WriteStartObject();
+
+			WriteQueryMeta(writer, value, options);
+
+			if (!string.IsNullOrEmpty(value.GreaterThan))
+			{
+				writer.WritePropertyName("gt");
+				writer.WriteStringValue(value.GreaterThan);
+			}
+			if (!string.IsNullOrEmpty(value.GreaterThanOrEqualTo))
+			{
+				writer.WritePropertyName("gte");
+				writer.WriteStringValue(value.GreaterThanOrEqualTo);
+			}
+			if (!string.IsNullOrEmpty(value.LessThan))
+			{
+				writer.WritePropertyName("lt");
+				writer.WriteStringValue(value.LessThan);
+			}
+			if (!string.IsNullOrEmpty(value.LessThanOrEqualTo))
+			{
+				writer.WritePropertyName("lte");
+				writer.WriteStringValue(value.LessThanOrEqualTo);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static void WriteQueryMeta(Utf8JsonWriter writer, IQuery value, JsonSerializerOptions options)
+		{
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteStringValue(value.Name);
+			}
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				JsonSerializer.Serialize(writer, value.Boost.Value, options);
+			}
+		}
+
+		private static bool IsDateValue(string value)
+		{
+			if (string.IsNullOrEmpty(value))
+				return false;
+
+			// Check for date math separators (||) or common date patterns
+			if (value.Contains("||"))
+				return true;
+
+			// Check for ISO date format indicators (contains T or dashes in date-like pattern)
+			if (value.Length >= 10 && value[4] == '-' && value[7] == '-')
+				return true;
+
+			// Check if it contains "now" (date math)
+			if (value.StartsWith("now", StringComparison.OrdinalIgnoreCase))
+				return true;
+
+			return false;
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Range/TermRangeQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Range/TermRangeQuery.cs
@@ -32,6 +32,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(TermRangeQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<TermRangeQuery, ITermRangeQuery>))]
 	public interface ITermRangeQuery : IRangeQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Regexp/RegexpQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Regexp/RegexpQuery.cs
@@ -35,6 +35,7 @@ namespace OpenSearch.Client
 	/// Queries documents that contain terms matching a regular expression.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(RegexpQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<RegexpQuery, IRegexpQuery>))]
 	public interface IRegexpQuery : IFieldNameQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Term/TermQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Term/TermQuery.cs
@@ -27,15 +27,18 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(TermQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<TermQuery, ITermQuery>))]
 	public interface ITermQuery : IFieldNameQuery
 	{
 		[DataMember(Name = "value")]
+		[JsonConverter(typeof(SourceValueWriteConverter))]
 		[JsonFormatter(typeof(SourceWriteFormatter<object>))]
 		object Value { get; set; }
 

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Terms/TermsQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Terms/TermsQuery.cs
@@ -31,11 +31,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[JsonConverter(typeof(TermsQueryConverter))]
 	[JsonFormatter(typeof(TermsQueryFormatter))]
 	public interface ITermsQuery : IFieldNameQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Terms/TermsQueryConverter.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Terms/TermsQueryConverter.cs
@@ -1,0 +1,233 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="ITermsQuery"/> that handles
+	/// the non-standard JSON shape where the field name is a dynamic key, and the value
+	/// can be either an array of terms or a terms lookup object.
+	/// <para>
+	/// Example JSON shapes:
+	/// <code>
+	/// { "_name": "named_query", "boost": 1.1, "field_name": ["val1", "val2"] }
+	/// { "field_name": { "id": "1", "index": "my-index", "path": "color" } }
+	/// </code>
+	/// </para>
+	/// </summary>
+	internal sealed class TermsQueryConverter : JsonConverter<ITermsQuery>
+	{
+		private static readonly JsonEncodedText BoostProp = JsonEncodedText.Encode("boost");
+		private static readonly JsonEncodedText NameProp = JsonEncodedText.Encode("_name");
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public TermsQueryConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override ITermsQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var query = new TermsQuery();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					break;
+
+				var propertyName = reader.GetString();
+				reader.Read(); // Move to value
+
+				switch (propertyName)
+				{
+					case "boost":
+						query.Boost = reader.GetDouble();
+						break;
+					case "_name":
+						query.Name = reader.GetString();
+						break;
+					default:
+						// This is the field name — value is either an array of terms or a lookup object
+						query.Field = propertyName;
+						ReadTermsOrLookup(ref reader, query, options);
+						break;
+				}
+			}
+
+			return query;
+		}
+
+		public override void Write(Utf8JsonWriter writer, ITermsQuery value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName(NameProp);
+				writer.WriteStringValue(value.Name);
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName(BoostProp);
+				writer.WriteNumberValue(value.Boost.Value);
+			}
+
+			// Write the field name and its value (terms array or lookup object)
+			var field = value.Field == null ? null : _settings.Inferrer.Field(value.Field);
+			if (!string.IsNullOrEmpty(field))
+			{
+				writer.WritePropertyName(field);
+
+				if (value.IsVerbatim)
+				{
+					if (value.TermsLookup != null)
+						JsonSerializer.Serialize(writer, value.TermsLookup, options);
+					else if (value.Terms != null)
+						WriteTermsArray(writer, value.Terms, options);
+					else
+						writer.WriteNullValue();
+				}
+				else
+				{
+					if (value.Terms != null)
+						WriteTermsArray(writer, value.Terms, options);
+					else if (value.TermsLookup != null)
+						JsonSerializer.Serialize(writer, value.TermsLookup, options);
+					else
+						writer.WriteNullValue();
+				}
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static void ReadTermsOrLookup(ref Utf8JsonReader reader, TermsQuery query, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.StartArray)
+			{
+				// Array of term values
+				var terms = new List<object>();
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+				{
+					switch (reader.TokenType)
+					{
+						case JsonTokenType.String:
+							terms.Add(reader.GetString());
+							break;
+						case JsonTokenType.Number:
+							if (reader.TryGetInt64(out var longVal))
+								terms.Add(longVal);
+							else
+								terms.Add(reader.GetDouble());
+							break;
+						case JsonTokenType.True:
+							terms.Add(true);
+							break;
+						case JsonTokenType.False:
+							terms.Add(false);
+							break;
+						case JsonTokenType.Null:
+							terms.Add(null);
+							break;
+						default:
+							// For nested objects/arrays, use JsonElement
+							using (var doc = JsonDocument.ParseValue(ref reader))
+								terms.Add(doc.RootElement.Clone());
+							break;
+					}
+				}
+				query.Terms = terms;
+			}
+			else if (reader.TokenType == JsonTokenType.StartObject)
+			{
+				// Terms lookup object
+				var fieldLookup = new FieldLookup();
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+				{
+					if (reader.TokenType != JsonTokenType.PropertyName)
+						continue;
+
+					var prop = reader.GetString();
+					reader.Read();
+
+					switch (prop)
+					{
+						case "id":
+							fieldLookup.Id = reader.GetString();
+							break;
+						case "index":
+							fieldLookup.Index = reader.GetString();
+							break;
+						case "path":
+							fieldLookup.Path = reader.GetString();
+							break;
+						case "routing":
+							fieldLookup.Routing = reader.GetString();
+							break;
+						default:
+							reader.Skip();
+							break;
+					}
+				}
+				query.TermsLookup = fieldLookup;
+			}
+			else
+			{
+				reader.Skip();
+			}
+		}
+
+		private static void WriteTermsArray(Utf8JsonWriter writer, IEnumerable<object> terms, JsonSerializerOptions options)
+		{
+			writer.WriteStartArray();
+			foreach (var term in terms)
+				WriteTerm(writer, term, options);
+			writer.WriteEndArray();
+		}
+
+		private static void WriteTerm(Utf8JsonWriter writer, object term, JsonSerializerOptions options)
+		{
+			switch (term)
+			{
+				case null:
+					writer.WriteNullValue();
+					break;
+				// Terms buffered during deserialization (e.g. nested arrays in a list-of-list terms
+				// query) are stored as JsonElement; write them verbatim rather than routing through
+				// the (source) serializer, which would emit the JsonElement's public shape.
+				case JsonElement element:
+					element.WriteTo(writer);
+					break;
+				default:
+					JsonSerializer.Serialize(writer, term, term.GetType(), options);
+					break;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/TermsSet/TermsSetQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/TermsSet/TermsSetQuery.cs
@@ -43,6 +43,7 @@ namespace OpenSearch.Client
 	/// field or computed per document in a minimum should match script.
 	/// </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(TermsSetQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<TermsSetQuery, ITermsSetQuery>))]
 	public interface ITermsSetQuery : IFieldNameQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
+++ b/src/OpenSearch.Client/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
@@ -34,6 +34,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(WildcardQuery))]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<WildcardQuery, IWildcardQuery>))]
 	public interface IWildcardQuery : ITermQuery
 	{

--- a/src/OpenSearch.Client/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/OpenSearch.Client/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
@@ -179,6 +179,8 @@ namespace OpenSearch.Client
 
 		public virtual void Visit(IMultiMatchQuery query) => Write("multi_match");
 
+		public virtual void Visit(ICombinedFieldsQuery query) => Write("combined_fields");
+
 		public virtual void Visit(INestedQuery query) => Write("nested");
 
         public virtual void Visit(INeuralQuery query) => Write("neural", query.Field);

--- a/src/OpenSearch.Client/QueryDsl/Visitor/QueryVisitor.cs
+++ b/src/OpenSearch.Client/QueryDsl/Visitor/QueryVisitor.cs
@@ -56,6 +56,8 @@ namespace OpenSearch.Client
 
 		void Visit(IBoostingQuery query);
 
+		void Visit(ICombinedFieldsQuery query);
+
 		void Visit(IConstantScoreQuery query);
 
 		void Visit(IDisMaxQuery query);
@@ -190,6 +192,8 @@ namespace OpenSearch.Client
 		public virtual void Visit(IBoolQuery query) { }
 
 		public virtual void Visit(IBoostingQuery query) { }
+
+		public virtual void Visit(ICombinedFieldsQuery query) { }
 
 		public virtual void Visit(IConstantScoreQuery query) { }
 

--- a/src/OpenSearch.Client/QueryDsl/Visitor/QueryWalker.cs
+++ b/src/OpenSearch.Client/QueryDsl/Visitor/QueryWalker.cs
@@ -41,6 +41,7 @@ namespace OpenSearch.Client
 			VisitQuery(qd.MatchNone, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.MoreLikeThis, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.MultiMatch, visitor, (v, d) => v.Visit(d));
+			VisitQuery(qd.CombinedFields, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.Fuzzy, visitor, (v, d) =>
 			{
 				v.Visit(d);

--- a/src/OpenSearch.Client/Search/Explain/ExplainGet.cs
+++ b/src/OpenSearch.Client/Search/Explain/ExplainGet.cs
@@ -42,6 +42,7 @@ namespace OpenSearch.Client
 		bool Found { get; }
 
 		[DataMember(Name = "_source")]
+		[SourceSerialization]
 		[JsonFormatter(typeof(SourceFormatter<>))]
 		TDocument Source { get; }
 	}

--- a/src/OpenSearch.Client/Search/Explain/ExplainResponse.cs
+++ b/src/OpenSearch.Client/Search/Explain/ExplainResponse.cs
@@ -27,9 +27,11 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[InterfaceDataContract]
 	public interface IExplainResponse<out TDocument> : IResponse
 		where TDocument : class
 	{

--- a/src/OpenSearch.Client/Search/ITypedSearchRequest.cs
+++ b/src/OpenSearch.Client/Search/ITypedSearchRequest.cs
@@ -27,6 +27,7 @@
 */
 
 using System;
+using System.Runtime.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -35,6 +36,12 @@ namespace OpenSearch.Client
 	[InterfaceDataContract]
 	public interface ITypedSearchRequest
 	{
+		/// <summary>
+		/// The CLR type that hits should be deserialized into. This is a client-side routing marker
+		/// only and must never be serialized into the request body — <see cref="System.Type"/> is not
+		/// serializable by System.Text.Json.
+		/// </summary>
+		[IgnoreDataMember]
 		Type ClrType { get; }
 	}
 }

--- a/src/OpenSearch.Client/Search/MultiSearch/MultiSearchConverter.cs
+++ b/src/OpenSearch.Client/Search/MultiSearch/MultiSearchConverter.cs
@@ -1,0 +1,194 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes an <see cref="IMultiSearchRequest"/> as newline-delimited JSON (NDJSON): for each
+	/// operation, a header line (index/search_type/preference/routing/ignore_unavailable) followed by
+	/// the search body line. Replaces the Utf8Json <c>MultiSearchFormatter</c>.
+	/// </summary>
+	internal sealed class MultiSearchConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public MultiSearchConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(IMultiSearchRequest).IsAssignableFrom(typeToConvert);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var converterType = typeof(MultiSearchConverter<>).MakeGenericType(typeToConvert);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+	}
+
+	internal sealed class MultiSearchConverter<T> : JsonConverter<T>
+		where T : class, IMultiSearchRequest
+	{
+		private const byte Newline = (byte)'\n';
+
+		private readonly IConnectionSettingsValues _settings;
+
+		public MultiSearchConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			// Reading NDJSON multi-search requests is not supported (matches Utf8Json behavior
+			// which round-tripped through the dynamic object resolver and is not exercised).
+			reader.Skip();
+			return null;
+		}
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			if (value?.Operations == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var serializer = _settings.RequestResponseSerializer;
+			var ndjson = new StringBuilder();
+
+			foreach (var operation in value.Operations.Values)
+			{
+				var p = operation.RequestParameters;
+
+				string GetString(string key) => p.GetResolvedQueryStringValue(key, _settings);
+
+				IUrlParameter indices = value.Index == null || !value.Index.Equals(operation.Index)
+					? operation.Index
+					: null;
+				var operationIndex = indices?.GetString(_settings);
+
+				var searchType = GetString("search_type");
+				if (searchType == "query_then_fetch")
+					searchType = null;
+
+				var header = new
+				{
+					index = operationIndex,
+					search_type = searchType,
+					preference = GetString("preference"),
+					routing = GetString("routing"),
+					ignore_unavailable = GetString("ignore_unavailable")
+				};
+
+				ndjson.Append(serializer.SerializeToString(header, _settings.MemoryStreamFactory, SerializationFormatting.None));
+				ndjson.Append('\n');
+				ndjson.Append(serializer.SerializeToString(operation, _settings.MemoryStreamFactory, SerializationFormatting.None));
+				ndjson.Append('\n');
+			}
+
+			if (ndjson.Length == 0)
+			{
+				// No operations: emit an empty object so the serializer produces a valid JSON token.
+				writer.WriteStartObject();
+				writer.WriteEndObject();
+				return;
+			}
+
+			writer.WriteRawValue(Encoding.UTF8.GetBytes(ndjson.ToString()), skipInputValidation: true);
+		}
+	}
+
+	/// <summary>
+	/// Serializes an <see cref="IMultiSearchTemplateRequest"/> as newline-delimited JSON (NDJSON).
+	/// Replaces the Utf8Json <c>MultiSearchTemplateFormatter</c>.
+	/// </summary>
+	internal sealed class MultiSearchTemplateConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public MultiSearchTemplateConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(IMultiSearchTemplateRequest).IsAssignableFrom(typeToConvert);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var converterType = typeof(MultiSearchTemplateConverter<>).MakeGenericType(typeToConvert);
+			return (JsonConverter)Activator.CreateInstance(converterType, _settings);
+		}
+	}
+
+	internal sealed class MultiSearchTemplateConverter<T> : JsonConverter<T>
+		where T : class, IMultiSearchTemplateRequest
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public MultiSearchTemplateConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			reader.Skip();
+			return null;
+		}
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		{
+			if (value?.Operations == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			var serializer = _settings.RequestResponseSerializer;
+			var ndjson = new StringBuilder();
+
+			foreach (var operation in value.Operations.Values)
+			{
+				var p = operation.RequestParameters;
+
+				string GetString(string key) => p.GetResolvedQueryStringValue(key, _settings);
+
+				IUrlParameter indices = value.Index == null || !value.Index.Equals(operation.Index)
+					? operation.Index
+					: null;
+				var operationIndex = indices?.GetString(_settings);
+
+				var searchType = GetString("search_type");
+				if (searchType == "query_then_fetch")
+					searchType = null;
+
+				var header = new
+				{
+					index = operationIndex,
+					search_type = searchType,
+					preference = GetString("preference"),
+					routing = GetString("routing"),
+					ignore_unavailable = GetString("ignore_unavailable")
+				};
+
+				ndjson.Append(serializer.SerializeToString(header, _settings.MemoryStreamFactory, SerializationFormatting.None));
+				ndjson.Append('\n');
+				ndjson.Append(serializer.SerializeToString(operation, _settings.MemoryStreamFactory, SerializationFormatting.None));
+				ndjson.Append('\n');
+			}
+
+			if (ndjson.Length == 0)
+			{
+				// No operations: emit an empty object so the serializer produces a valid JSON token.
+				writer.WriteStartObject();
+				writer.WriteEndObject();
+				return;
+			}
+
+			writer.WriteRawValue(Encoding.UTF8.GetBytes(ndjson.ToString()), skipInputValidation: true);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/MultiSearch/MultiSearchResponseBuilder.cs
+++ b/src/OpenSearch.Client/Search/MultiSearch/MultiSearchResponseBuilder.cs
@@ -26,34 +26,134 @@
 *  under the License.
 */
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
+	/// <summary>
+	/// Builds a <see cref="MultiSearchResponse"/> from the <c>{ "took": ..., "responses": [ ... ] }</c>
+	/// envelope. The responses array is in the same order as the request operations, so each element is
+	/// deserialized as a <see cref="SearchResponse{T}"/> using the CLR type of the corresponding operation
+	/// and stored under the operation's key (matching the pre-STJ stateful <c>MultiSearchResponseFormatter</c>).
+	/// </summary>
 	internal class MultiSearchResponseBuilder : CustomResponseBuilderBase
 	{
-		public MultiSearchResponseBuilder(IRequest request) => Formatter = new MultiSearchResponseFormatter(request);
+		private static readonly ConcurrentDictionary<Type, MethodInfo> DeserializeResponseMethods = new();
 
-		private MultiSearchResponseFormatter Formatter { get; }
+		private static readonly MethodInfo DeserializeResponseGenericMethod =
+			typeof(MultiSearchResponseBuilder).GetMethod(nameof(DeserializeSearchResponse), BindingFlags.Static | BindingFlags.NonPublic);
 
-		public override object DeserializeResponse(IOpenSearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
-			response.Success
-				? builtInSerializer.CreateStateful(Formatter).Deserialize<MultiSearchResponse>(stream)
-				: new MultiSearchResponse();
+		public MultiSearchResponseBuilder(IRequest request) => Request = request;
+
+		private IRequest Request { get; }
+
+		public override object DeserializeResponse(IOpenSearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
+		{
+			if (!response.Success)
+				return new MultiSearchResponse();
+
+			if (builtInSerializer is IInternalSerializer internalSerializer && internalSerializer.TryGetJsonFormatter(out var formatterResolver))
+				return builtInSerializer.CreateStateful(new MultiSearchResponseFormatter(Request)).Deserialize<MultiSearchResponse>(stream);
+
+			if (IsEmpty(stream))
+				return new MultiSearchResponse();
+
+			using var doc = JsonDocument.Parse(stream);
+			return Build(builtInSerializer, doc);
+		}
 
 		public override async Task<object> DeserializeResponseAsync(
 			IOpenSearchSerializer builtInSerializer,
 			IApiCallDetails response,
 			Stream stream,
 			CancellationToken ctx = default
-		) =>
-			response.Success
-				? await builtInSerializer.CreateStateful(Formatter)
+		)
+		{
+			if (!response.Success)
+				return new MultiSearchResponse();
+
+			if (builtInSerializer is IInternalSerializer internalSerializer && internalSerializer.TryGetJsonFormatter(out var formatterResolver))
+				return await builtInSerializer.CreateStateful(new MultiSearchResponseFormatter(Request))
 					.DeserializeAsync<MultiSearchResponse>(stream, ctx)
-					.ConfigureAwait(false)
-				: new MultiSearchResponse();
+					.ConfigureAwait(false);
+
+			if (IsEmpty(stream))
+				return new MultiSearchResponse();
+
+			using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ctx).ConfigureAwait(false);
+			return Build(builtInSerializer, doc);
+		}
+
+		// Mocked/unit-test responses (URL and HTTP-method assertions) provide an empty response stream;
+		// JsonDocument.Parse throws on empty input, so short-circuit to an empty response.
+		private static bool IsEmpty(Stream stream) =>
+			stream == null || (stream.CanSeek && stream.Length == 0);
+
+		private MultiSearchResponse Build(IOpenSearchSerializer builtInSerializer, JsonDocument doc)
+		{
+			var response = new MultiSearchResponse();
+
+			// The order and key of each operation is required to reconstruct the keyed responses.
+			IEnumerable<KeyValuePair<string, ITypedSearchRequest>> operations;
+			switch (Request)
+			{
+				case IMultiSearchRequest multiSearch when multiSearch.Operations != null:
+					operations = Project(multiSearch.Operations);
+					break;
+				case IMultiSearchTemplateRequest multiSearchTemplate when multiSearchTemplate.Operations != null:
+					operations = Project(multiSearchTemplate.Operations);
+					break;
+				default:
+					return response;
+			}
+
+			if (doc.RootElement.ValueKind != JsonValueKind.Object)
+				return response;
+
+			if (doc.RootElement.TryGetProperty("took", out var took) && took.ValueKind == JsonValueKind.Number)
+				response.Took = took.GetInt64();
+
+			if (!doc.RootElement.TryGetProperty("responses", out var responses) || responses.ValueKind != JsonValueKind.Array)
+				return response;
+
+			if (builtInSerializer is not IInternalSerializer internalSerializer
+				|| !internalSerializer.TryGetJsonSerializerOptions(out var options))
+				return response;
+
+			using var operationEnumerator = operations.GetEnumerator();
+			foreach (var responseElement in responses.EnumerateArray())
+			{
+				if (!operationEnumerator.MoveNext())
+					break;
+
+				var operation = operationEnumerator.Current;
+				var clrType = operation.Value.ClrType ?? typeof(object);
+				var method = DeserializeResponseMethods.GetOrAdd(clrType, static t => DeserializeResponseGenericMethod.MakeGenericMethod(t));
+				var searchResponse = (IResponse)method.Invoke(null, new object[] { responseElement, options });
+				if (searchResponse != null)
+					response.Responses[operation.Key] = searchResponse;
+			}
+
+			return response;
+		}
+
+		private static IEnumerable<KeyValuePair<string, ITypedSearchRequest>> Project<TValue>(IDictionary<string, TValue> operations)
+			where TValue : ITypedSearchRequest
+		{
+			foreach (var kv in operations)
+				yield return new KeyValuePair<string, ITypedSearchRequest>(kv.Key, kv.Value);
+		}
+
+		private static IResponse DeserializeSearchResponse<T>(JsonElement element, JsonSerializerOptions options)
+			where T : class =>
+			element.Deserialize<SearchResponse<T>>(options);
 	}
 }

--- a/src/OpenSearch.Client/Search/Scroll/Scroll/SlicedScroll.cs
+++ b/src/OpenSearch.Client/Search/Scroll/Scroll/SlicedScroll.cs
@@ -29,10 +29,12 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(SlicedScroll))]
+	[InterfaceDataContract]
 	public interface ISlicedScroll
 	{
 		[DataMember(Name ="field")]

--- a/src/OpenSearch.Client/Search/Search/Collapsing/FieldCollapse.cs
+++ b/src/OpenSearch.Client/Search/Search/Collapsing/FieldCollapse.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
@@ -41,6 +42,7 @@ namespace OpenSearch.Client
 	/// </para>
 	/// </summary>
 	[ReadAs(typeof(FieldCollapse))]
+	[InterfaceDataContract]
 	public interface IFieldCollapse
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Search/Search/Hits/HitConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/HitConverter.cs
@@ -1,0 +1,373 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> that creates <see cref="HitConverter{TDocument}"/>
+	/// instances for any <see cref="IHit{TDocument}"/> type.
+	/// Replaces the Utf8Json-based <c>HitFormatter</c>.
+	/// </summary>
+	internal sealed class HitConverterFactory : JsonConverterFactory
+	{
+		private static readonly ConcurrentDictionary<Type, JsonConverter> ConverterCache = new();
+
+		public override bool CanConvert(Type typeToConvert)
+		{
+			if (!typeToConvert.IsGenericType) return false;
+
+			var genericDef = typeToConvert.GetGenericTypeDefinition();
+			return genericDef == typeof(IHit<>) || genericDef == typeof(Hit<>);
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			return ConverterCache.GetOrAdd(typeToConvert, type =>
+			{
+				var docType = type.IsGenericType
+					? type.GetGenericArguments()[0]
+					: typeof(object);
+
+				var converterType = typeof(HitConverter<>).MakeGenericType(docType);
+				return (JsonConverter)Activator.CreateInstance(converterType);
+			});
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IHit{TDocument}"/> / <see cref="Hit{TDocument}"/>
+	/// that handles all hit properties including <c>_source</c> delegation to the SourceConverter,
+	/// inner hits, highlights, fields, sorts, and matched queries.
+	/// </summary>
+	internal sealed class HitConverter<TDocument> : JsonConverter<IHit<TDocument>>
+		where TDocument : class
+	{
+		private static readonly JsonEncodedText IdProp = JsonEncodedText.Encode("_id");
+		private static readonly JsonEncodedText IndexProp = JsonEncodedText.Encode("_index");
+		private static readonly JsonEncodedText TypeProp = JsonEncodedText.Encode("_type");
+		private static readonly JsonEncodedText ScoreProp = JsonEncodedText.Encode("_score");
+		private static readonly JsonEncodedText SourceProp = JsonEncodedText.Encode("_source");
+		private static readonly JsonEncodedText VersionProp = JsonEncodedText.Encode("_version");
+		private static readonly JsonEncodedText RoutingProp = JsonEncodedText.Encode("_routing");
+		private static readonly JsonEncodedText PrimaryTermProp = JsonEncodedText.Encode("_primary_term");
+		private static readonly JsonEncodedText SeqNoProp = JsonEncodedText.Encode("_seq_no");
+		private static readonly JsonEncodedText ExplanationProp = JsonEncodedText.Encode("_explanation");
+		private static readonly JsonEncodedText FieldsProp = JsonEncodedText.Encode("fields");
+		private static readonly JsonEncodedText HighlightProp = JsonEncodedText.Encode("highlight");
+		private static readonly JsonEncodedText InnerHitsProp = JsonEncodedText.Encode("inner_hits");
+		private static readonly JsonEncodedText NestedProp = JsonEncodedText.Encode("_nested");
+		private static readonly JsonEncodedText MatchedQueriesProp = JsonEncodedText.Encode("matched_queries");
+		private static readonly JsonEncodedText SortProp = JsonEncodedText.Encode("sort");
+
+		public override IHit<TDocument> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var hit = new Hit<TDocument>();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName) continue;
+
+				if (reader.ValueTextEquals(IdProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Id = reader.GetString();
+				}
+				else if (reader.ValueTextEquals(IndexProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Index = reader.GetString();
+				}
+				else if (reader.ValueTextEquals(TypeProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Type = reader.GetString();
+				}
+				else if (reader.ValueTextEquals(ScoreProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					if (reader.TokenType == JsonTokenType.Null)
+						hit.Score = null;
+					else
+						hit.Score = reader.GetDouble();
+				}
+				else if (reader.ValueTextEquals(SourceProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					// Delegate _source deserialization to SourceConverter or STJ default for TDocument
+					hit.Source = JsonSerializer.Deserialize<TDocument>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(VersionProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Version = reader.GetInt64();
+				}
+				else if (reader.ValueTextEquals(RoutingProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Routing = reader.GetString();
+				}
+				else if (reader.ValueTextEquals(PrimaryTermProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.PrimaryTerm = reader.GetInt64();
+				}
+				else if (reader.ValueTextEquals(SeqNoProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.SequenceNumber = reader.GetInt64();
+				}
+				else if (reader.ValueTextEquals(ExplanationProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Explanation = JsonSerializer.Deserialize<Explanation>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(FieldsProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Fields = JsonSerializer.Deserialize<FieldValues>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(HighlightProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Highlight = JsonSerializer.Deserialize<IReadOnlyDictionary<string, IReadOnlyCollection<string>>>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(InnerHitsProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.InnerHits = JsonSerializer.Deserialize<IReadOnlyDictionary<string, InnerHitsResult>>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(NestedProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Nested = JsonSerializer.Deserialize<NestedIdentity>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(MatchedQueriesProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.MatchedQueries = JsonSerializer.Deserialize<IReadOnlyCollection<string>>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(SortProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					hit.Sorts = ReadSortValues(ref reader);
+				}
+				else
+				{
+					// Skip unknown properties
+					reader.Read();
+					reader.Skip();
+				}
+			}
+
+			return hit;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IHit<TDocument> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (value.Index != null)
+			{
+				writer.WritePropertyName(IndexProp);
+				writer.WriteStringValue(value.Index);
+			}
+
+			if (value.Type != null)
+			{
+				writer.WritePropertyName(TypeProp);
+				writer.WriteStringValue(value.Type);
+			}
+
+			if (value.Id != null)
+			{
+				writer.WritePropertyName(IdProp);
+				writer.WriteStringValue(value.Id);
+			}
+
+			if (value.Score.HasValue)
+			{
+				writer.WritePropertyName(ScoreProp);
+				writer.WriteNumberValue(value.Score.Value);
+			}
+
+			if (value.Source != null)
+			{
+				writer.WritePropertyName(SourceProp);
+				JsonSerializer.Serialize(writer, value.Source, options);
+			}
+
+			if (value.Version != 0)
+			{
+				writer.WritePropertyName(VersionProp);
+				writer.WriteNumberValue(value.Version);
+			}
+
+			if (value.Routing != null)
+			{
+				writer.WritePropertyName(RoutingProp);
+				writer.WriteStringValue(value.Routing);
+			}
+
+			if (value.PrimaryTerm.HasValue)
+			{
+				writer.WritePropertyName(PrimaryTermProp);
+				writer.WriteNumberValue(value.PrimaryTerm.Value);
+			}
+
+			if (value.SequenceNumber.HasValue)
+			{
+				writer.WritePropertyName(SeqNoProp);
+				writer.WriteNumberValue(value.SequenceNumber.Value);
+			}
+
+			if (value.Explanation != null)
+			{
+				writer.WritePropertyName(ExplanationProp);
+				JsonSerializer.Serialize(writer, value.Explanation, options);
+			}
+
+			if (value.Fields != null)
+			{
+				writer.WritePropertyName(FieldsProp);
+				JsonSerializer.Serialize(writer, value.Fields, options);
+			}
+
+			if (value.Highlight != null && value.Highlight.Count > 0)
+			{
+				writer.WritePropertyName(HighlightProp);
+				JsonSerializer.Serialize(writer, value.Highlight, options);
+			}
+
+			if (value.InnerHits != null && value.InnerHits.Count > 0)
+			{
+				writer.WritePropertyName(InnerHitsProp);
+				JsonSerializer.Serialize(writer, value.InnerHits, options);
+			}
+
+			if (value.Nested != null)
+			{
+				writer.WritePropertyName(NestedProp);
+				JsonSerializer.Serialize(writer, value.Nested, options);
+			}
+
+			if (value.MatchedQueries != null && value.MatchedQueries.Count > 0)
+			{
+				writer.WritePropertyName(MatchedQueriesProp);
+				JsonSerializer.Serialize(writer, value.MatchedQueries, options);
+			}
+
+			if (value.Sorts != null && value.Sorts.Count > 0)
+			{
+				writer.WritePropertyName(SortProp);
+				WriteSortValues(writer, value.Sorts);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static IReadOnlyCollection<object> ReadSortValues(ref Utf8JsonReader reader)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return EmptyReadOnly<object>.Collection;
+
+			if (reader.TokenType != JsonTokenType.StartArray)
+			{
+				reader.Skip();
+				return EmptyReadOnly<object>.Collection;
+			}
+
+			var sorts = new List<object>();
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+			{
+				switch (reader.TokenType)
+				{
+					case JsonTokenType.String:
+						sorts.Add(reader.GetString());
+						break;
+					case JsonTokenType.Number:
+						if (reader.TryGetInt64(out var l))
+							sorts.Add(l);
+						else
+							sorts.Add(reader.GetDouble());
+						break;
+					case JsonTokenType.True:
+						sorts.Add(true);
+						break;
+					case JsonTokenType.False:
+						sorts.Add(false);
+						break;
+					case JsonTokenType.Null:
+						sorts.Add(null);
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+
+			return sorts;
+		}
+
+		private static void WriteSortValues(Utf8JsonWriter writer, IReadOnlyCollection<object> sorts)
+		{
+			writer.WriteStartArray();
+			foreach (var sort in sorts)
+			{
+				switch (sort)
+				{
+					case null:
+						writer.WriteNullValue();
+						break;
+					case string s:
+						writer.WriteStringValue(s);
+						break;
+					case int i:
+						writer.WriteNumberValue(i);
+						break;
+					case long l:
+						writer.WriteNumberValue(l);
+						break;
+					case double d:
+						writer.WriteNumberValue(d);
+						break;
+					case float f:
+						writer.WriteNumberValue(f);
+						break;
+					case bool b:
+						writer.WriteBooleanValue(b);
+						break;
+					default:
+						writer.WriteStringValue(sort.ToString());
+						break;
+				}
+			}
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Search/Hits/HitsMetadataConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/HitsMetadataConverter.cs
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> that creates converters for
+	/// <see cref="IHitsMetadata{T}"/> and <see cref="HitsMetadata{T}"/>.
+	/// Handles the hits envelope containing total, max_score, and the hits array.
+	/// </summary>
+	internal sealed class HitsMetadataConverterFactory : JsonConverterFactory
+	{
+		private static readonly ConcurrentDictionary<Type, JsonConverter> ConverterCache = new();
+
+		public override bool CanConvert(Type typeToConvert)
+		{
+			if (!typeToConvert.IsGenericType) return false;
+
+			var genericDef = typeToConvert.GetGenericTypeDefinition();
+			return genericDef == typeof(IHitsMetadata<>) || genericDef == typeof(HitsMetadata<>);
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			return ConverterCache.GetOrAdd(typeToConvert, type =>
+			{
+				var docType = type.IsGenericType
+					? type.GetGenericArguments()[0]
+					: typeof(object);
+
+				var converterType = typeof(HitsMetadataConverter<>).MakeGenericType(docType);
+				return (JsonConverter)Activator.CreateInstance(converterType);
+			});
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="IHitsMetadata{TDocument}"/>
+	/// that reads the hits envelope: <c>{"total": ..., "max_score": ..., "hits": [...]}</c>.
+	/// </summary>
+	internal sealed class HitsMetadataConverter<TDocument> : JsonConverter<IHitsMetadata<TDocument>>
+		where TDocument : class
+	{
+		private static readonly JsonEncodedText TotalProp = JsonEncodedText.Encode("total");
+		private static readonly JsonEncodedText MaxScoreProp = JsonEncodedText.Encode("max_score");
+		private static readonly JsonEncodedText HitsProp = JsonEncodedText.Encode("hits");
+
+		public override IHitsMetadata<TDocument> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var metadata = new HitsMetadata<TDocument>();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName) continue;
+
+				if (reader.ValueTextEquals(TotalProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					metadata.Total = JsonSerializer.Deserialize<TotalHits>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(MaxScoreProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					if (reader.TokenType == JsonTokenType.Null)
+						metadata.MaxScore = null;
+					else if (reader.TokenType == JsonTokenType.Number)
+						metadata.MaxScore = reader.GetDouble();
+					else
+					{
+						reader.Skip();
+						metadata.MaxScore = null;
+					}
+				}
+				else if (reader.ValueTextEquals(HitsProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					metadata.Hits = ReadHitsArray(ref reader, options);
+				}
+				else
+				{
+					reader.Read();
+					reader.Skip();
+				}
+			}
+
+			return metadata;
+		}
+
+		public override void Write(Utf8JsonWriter writer, IHitsMetadata<TDocument> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (value.Total != null)
+			{
+				writer.WritePropertyName(TotalProp);
+				JsonSerializer.Serialize(writer, value.Total, options);
+			}
+
+			if (value.MaxScore.HasValue)
+			{
+				writer.WritePropertyName(MaxScoreProp);
+				writer.WriteNumberValue(value.MaxScore.Value);
+			}
+
+			writer.WritePropertyName(HitsProp);
+			writer.WriteStartArray();
+			if (value.Hits != null)
+			{
+				foreach (var hit in value.Hits)
+					JsonSerializer.Serialize(writer, hit, options);
+			}
+			writer.WriteEndArray();
+
+			writer.WriteEndObject();
+		}
+
+		private static IReadOnlyCollection<IHit<TDocument>> ReadHitsArray(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return EmptyReadOnly<IHit<TDocument>>.Collection;
+
+			if (reader.TokenType != JsonTokenType.StartArray)
+			{
+				reader.Skip();
+				return EmptyReadOnly<IHit<TDocument>>.Collection;
+			}
+
+			var hits = new List<IHit<TDocument>>();
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+			{
+				var hit = JsonSerializer.Deserialize<IHit<TDocument>>(ref reader, options);
+				if (hit != null)
+					hits.Add(hit);
+			}
+
+			return hits;
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Search/Hits/InnerHitsConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/InnerHitsConverter.cs
@@ -1,0 +1,194 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="InnerHitsMetadata"/> that handles the
+	/// inner hits metadata envelope containing total, max_score, and hits array.
+	/// Inner hits use <see cref="ILazyDocument"/> for the document type since the concrete
+	/// type is not known at deserialization time.
+	/// Replaces the Utf8Json-based <c>InnerHitsFormatter</c>.
+	/// </summary>
+	internal sealed class InnerHitsMetadataConverter : JsonConverter<InnerHitsMetadata>
+	{
+		private static readonly JsonEncodedText TotalProp = JsonEncodedText.Encode("total");
+		private static readonly JsonEncodedText MaxScoreProp = JsonEncodedText.Encode("max_score");
+		private static readonly JsonEncodedText HitsProp = JsonEncodedText.Encode("hits");
+
+		public override InnerHitsMetadata Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var metadata = new InnerHitsMetadata();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName) continue;
+
+				if (reader.ValueTextEquals(TotalProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					metadata.Total = JsonSerializer.Deserialize<TotalHits>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(MaxScoreProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					if (reader.TokenType == JsonTokenType.Null)
+						metadata.MaxScore = null;
+					else if (reader.TokenType == JsonTokenType.Number)
+						metadata.MaxScore = reader.GetDouble();
+					else
+					{
+						reader.Skip();
+						metadata.MaxScore = null;
+					}
+				}
+				else if (reader.ValueTextEquals(HitsProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					metadata.Hits = ReadHitsArray(ref reader, options);
+				}
+				else
+				{
+					reader.Read();
+					reader.Skip();
+				}
+			}
+
+			return metadata;
+		}
+
+		public override void Write(Utf8JsonWriter writer, InnerHitsMetadata value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (value.Total != null)
+			{
+				writer.WritePropertyName(TotalProp);
+				JsonSerializer.Serialize(writer, value.Total, options);
+			}
+
+			if (value.MaxScore.HasValue)
+			{
+				writer.WritePropertyName(MaxScoreProp);
+				writer.WriteNumberValue(value.MaxScore.Value);
+			}
+
+			writer.WritePropertyName(HitsProp);
+			writer.WriteStartArray();
+			if (value.Hits != null)
+			{
+				foreach (var hit in value.Hits)
+					JsonSerializer.Serialize(writer, hit, options);
+			}
+			writer.WriteEndArray();
+
+			writer.WriteEndObject();
+		}
+
+		private static List<IHit<ILazyDocument>> ReadHitsArray(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return new List<IHit<ILazyDocument>>();
+
+			if (reader.TokenType != JsonTokenType.StartArray)
+			{
+				reader.Skip();
+				return new List<IHit<ILazyDocument>>();
+			}
+
+			var hits = new List<IHit<ILazyDocument>>();
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+			{
+				var hit = JsonSerializer.Deserialize<IHit<ILazyDocument>>(ref reader, options);
+				if (hit != null)
+					hits.Add(hit);
+			}
+
+			return hits;
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="InnerHitsResult"/> that reads/writes
+	/// the wrapper object containing the inner hits metadata.
+	/// </summary>
+	internal sealed class InnerHitsResultConverter : JsonConverter<InnerHitsResult>
+	{
+		private static readonly JsonEncodedText HitsProp = JsonEncodedText.Encode("hits");
+
+		public override InnerHitsResult Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var result = new InnerHitsResult();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName) continue;
+
+				if (reader.ValueTextEquals(HitsProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					result.Hits = JsonSerializer.Deserialize<InnerHitsMetadata>(ref reader, options);
+				}
+				else
+				{
+					reader.Read();
+					reader.Skip();
+				}
+			}
+
+			return result;
+		}
+
+		public override void Write(Utf8JsonWriter writer, InnerHitsResult value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			if (value.Hits != null)
+			{
+				writer.WritePropertyName(HitsProp);
+				JsonSerializer.Serialize(writer, value.Hits, options);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Search/Hits/TotalHits.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/TotalHits.cs
@@ -27,9 +27,10 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net;
 using OpenSearch.Net.Extensions;
-using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Formatters;
 
 namespace OpenSearch.Client
@@ -42,6 +43,7 @@ namespace OpenSearch.Client
 	/// "there are more than 1000 hits", OpenSearch has options to stop counting as soon
 	/// as a threshold has been reached in order to improve query times.
 	/// </summary>
+	[JsonConverter(typeof(TotalHitsConverter))]
 	[JsonFormatter(typeof(TotalHitsFormatter))]
 	public class TotalHits
 	{
@@ -126,4 +128,6 @@ namespace OpenSearch.Client
 				writer.WriteInt64(value.Value);
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Search/Search/Hits/TotalHitsConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/Hits/TotalHitsConverter.cs
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="TotalHits"/> that handles two formats:
+	/// <list type="bullet">
+	/// <item>Legacy format: a simple number (e.g. <c>42</c>)</item>
+	/// <item>Object format: <c>{"value": 42, "relation": "eq"}</c></item>
+	/// </list>
+	/// Replaces the Utf8Json-based <c>TotalHitsFormatter</c>.
+	/// </summary>
+	internal sealed class TotalHitsConverter : JsonConverter<TotalHits>
+	{
+		private static readonly JsonEncodedText ValueProp = JsonEncodedText.Encode("value");
+		private static readonly JsonEncodedText RelationProp = JsonEncodedText.Encode("relation");
+
+		public override TotalHits Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+			{
+				reader.Read();
+				return null;
+			}
+
+			if (reader.TokenType == JsonTokenType.Number)
+			{
+				// Legacy format: just a number
+				return new TotalHits { Value = reader.GetInt64() };
+			}
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			long value = -1;
+			TotalHitsRelation? relation = null;
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName) continue;
+
+				if (reader.ValueTextEquals(ValueProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					value = reader.GetInt64();
+				}
+				else if (reader.ValueTextEquals(RelationProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					relation = JsonSerializer.Deserialize<TotalHitsRelation?>(ref reader, options);
+				}
+				else
+				{
+					reader.Read();
+					reader.Skip();
+				}
+			}
+
+			return new TotalHits { Value = value, Relation = relation };
+		}
+
+		public override void Write(Utf8JsonWriter writer, TotalHits value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			if (value.Relation.HasValue)
+			{
+				writer.WriteStartObject();
+				writer.WriteNumber(ValueProp, value.Value);
+				writer.WritePropertyName(RelationProp);
+				JsonSerializer.Serialize(writer, value.Relation.Value, options);
+				writer.WriteEndObject();
+			}
+			else
+			{
+				writer.WriteNumberValue(value.Value);
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Search/IndicesBoostConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/IndicesBoostConverter.cs
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes an <c>indices_boost</c> dictionary (<see cref="IDictionary{IndexName, Double}"/>)
+	/// as an ordered JSON array of single-key objects (e.g. <c>[{"project":1.4},{"devs":1.3}]</c>)
+	/// and deserializes either that array form or a plain object form. Replaces the Utf8Json
+	/// <c>IndicesBoostFormatter</c>.
+	/// </summary>
+	internal sealed class IndicesBoostConverterFactory : JsonConverterFactory
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IndicesBoostConverterFactory(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeToConvert == typeof(IDictionary<IndexName, double>) ||
+			typeToConvert == typeof(Dictionary<IndexName, double>);
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+			new IndicesBoostConverter(_settings);
+	}
+
+	internal sealed class IndicesBoostConverter : JsonConverter<IDictionary<IndexName, double>>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public IndicesBoostConverter(IConnectionSettingsValues settings) => _settings = settings;
+
+		public override IDictionary<IndexName, double> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.StartObject:
+				{
+					var dictionary = new Dictionary<IndexName, double>();
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+					{
+						if (reader.TokenType != JsonTokenType.PropertyName)
+							continue;
+
+						var indexName = (IndexName)reader.GetString();
+						reader.Read();
+						dictionary[indexName] = reader.GetDouble();
+					}
+					return dictionary;
+				}
+				case JsonTokenType.StartArray:
+				{
+					var dictionary = new Dictionary<IndexName, double>();
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+					{
+						if (reader.TokenType != JsonTokenType.StartObject)
+							continue;
+
+						while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+						{
+							if (reader.TokenType != JsonTokenType.PropertyName)
+								continue;
+
+							var indexName = (IndexName)reader.GetString();
+							reader.Read();
+							dictionary[indexName] = reader.GetDouble();
+						}
+					}
+					return dictionary;
+				}
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, IDictionary<IndexName, double> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach (var entry in value)
+			{
+				writer.WriteStartObject();
+				var indexName = _settings.Inferrer.IndexName(entry.Key);
+				writer.WriteNumber(indexName, entry.Value);
+				writer.WriteEndObject();
+			}
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Search/InnerHits/InnerHits.cs
+++ b/src/OpenSearch.Client/Search/Search/InnerHits/InnerHits.cs
@@ -29,10 +29,12 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	[ReadAs(typeof(InnerHits))]
+	[InterfaceDataContract]
 	public interface IInnerHits
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Search/Search/PointInTime/PointInTime.cs
+++ b/src/OpenSearch.Client/Search/Search/PointInTime/PointInTime.cs
@@ -6,10 +6,12 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client;
 
 [ReadAs(typeof(PointInTime))]
+[InterfaceDataContract]
 public interface IPointInTime
 {
 	[DataMember(Name = "id")]

--- a/src/OpenSearch.Client/Search/Search/SearchResponseConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/SearchResponseConverter.cs
@@ -1,0 +1,236 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> for <see cref="SearchResponse{TDocument}"/> and
+	/// <see cref="ISearchResponse{TDocument}"/>.
+	/// Delegates to the standard STJ deserialization with DataMember support but ensures
+	/// the generic type argument is properly resolved for hits and suggest handling.
+	/// </summary>
+	internal sealed class SearchResponseConverterFactory : JsonConverterFactory
+	{
+		private static readonly ConcurrentDictionary<Type, JsonConverter> ConverterCache = new();
+
+		public override bool CanConvert(Type typeToConvert)
+		{
+			if (!typeToConvert.IsGenericType) return false;
+
+			var genericDef = typeToConvert.GetGenericTypeDefinition();
+			return genericDef == typeof(SearchResponse<>) || genericDef == typeof(ISearchResponse<>);
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			return ConverterCache.GetOrAdd(typeToConvert, type =>
+			{
+				var docType = type.IsGenericType
+					? type.GetGenericArguments()[0]
+					: typeof(object);
+
+				var converterType = typeof(SearchResponseConverter<>).MakeGenericType(docType);
+				return (JsonConverter)Activator.CreateInstance(converterType);
+			});
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="SearchResponse{TDocument}"/>
+	/// that handles all search response properties including hits metadata, aggregations,
+	/// suggest results, and other metadata fields.
+	/// Replaces the Utf8Json-based <c>SearchResponseFormatter</c>.
+	/// </summary>
+	internal sealed class SearchResponseConverter<TDocument> : JsonConverter<SearchResponse<TDocument>>
+		where TDocument : class
+	{
+		private static readonly JsonEncodedText TookProp = JsonEncodedText.Encode("took");
+		private static readonly JsonEncodedText TimedOutProp = JsonEncodedText.Encode("timed_out");
+		private static readonly JsonEncodedText TerminatedEarlyProp = JsonEncodedText.Encode("terminated_early");
+		private static readonly JsonEncodedText ShardsProp = JsonEncodedText.Encode("_shards");
+		private static readonly JsonEncodedText HitsProp = JsonEncodedText.Encode("hits");
+		private static readonly JsonEncodedText AggregationsProp = JsonEncodedText.Encode("aggregations");
+		private static readonly JsonEncodedText SuggestProp = JsonEncodedText.Encode("suggest");
+		private static readonly JsonEncodedText ProfileProp = JsonEncodedText.Encode("profile");
+		private static readonly JsonEncodedText ScrollIdProp = JsonEncodedText.Encode("_scroll_id");
+		private static readonly JsonEncodedText ClustersProp = JsonEncodedText.Encode("_clusters");
+		private static readonly JsonEncodedText NumReducePhasesProp = JsonEncodedText.Encode("num_reduce_phases");
+		private static readonly JsonEncodedText ErrorProp = JsonEncodedText.Encode("error");
+		private static readonly JsonEncodedText StatusProp = JsonEncodedText.Encode("status");
+
+		public override SearchResponse<TDocument> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var response = new SearchResponse<TDocument>();
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName) continue;
+
+				if (reader.ValueTextEquals(TookProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.Took = reader.GetInt64();
+				}
+				else if (reader.ValueTextEquals(TimedOutProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.TimedOut = reader.GetBoolean();
+				}
+				else if (reader.ValueTextEquals(TerminatedEarlyProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.TerminatedEarly = reader.GetBoolean();
+				}
+				else if (reader.ValueTextEquals(ShardsProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.Shards = JsonSerializer.Deserialize<ShardStatistics>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(HitsProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.HitsMetadata = JsonSerializer.Deserialize<IHitsMetadata<TDocument>>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(AggregationsProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.Aggregations = JsonSerializer.Deserialize<AggregateDictionary>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(SuggestProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.Suggest = JsonSerializer.Deserialize<ISuggestDictionary<TDocument>>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(ProfileProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.Profile = JsonSerializer.Deserialize<Profile>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(ScrollIdProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.ScrollId = reader.GetString();
+				}
+				else if (reader.ValueTextEquals(ClustersProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.Clusters = JsonSerializer.Deserialize<ClusterStatistics>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(NumReducePhasesProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.NumberOfReducePhases = reader.GetInt64();
+				}
+				else if (reader.ValueTextEquals(ErrorProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.Error = JsonSerializer.Deserialize<OpenSearch.Net.Error>(ref reader, options);
+				}
+				else if (reader.ValueTextEquals(StatusProp.EncodedUtf8Bytes))
+				{
+					reader.Read();
+					response.StatusCode = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt32();
+				}
+				else
+				{
+					// Skip unknown properties
+					reader.Read();
+					reader.Skip();
+				}
+			}
+
+			return response;
+		}
+
+		public override void Write(Utf8JsonWriter writer, SearchResponse<TDocument> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			writer.WritePropertyName(TookProp);
+			writer.WriteNumberValue(value.Took);
+
+			writer.WritePropertyName(TimedOutProp);
+			writer.WriteBooleanValue(value.TimedOut);
+
+			if (value.TerminatedEarly)
+			{
+				writer.WritePropertyName(TerminatedEarlyProp);
+				writer.WriteBooleanValue(value.TerminatedEarly);
+			}
+
+			if (value.Shards != null)
+			{
+				writer.WritePropertyName(ShardsProp);
+				JsonSerializer.Serialize(writer, value.Shards, options);
+			}
+
+			if (value.HitsMetadata != null)
+			{
+				writer.WritePropertyName(HitsProp);
+				JsonSerializer.Serialize(writer, value.HitsMetadata, options);
+			}
+
+			if (value.Aggregations != null && value.Aggregations != AggregateDictionary.Default)
+			{
+				writer.WritePropertyName(AggregationsProp);
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
+			if (value.Suggest != null && value.Suggest != SuggestDictionary<TDocument>.Default)
+			{
+				writer.WritePropertyName(SuggestProp);
+				JsonSerializer.Serialize(writer, value.Suggest, options);
+			}
+
+			if (value.Profile != null)
+			{
+				writer.WritePropertyName(ProfileProp);
+				JsonSerializer.Serialize(writer, value.Profile, options);
+			}
+
+			if (value.ScrollId != null)
+			{
+				writer.WritePropertyName(ScrollIdProp);
+				writer.WriteStringValue(value.ScrollId);
+			}
+
+			if (value.Clusters != null)
+			{
+				writer.WritePropertyName(ClustersProp);
+				JsonSerializer.Serialize(writer, value.Clusters, options);
+			}
+
+			if (value.NumberOfReducePhases != 0)
+			{
+				writer.WritePropertyName(NumReducePhasesProp);
+				writer.WriteNumberValue(value.NumberOfReducePhases);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Search/Sort/FieldSort.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/FieldSort.cs
@@ -37,6 +37,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(FieldSort))]
 	public interface IFieldSort : ISort
 	{
 		[DataMember(Name ="ignore_unmapped")]

--- a/src/OpenSearch.Client/Search/Search/Sort/GeoDistanceSort.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/GeoDistanceSort.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 {
 	/// <summary> Allows you to sort based on a proximity to one or more <see cref="GeoLocation" /> </summary>
 	[InterfaceDataContract]
+	[ReadAs(typeof(GeoDistanceSort))]
 	public interface IGeoDistanceSort : ISort
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Search/Search/Sort/SortConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/Sort/SortConverter.cs
@@ -1,0 +1,268 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Handles serialization and deserialization of <see cref="ISort"/> instances.
+	/// <para>
+	/// Write format: <c>{ "sort_key": { ...body... } }</c>
+	/// </para>
+	/// <para>
+	/// Read format:
+	/// <list type="bullet">
+	/// <item><c>"string"</c> → <see cref="FieldSort"/> with <c>Field = string</c></item>
+	/// <item><c>{ "_script": { ... } }</c> → <see cref="ScriptSort"/></item>
+	/// <item><c>{ "_geo_distance": { ... } }</c> → <see cref="GeoDistanceSort"/></item>
+	/// <item><c>{ "field": "asc"/"desc" }</c> → <see cref="FieldSort"/> with Order</item>
+	/// <item><c>{ "field": { ... } }</c> → <see cref="FieldSort"/></item>
+	/// </list>
+	/// </para>
+	/// </summary>
+	internal sealed class SortConverter : JsonConverter<ISort>
+	{
+		private readonly IConnectionSettingsValues _settings;
+
+		public SortConverter(IConnectionSettingsValues settings) =>
+			_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+		public override ISort Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			// Simple string form: "fieldName"
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var field = reader.GetString();
+				return new FieldSort { Field = field };
+			}
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Cannot deserialize ISort from {reader.TokenType}");
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			// Single-key object dispatch
+			foreach (var prop in root.EnumerateObject())
+			{
+				var key = prop.Name;
+
+				if (key == "_script")
+				{
+					var scriptSort = JsonSerializer.Deserialize<ScriptSort>(prop.Value.GetRawText(), options);
+					return scriptSort;
+				}
+
+				if (key == "_geo_distance")
+				{
+					return DeserializeGeoDistanceSort(prop.Value, options);
+				}
+
+				// Default: field sort
+				if (prop.Value.ValueKind == JsonValueKind.String)
+				{
+					// { "field": "asc" } shorthand
+					var orderStr = prop.Value.GetString();
+					SortOrder? order = null;
+					if (string.Equals(orderStr, "asc", StringComparison.OrdinalIgnoreCase))
+						order = SortOrder.Ascending;
+					else if (string.Equals(orderStr, "desc", StringComparison.OrdinalIgnoreCase))
+						order = SortOrder.Descending;
+
+					return new FieldSort { Field = key, Order = order };
+				}
+
+				// { "field": { ...body... } }
+				var fieldSort = JsonSerializer.Deserialize<FieldSort>(prop.Value.GetRawText(), options);
+				if (fieldSort != null)
+					fieldSort.Field = key;
+				return fieldSort;
+			}
+
+			return null;
+		}
+
+		public override void Write(Utf8JsonWriter writer, ISort value, JsonSerializerOptions options)
+		{
+			if (value?.SortKey == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			var sortKey = value.SortKey.Name ?? _settings.Inferrer.Field(value.SortKey);
+
+			switch (sortKey)
+			{
+				case "_script":
+					writer.WritePropertyName("_script");
+					WriteBodyWithoutSortKey<IScriptSort>(writer, value as IScriptSort, options);
+					break;
+
+				case "_geo_distance":
+					writer.WritePropertyName("_geo_distance");
+					WriteGeoDistanceBody(writer, value as IGeoDistanceSort, options);
+					break;
+
+				default:
+					// Field sort: { "resolved_field_name": { ...body... } }
+					var resolvedField = _settings.Inferrer.Field(value.SortKey);
+					writer.WritePropertyName(resolvedField);
+					WriteBodyWithoutSortKey<IFieldSort>(writer, value as IFieldSort, options);
+					break;
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private void WriteBodyWithoutSortKey<T>(Utf8JsonWriter writer, T value, JsonSerializerOptions options) where T : class, ISort
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// Serialize the body properties using the interface contract (which excludes SortKey via [IgnoreDataMember])
+			JsonSerializer.Serialize(writer, value, typeof(T), options);
+		}
+
+		private void WriteGeoDistanceBody(Utf8JsonWriter writer, IGeoDistanceSort value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			// GeoDistanceSort serialization is special: the field name with points array is
+			// injected INSIDE the body alongside normal properties.
+			// Output: { "distance_type": "...", "unit": "...", ..., "<field>": [...points...] }
+			writer.WriteStartObject();
+
+			// Write standard properties
+			if (value.DistanceType.HasValue)
+			{
+				writer.WritePropertyName("distance_type");
+				JsonSerializer.Serialize(writer, value.DistanceType.Value, options);
+			}
+			if (value.Unit.HasValue)
+			{
+				writer.WritePropertyName("unit");
+				JsonSerializer.Serialize(writer, value.Unit.Value, options);
+			}
+			if (value.IgnoreUnmapped.HasValue)
+			{
+				writer.WritePropertyName("ignore_unmapped");
+				writer.WriteBooleanValue(value.IgnoreUnmapped.Value);
+			}
+			if (value.Order.HasValue)
+			{
+				writer.WritePropertyName("order");
+				JsonSerializer.Serialize(writer, value.Order.Value, options);
+			}
+			if (value.Mode.HasValue)
+			{
+				writer.WritePropertyName("mode");
+				JsonSerializer.Serialize(writer, value.Mode.Value, options);
+			}
+			if (value.NumericType.HasValue)
+			{
+				writer.WritePropertyName("numeric_type");
+				JsonSerializer.Serialize(writer, value.NumericType.Value, options);
+			}
+			if (value.Missing != null)
+			{
+				writer.WritePropertyName("missing");
+				JsonSerializer.Serialize(writer, value.Missing, options);
+			}
+			if (value.Nested != null)
+			{
+				writer.WritePropertyName("nested");
+				JsonSerializer.Serialize(writer, value.Nested, options);
+			}
+
+			// Write the field with its points array: "<field_name>": [lat,lon, lat,lon, ...]
+			if (value.Field != null)
+			{
+				var fieldName = _settings.Inferrer.Field(value.Field);
+				writer.WritePropertyName(fieldName);
+				JsonSerializer.Serialize(writer, value.Points, options);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private ISort DeserializeGeoDistanceSort(JsonElement body, JsonSerializerOptions options)
+		{
+			var geoSort = new GeoDistanceSort();
+
+			foreach (var prop in body.EnumerateObject())
+			{
+				switch (prop.Name)
+				{
+					case "distance_type":
+						geoSort.DistanceType = JsonSerializer.Deserialize<GeoDistanceType?>(prop.Value.GetRawText(), options);
+						break;
+					case "unit":
+						geoSort.Unit = JsonSerializer.Deserialize<DistanceUnit?>(prop.Value.GetRawText(), options);
+						break;
+					case "ignore_unmapped":
+						geoSort.IgnoreUnmapped = prop.Value.GetBoolean();
+						break;
+					case "order":
+						geoSort.Order = JsonSerializer.Deserialize<SortOrder?>(prop.Value.GetRawText(), options);
+						break;
+					case "mode":
+						geoSort.Mode = JsonSerializer.Deserialize<SortMode?>(prop.Value.GetRawText(), options);
+						break;
+					case "numeric_type":
+						geoSort.NumericType = JsonSerializer.Deserialize<NumericType?>(prop.Value.GetRawText(), options);
+						break;
+					case "missing":
+						geoSort.Missing = DeserializeMissing(prop.Value);
+						break;
+					case "nested":
+						geoSort.Nested = JsonSerializer.Deserialize<NestedSort>(prop.Value.GetRawText(), options);
+						break;
+					default:
+						// Unknown property is the field with geo points
+						if (prop.Value.ValueKind == JsonValueKind.Array)
+						{
+							geoSort.Field = prop.Name;
+							geoSort.Points = JsonSerializer.Deserialize<IEnumerable<GeoLocation>>(prop.Value.GetRawText(), options);
+						}
+						break;
+				}
+			}
+
+			return geoSort;
+		}
+
+		private static object DeserializeMissing(JsonElement element)
+		{
+			return element.ValueKind switch
+			{
+				JsonValueKind.String => element.GetString(),
+				JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
+				JsonValueKind.True => true,
+				JsonValueKind.False => false,
+				_ => null
+			};
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Search/SourceFiltering/SourceFilter.cs
+++ b/src/OpenSearch.Client/Search/Search/SourceFiltering/SourceFilter.cs
@@ -33,6 +33,8 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(SourceFilter))]
+	[System.Text.Json.Serialization.JsonConverter(typeof(SourceFilterConverter))]
 	[JsonFormatter(typeof(SourceFilterFormatter))]
 	public interface ISourceFilter
 	{

--- a/src/OpenSearch.Client/Search/Search/SourceFiltering/SourceFilterConverter.cs
+++ b/src/OpenSearch.Client/Search/Search/SourceFiltering/SourceFilterConverter.cs
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes the <c>_source</c> filter, which may take the form of a single field string,
+	/// an array of field strings (both treated as <c>includes</c>), or an object with
+	/// <c>includes</c>/<c>excludes</c> arrays. Serializes as the object form. Replaces the Utf8Json
+	/// <c>SourceFilterFormatter</c>.
+	/// </summary>
+	internal sealed class SourceFilterConverter : JsonConverter<ISourceFilter>
+	{
+		public override ISourceFilter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.String:
+				{
+					var name = reader.GetString();
+					return new SourceFilter { Includes = new[] { name } };
+				}
+				case JsonTokenType.StartArray:
+				{
+					var includes = JsonSerializer.Deserialize<Fields>(ref reader, options);
+					return new SourceFilter { Includes = includes };
+				}
+				case JsonTokenType.StartObject:
+				{
+					var filter = new SourceFilter();
+					while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+					{
+						if (reader.TokenType != JsonTokenType.PropertyName)
+							continue;
+
+						var propertyName = reader.GetString();
+						reader.Read();
+
+						switch (propertyName)
+						{
+							case "includes":
+								filter.Includes = JsonSerializer.Deserialize<Fields>(ref reader, options);
+								break;
+							case "excludes":
+								filter.Excludes = JsonSerializer.Deserialize<Fields>(ref reader, options);
+								break;
+							default:
+								reader.Skip();
+								break;
+						}
+					}
+					return filter;
+				}
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, ISourceFilter value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			if (value.Excludes != null)
+			{
+				writer.WritePropertyName("excludes");
+				JsonSerializer.Serialize(writer, value.Excludes, options);
+			}
+			if (value.Includes != null)
+			{
+				writer.WritePropertyName("includes");
+				JsonSerializer.Serialize(writer, value.Includes, options);
+			}
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Suggesters/ContextSuggester/Context.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/ContextSuggester/Context.cs
@@ -26,10 +26,15 @@
 *  under the License.
 */
 
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
+	[JsonConverter(typeof(ContextConverter))]
 	[JsonFormatter(typeof(ContextFormatter))]
 	public class Context : Union<string, GeoLocation>
 	{
@@ -45,6 +50,41 @@ namespace OpenSearch.Client
 		public static implicit operator Context(GeoLocation context) => new Context(context);
 	}
 
+	/// <summary>
+	/// (De)serializes <see cref="Context"/> (a <see cref="Union{String, GeoLocation}"/> subtype).
+	/// Reads via the underlying union and wraps the resulting member in a <see cref="Context"/>;
+	/// writes whichever member is set. Replaces the Utf8Json <c>ContextFormatter</c>.
+	/// </summary>
+	internal sealed class ContextConverter : JsonConverter<Context>
+	{
+		public override Context Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			var union = System.Text.Json.JsonSerializer.Deserialize<Union<string, GeoLocation>>(ref reader, options);
+			if (union == null)
+				return null;
+
+			return union.Tag switch
+			{
+				0 => new Context(union.Item1),
+				1 => new Context(union.Item2),
+				_ => null
+			};
+		}
+
+		public override void Write(Utf8JsonWriter writer, Context value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			System.Text.Json.JsonSerializer.Serialize(writer, value, typeof(Union<string, GeoLocation>), options);
+		}
+	}
 	internal class ContextFormatter : IJsonFormatter<Context>
 	{
 		public Context Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
@@ -68,4 +108,6 @@ namespace OpenSearch.Client
 			formatter.Serialize(ref writer, value, formatterResolver);
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/DirectGenerator.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/PhraseSuggester/DirectGenerator.cs
@@ -69,7 +69,6 @@ namespace OpenSearch.Client
 		int? Size { get; set; }
 
 		[DataMember(Name = "suggest_mode")]
-
 		SuggestMode? SuggestMode { get; set; }
 	}
 

--- a/src/OpenSearch.Client/Search/Suggesters/SuggestContainer.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggestContainer.cs
@@ -33,7 +33,7 @@ using OpenSearch.Net.Utf8Json;
 namespace OpenSearch.Client
 {
 	[JsonFormatter(typeof(VerbatimDictionaryKeysFormatter<SuggestContainer, ISuggestContainer, string, ISuggestBucket>))]
-	public interface ISuggestContainer : IIsADictionary<string, ISuggestBucket> { }
+	public interface ISuggestContainer : IIsADictionary<string, ISuggestBucket>, IVerbatimDictionaryKeys { }
 
 	public class SuggestContainer : IsADictionaryBase<string, ISuggestBucket>, ISuggestContainer
 	{

--- a/src/OpenSearch.Client/Search/Suggesters/SuggestDictionary.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggestDictionary.cs
@@ -32,22 +32,6 @@ using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
-	internal class SuggestDictionaryFormatter<T> : IJsonFormatter<ISuggestDictionary<T>>
-		where T : class
-	{
-		public ISuggestDictionary<T> Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
-		{
-			var formatter = formatterResolver.GetFormatter<Dictionary<string, ISuggest<T>[]>>();
-			var dict = formatter.Deserialize(ref reader, formatterResolver);
-			return new SuggestDictionary<T>(dict);
-		}
-
-		public void Serialize(ref JsonWriter writer, ISuggestDictionary<T> value, IJsonFormatterResolver formatterResolver)
-		{
-			var formatter = new VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, ISuggest<T>[]>();
-			formatter.Serialize(ref writer, (SuggestDictionary<T>)value, formatterResolver);
-		}
-	}
 
 	[JsonFormatter(typeof(SuggestDictionaryFormatter<>))]
 	public interface ISuggestDictionary<out T>
@@ -79,4 +63,22 @@ namespace OpenSearch.Client
 		}
 
 	}
+	internal class SuggestDictionaryFormatter<T> : IJsonFormatter<ISuggestDictionary<T>>
+		where T : class
+	{
+		public ISuggestDictionary<T> Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
+		{
+			var formatter = formatterResolver.GetFormatter<Dictionary<string, ISuggest<T>[]>>();
+			var dict = formatter.Deserialize(ref reader, formatterResolver);
+			return new SuggestDictionary<T>(dict);
+		}
+
+		public void Serialize(ref JsonWriter writer, ISuggestDictionary<T> value, IJsonFormatterResolver formatterResolver)
+		{
+			var formatter = new VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, ISuggest<T>[]>();
+			formatter.Serialize(ref writer, (SuggestDictionary<T>)value, formatterResolver);
+		}
+	}
+
+
 }

--- a/src/OpenSearch.Client/Search/Suggesters/SuggestDictionaryConverter.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggestDictionaryConverter.cs
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> for <see cref="ISuggestDictionary{T}"/> that
+	/// handles the suggest result dictionary in search responses.
+	/// Replaces the Utf8Json-based <c>SuggestDictionaryFormatter</c>.
+	/// </summary>
+	internal sealed class SuggestDictionaryConverterFactory : JsonConverterFactory
+	{
+		private static readonly ConcurrentDictionary<Type, JsonConverter> ConverterCache = new();
+
+		public override bool CanConvert(Type typeToConvert)
+		{
+			if (!typeToConvert.IsGenericType) return false;
+
+			var genericDef = typeToConvert.GetGenericTypeDefinition();
+			return genericDef == typeof(ISuggestDictionary<>) || genericDef == typeof(SuggestDictionary<>);
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			return ConverterCache.GetOrAdd(typeToConvert, type =>
+			{
+				var docType = type.IsGenericType
+					? type.GetGenericArguments()[0]
+					: typeof(object);
+
+				var converterType = typeof(SuggestDictionaryConverter<>).MakeGenericType(docType);
+				return (JsonConverter)Activator.CreateInstance(converterType);
+			});
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="ISuggestDictionary{TDocument}"/>.
+	/// Reads a JSON object where each key is a suggest name and the value is an array of suggest results.
+	/// </summary>
+	internal sealed class SuggestDictionaryConverter<TDocument> : JsonConverter<ISuggestDictionary<TDocument>>
+		where TDocument : class
+	{
+		public override ISuggestDictionary<TDocument> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return SuggestDictionary<TDocument>.Default;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return SuggestDictionary<TDocument>.Default;
+			}
+
+			var dict = JsonSerializer.Deserialize<Dictionary<string, ISuggest<TDocument>[]>>(ref reader, options);
+			return new SuggestDictionary<TDocument>(dict ?? new Dictionary<string, ISuggest<TDocument>[]>());
+		}
+
+		public override void Write(Utf8JsonWriter writer, ISuggestDictionary<TDocument> value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			foreach (var key in value.Keys)
+			{
+				writer.WritePropertyName(key);
+				JsonSerializer.Serialize(writer, value[key], options);
+			}
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Search/Suggesters/SuggesterBase.cs
+++ b/src/OpenSearch.Client/Search/Suggesters/SuggesterBase.cs
@@ -29,12 +29,14 @@
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A suggester that suggests similar looking terms based on a provided text
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ISuggester
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Search/TrackTotalHits/TrackTotalHits.cs
+++ b/src/OpenSearch.Client/Search/TrackTotalHits/TrackTotalHits.cs
@@ -5,10 +5,15 @@
 * compatible open source license.
 */
 
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client;
 
+[JsonConverter(typeof(TrackTotalHitsConverter))]
 [JsonFormatter(typeof(TrackTotalHitsFormatter))]
 public class TrackTotalHits : Union<bool, long>
 {
@@ -28,4 +33,40 @@ public class TrackTotalHits : Union<bool, long>
 		1 => Item2.ToString(),
 		_ => null
 	};
+}
+
+/// <summary>
+/// (De)serializes <see cref="TrackTotalHits"/> (a <see cref="Union{Boolean, Int64}"/> subtype).
+/// Reads via the underlying union and wraps the resulting member in a <see cref="TrackTotalHits"/>;
+/// writes whichever member is set.
+/// </summary>
+internal sealed class TrackTotalHitsConverter : JsonConverter<TrackTotalHits>
+{
+	public override TrackTotalHits Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		if (reader.TokenType == JsonTokenType.Null)
+			return null;
+
+		var union = System.Text.Json.JsonSerializer.Deserialize<Union<bool, long>>(ref reader, options);
+		if (union == null)
+			return null;
+
+		return union.Tag switch
+		{
+			0 => new TrackTotalHits(union.Item1),
+			1 => new TrackTotalHits(union.Item2),
+			_ => null
+		};
+	}
+
+	public override void Write(Utf8JsonWriter writer, TrackTotalHits value, JsonSerializerOptions options)
+	{
+		if (value == null)
+		{
+			writer.WriteNullValue();
+			return;
+		}
+
+		System.Text.Json.JsonSerializer.Serialize(writer, value, typeof(Union<bool, long>), options);
+	}
 }

--- a/src/OpenSearch.Client/Snapshot/Repositories/AzureRepository.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/AzureRepository.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// <para />
 	/// Requires the repository-azure plugin to be installed on the cluster
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IAzureRepository : IRepository<IAzureRepositorySettings> { }
 
 	/// <inheritdoc />
@@ -54,6 +56,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Snapshot repository settings for <see cref="IAzureRepository"/>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IAzureRepositorySettings : IRepositorySettings
 	{
 		/// <summary>
@@ -75,6 +78,7 @@ namespace OpenSearch.Client
 		/// affect index files that are already compressed by default. Defaults to <c>false</c>.
 		/// </summary>
 		[DataMember(Name ="compress")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? Compress { get; set; }
 

--- a/src/OpenSearch.Client/Snapshot/Repositories/CreateRepository/CreateRepositoryConverter.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/CreateRepository/CreateRepositoryConverter.cs
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes an <see cref="ICreateRepositoryRequest"/> as the repository object itself
+	/// (<c>{ "type": "...", "settings": { ... } }</c>) rather than wrapping it in a
+	/// <c>repository</c> property. Mirrors the historical (Utf8Json) <c>CreateRepositoryFormatter</c>.
+	/// </summary>
+	internal sealed class CreateRepositoryConverter : JsonConverter<ICreateRepositoryRequest>
+	{
+		public override ICreateRepositoryRequest Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+			throw new NotSupportedException();
+
+		public override void Write(Utf8JsonWriter writer, ICreateRepositoryRequest value, JsonSerializerOptions options)
+		{
+			if (value?.Repository == null)
+			{
+				writer.WriteStartObject();
+				writer.WriteEndObject();
+				return;
+			}
+
+			// Source-only repositories carry a dedicated interface-level converter (they have no
+			// [InterfaceDataContract] and their settings are flattened with a delegate_type
+			// discriminator). Route them through the interface so that converter is used.
+			if (value.Repository is ISourceOnlyRepository sourceOnly)
+			{
+				JsonSerializer.Serialize(writer, sourceOnly, options);
+				return;
+			}
+
+			// Other repositories serialize by their runtime type so the interface data contract
+			// (type + settings) is emitted.
+			JsonSerializer.Serialize(writer, value.Repository, value.Repository.GetType(), options);
+		}
+	}
+}

--- a/src/OpenSearch.Client/Snapshot/Repositories/CreateRepository/CreateRepositoryRequest.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/CreateRepository/CreateRepositoryRequest.cs
@@ -27,6 +27,7 @@
 */
 
 using System;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -35,6 +36,7 @@ namespace OpenSearch.Client
 	/// Creates a snapshot repository
 	/// </summary>
 	[MapsApi("snapshot.create_repository.json")]
+	[JsonConverter(typeof(CreateRepositoryConverter))]
 	[JsonFormatter(typeof(CreateRepositoryFormatter))]
 	public partial interface ICreateRepositoryRequest
 	{

--- a/src/OpenSearch.Client/Snapshot/Repositories/FileSystemRepository.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/FileSystemRepository.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// The path specified in the location parameter should point to the same location in the shared
 	/// filesystem and be accessible on all data and cluster_manager nodes.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IFileSystemRepository : IRepository<IFileSystemRepositorySettings> { }
 
 	/// <inheritdoc />
@@ -52,6 +54,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Repository settings for <see cref="IFileSystemRepository"/>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IFileSystemRepositorySettings : IRepositorySettings
 	{
 		/// <summary>
@@ -66,6 +69,7 @@ namespace OpenSearch.Client
 		/// Turns on compression of the snapshot files. Defaults to true.
 		/// </summary>
 		[DataMember(Name ="compress")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? Compress { get; set; }
 

--- a/src/OpenSearch.Client/Snapshot/Repositories/GetRepository/GetRepositoryResponse.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/GetRepository/GetRepositoryResponse.cs
@@ -28,12 +28,14 @@
 
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using OpenSearch.Net;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net;
 
 namespace OpenSearch.Client
 {
 	[DataContract]
+	[JsonConverter(typeof(GetRepositoryResponseConverter))]
 	[JsonFormatter(typeof(GetRepositoryResponseFormatter))]
 	public class GetRepositoryResponse : ResponseBase
 	{

--- a/src/OpenSearch.Client/Snapshot/Repositories/GetRepository/GetRepositoryResponseConverter.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/GetRepository/GetRepositoryResponseConverter.cs
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenSearch.Net;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Deserializes a <see cref="GetRepositoryResponse"/> whose root object is a map of
+	/// <c>{ "&lt;repository-name&gt;": { "type": "...", "settings": { ... } } }</c>.
+	/// Dispatches each repository on its <c>type</c> discriminator (fs/url/azure/s3/hdfs/source) and
+	/// tolerates a missing <c>settings</c> object. Also honours the top-level <c>error</c>/<c>status</c>
+	/// server-error fields. Mirrors the historical (Utf8Json) <c>GetRepositoryResponseFormatter</c>.
+	/// </summary>
+	internal sealed class GetRepositoryResponseConverter : JsonConverter<GetRepositoryResponse>
+	{
+		public override GetRepositoryResponse Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var response = new GetRepositoryResponse();
+
+			if (reader.TokenType == JsonTokenType.Null)
+				return response;
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+			var repositories = new Dictionary<string, ISnapshotRepository>();
+
+			reader.Read();
+			while (reader.TokenType != JsonTokenType.EndObject)
+			{
+				var name = reader.GetString();
+				reader.Read();
+
+				if (ResponseFormatterHelpers.ServerErrorFields.TryGetValue(name, out var errorValue))
+				{
+					switch (errorValue)
+					{
+						case 0: // "error"
+							if (reader.TokenType == JsonTokenType.String)
+								response.Error = new Error { Reason = reader.GetString() };
+							else
+								response.Error = JsonSerializer.Deserialize<Error>(ref reader, options);
+							break;
+						case 1: // "status"
+							response.StatusCode = reader.TokenType == JsonTokenType.Number ? reader.GetInt32() : (int?)null;
+							if (reader.TokenType != JsonTokenType.Number)
+								reader.Skip();
+							break;
+					}
+
+					reader.Read();
+					continue;
+				}
+
+				using var doc = JsonDocument.ParseValue(ref reader);
+				var root = doc.RootElement;
+
+				var repository = ReadRepository(root, options);
+				if (repository != null)
+					repositories.Add(name, repository);
+
+				reader.Read();
+			}
+
+			response.Repositories = repositories;
+			return response;
+		}
+
+		private static ISnapshotRepository ReadRepository(JsonElement root, JsonSerializerOptions options)
+		{
+			if (root.ValueKind != JsonValueKind.Object || !root.TryGetProperty("type", out var typeElement))
+				return null;
+
+			var type = typeElement.GetString();
+			var hasSettings = root.TryGetProperty("settings", out var settings) && settings.ValueKind == JsonValueKind.Object;
+
+			switch (type)
+			{
+				case "fs":
+					return new FileSystemRepository(hasSettings ? settings.Deserialize<FileSystemRepositorySettings>(options) : null);
+				case "url":
+					return new ReadOnlyUrlRepository(hasSettings ? settings.Deserialize<ReadOnlyUrlRepositorySettings>(options) : null);
+				case "azure":
+					return new AzureRepository(hasSettings ? settings.Deserialize<AzureRepositorySettings>(options) : null);
+				case "s3":
+					return new S3Repository(hasSettings ? settings.Deserialize<S3RepositorySettings>(options) : null);
+				case "hdfs":
+					return new HdfsRepository(hasSettings ? settings.Deserialize<HdfsRepositorySettings>(options) : null);
+				case "source":
+					return root.Deserialize<ISourceOnlyRepository>(options);
+				default:
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, GetRepositoryResponse value, JsonSerializerOptions options)
+		{
+			if (value?.Repositories == null)
+			{
+				writer.WriteStartObject();
+				writer.WriteEndObject();
+				return;
+			}
+
+			writer.WriteStartObject();
+			foreach (var kvp in value.Repositories)
+			{
+				writer.WritePropertyName(kvp.Key);
+				if (kvp.Value == null)
+					writer.WriteNullValue();
+				else
+					JsonSerializer.Serialize(writer, kvp.Value, kvp.Value.GetType(), options);
+			}
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Snapshot/Repositories/GetRepository/GetRepositoryResponseFormatter.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/GetRepository/GetRepositoryResponseFormatter.cs
@@ -46,7 +46,7 @@ namespace OpenSearch.Client
 			while (reader.ReadIsInObject(ref count))
 			{
 				var property = reader.ReadPropertyNameSegmentRaw();
-				if (ResponseFormatterHelpers.ServerErrorFields.TryGetValue(property, out var errorValue))
+				if (ResponseFormatterHelpers.ServerErrorFieldsAutomata.TryGetValue(property, out var errorValue))
 				{
 					switch (errorValue)
 					{

--- a/src/OpenSearch.Client/Snapshot/Repositories/HdfsRepository.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/HdfsRepository.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -38,6 +39,7 @@ namespace OpenSearch.Client
 	/// <para />
 	/// Requires the repository-hdfs plugin to be installed on the cluster
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IHdfsRepository : IRepository<IHdfsRepositorySettings> { }
 
 	/// <inheritdoc />
@@ -53,6 +55,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Snapshot repository settings for <see cref="IHdfsRepository"/>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IHdfsRepositorySettings : IRepositorySettings
 	{
 		/// <summary>
@@ -68,6 +71,7 @@ namespace OpenSearch.Client
 		/// affect index files that are already compressed by default. Defaults to <c>false</c>.
 		/// </summary>
 		[DataMember(Name ="compress")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? Compress { get; set; }
 
@@ -94,6 +98,7 @@ namespace OpenSearch.Client
 		/// Whether to load the default Hadoop configuration (default) or not
 		/// </summary>
 		[DataMember(Name ="load_defaults")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? LoadDefaults { get; set; }
 

--- a/src/OpenSearch.Client/Snapshot/Repositories/ISnapshotRepository.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/ISnapshotRepository.cs
@@ -27,12 +27,14 @@
 */
 
 using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
 {
 	/// <summary>
 	/// A snapshot repository
 	/// </summary>
+	[InterfaceDataContract]
 	public interface ISnapshotRepository
 	{
 		[DataMember(Name ="type")]
@@ -42,6 +44,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A snapshot repository with settings
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IRepositoryWithSettings: ISnapshotRepository
 	{
 		/// <summary>
@@ -54,6 +57,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// A snapshot repository with typed settings
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IRepository<TSettings> : IRepositoryWithSettings
 		where TSettings : class, IRepositorySettings
 	{

--- a/src/OpenSearch.Client/Snapshot/Repositories/ReadOnlyUrlRepository.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/ReadOnlyUrlRepository.cs
@@ -36,6 +36,7 @@ namespace OpenSearch.Client
 	/// A snapshot repository that can be used as an alternative read-only way to access data created by the <see cref="IFileSystemRepository"/>.
 	/// The URL specified in the url parameter should point to the root of the shared filesystem repository.
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IReadOnlyUrlRepository : IRepository<IReadOnlyUrlRepositorySettings> { }
 
 	/// <inheritdoc />
@@ -51,6 +52,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Snapshot repository settings for <see cref="IReadOnlyUrlRepository"/>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IReadOnlyUrlRepositorySettings : IRepositorySettings
 	{
 		/// <summary>

--- a/src/OpenSearch.Client/Snapshot/Repositories/S3Repository.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/S3Repository.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -37,6 +38,7 @@ namespace OpenSearch.Client
 	/// <para />
 	/// Requires the repository-s3 plugin to be installed on the cluster
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IS3Repository : IRepository<IS3RepositorySettings> { }
 
 	/// <inheritdoc />
@@ -54,6 +56,7 @@ namespace OpenSearch.Client
 	/// <summary>
 	/// Snapshot repository settings for <see cref="IS3Repository"/>
 	/// </summary>
+	[InterfaceDataContract]
 	public interface IS3RepositorySettings : IRepositorySettings
 	{
 		/// <summary>
@@ -108,6 +111,7 @@ namespace OpenSearch.Client
 		/// Defaults to false.
 		/// </summary>
 		[DataMember(Name ="compress")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? Compress { get; set; }
 
@@ -116,6 +120,7 @@ namespace OpenSearch.Client
 		/// Defaults to false.
 		/// </summary>
 		[DataMember(Name ="server_side_encryption")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? ServerSideEncryption { get; set; }
 
@@ -132,6 +137,7 @@ namespace OpenSearch.Client
 		/// be automatically determined by the AWS Java SDK used internally by OpenSearch
 		/// </summary>
 		[DataMember(Name = "path_style_access")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? PathStyleAccess { get; set; }
 
@@ -142,6 +148,7 @@ namespace OpenSearch.Client
 		/// encoding. Defaults to false.
 		/// </summary>
 		[DataMember(Name = "disable_chunked_encoding")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? DisableChunkedEncoding { get; set; }
 
@@ -149,6 +156,7 @@ namespace OpenSearch.Client
 		/// Make the repository readonly. Defaults to false.
 		/// </summary>
 		[DataMember(Name = "readonly")]
+		[JsonConverter(typeof(NullableStringBooleanConverter))]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? ReadOnly { get; set; }
 

--- a/src/OpenSearch.Client/Snapshot/Repositories/SourceOnlyRepository.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/SourceOnlyRepository.cs
@@ -28,8 +28,9 @@
 
 using System;
 using System.Runtime.Serialization;
-using OpenSearch.Net.Extensions;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
+using OpenSearch.Net.Extensions;
 using OpenSearch.Net.Utf8Json.Internal;
 
 namespace OpenSearch.Client
@@ -39,6 +40,7 @@ namespace OpenSearch.Client
 	/// Source only snapshots contain stored fields and index metadata. They do not include index or doc values structures
 	/// and are not searchable when restored. After restoring a source-only snapshot, you must reindex the data into a new index.
 	/// </summary>
+	[JsonConverter(typeof(SourceOnlyRepositoryConverter))]
 	[JsonFormatter(typeof(SourceOnlyRepositoryFormatter))]
 	public interface ISourceOnlyRepository : IRepositoryWithSettings
 	{
@@ -272,4 +274,6 @@ namespace OpenSearch.Client
 			return new SourceOnlyRepository(delegateType, delegateSettings);
 		}
 	}
+
+
 }

--- a/src/OpenSearch.Client/Snapshot/Repositories/SourceOnlyRepositoryConverter.cs
+++ b/src/OpenSearch.Client/Snapshot/Repositories/SourceOnlyRepositoryConverter.cs
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// Serializes an <see cref="ISourceOnlyRepository"/> as
+	/// <c>{ "type": "source", "settings": { "delegate_type": &lt;type&gt;, ...delegate settings... } }</c>.
+	/// Mirrors the historical (Utf8Json) <c>SourceOnlyRepositoryFormatter</c>: the delegate
+	/// repository's settings are flattened alongside the <c>delegate_type</c> discriminator.
+	/// </summary>
+	internal sealed class SourceOnlyRepositoryConverter : JsonConverter<ISourceOnlyRepository>
+	{
+		public override ISourceOnlyRepository Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			using var doc = JsonDocument.ParseValue(ref reader);
+			var root = doc.RootElement;
+
+			if (root.ValueKind != JsonValueKind.Object
+				|| !root.TryGetProperty("settings", out var settings)
+				|| settings.ValueKind != JsonValueKind.Object
+				|| !settings.TryGetProperty("delegate_type", out var delegateTypeElement))
+				return null;
+
+			var delegateType = delegateTypeElement.GetString();
+
+			object delegateSettings = delegateType switch
+			{
+				"s3" => settings.Deserialize<S3RepositorySettings>(options),
+				"azure" => settings.Deserialize<AzureRepositorySettings>(options),
+				"url" => settings.Deserialize<ReadOnlyUrlRepositorySettings>(options),
+				"hdfs" => settings.Deserialize<HdfsRepositorySettings>(options),
+				"fs" => settings.Deserialize<FileSystemRepositorySettings>(options),
+				_ => null
+			};
+
+			return new SourceOnlyRepository(delegateType, delegateSettings);
+		}
+
+		public override void Write(Utf8JsonWriter writer, ISourceOnlyRepository value, JsonSerializerOptions options)
+		{
+			if (value == null || string.IsNullOrEmpty(value.DelegateType))
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+			writer.WriteString("type", "source");
+
+			var delegateSettings = ((IRepositoryWithSettings)value).DelegateSettings;
+			if (delegateSettings != null)
+			{
+				writer.WritePropertyName("settings");
+				writer.WriteStartObject();
+				writer.WriteString("delegate_type", value.DelegateType);
+
+				// Serialize the delegate settings by runtime type, then splice its members
+				// alongside delegate_type inside the same settings object.
+				using var settingsDoc = JsonSerializer.SerializeToDocument(
+					delegateSettings, delegateSettings.GetType(), options);
+				if (settingsDoc.RootElement.ValueKind == JsonValueKind.Object)
+				{
+					foreach (var prop in settingsDoc.RootElement.EnumerateObject())
+						prop.WriteTo(writer);
+				}
+
+				writer.WriteEndObject();
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Client/Snapshot/Snapshot/SnapshotShardFailure.cs
+++ b/src/OpenSearch.Client/Snapshot/Snapshot/SnapshotShardFailure.cs
@@ -27,6 +27,7 @@
 */
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Client
@@ -44,6 +45,7 @@ namespace OpenSearch.Client
 		public string Reason { get; set; }
 
 		[DataMember(Name ="shard_id")]
+		[JsonConverter(typeof(IntStringConverter))]
 		[JsonFormatter(typeof(IntStringFormatter))]
 		public string ShardId { get; set; }
 

--- a/src/OpenSearch.Net/Extensions/ArraySegmentBytesExtensions.cs
+++ b/src/OpenSearch.Net/Extensions/ArraySegmentBytesExtensions.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Formatters;
 using OpenSearch.Net.Utf8Json.Internal;
@@ -58,9 +59,9 @@ namespace OpenSearch.Net.Extensions
 			return false;
 		}
 
-		private static readonly byte[] LongMaxValue = StringEncoding.UTF8.GetBytes(long.MaxValue.ToString(CultureInfo.InvariantCulture));
+		private static readonly byte[] LongMaxValue = Encoding.UTF8.GetBytes(long.MaxValue.ToString(CultureInfo.InvariantCulture));
 
-		private static readonly byte[] LongMinValue = StringEncoding.UTF8.GetBytes(long.MinValue.ToString(CultureInfo.InvariantCulture));
+		private static readonly byte[] LongMinValue = Encoding.UTF8.GetBytes(long.MinValue.ToString(CultureInfo.InvariantCulture));
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsLong(this ref ArraySegment<byte> arraySegment)
@@ -82,7 +83,7 @@ namespace OpenSearch.Net.Extensions
 			while (i < arraySegment.Count)
 			{
 				var b = arraySegment.Array[arraySegment.Offset + i];
-				if (!NumberConverter.IsNumber(b))
+				if (b < (byte)'0' || b > (byte)'9')
 					return false;
 
 				// only compare to long.MinValue or long.MaxValue if we're dealing with same number of bytes
@@ -121,12 +122,13 @@ namespace OpenSearch.Net.Extensions
 			return true;
 		}
 
+		// Used by the restored Utf8Json date-math formatters to detect whether a raw JSON string segment holds
+		// an ISO8601 date-time. Only referenced on the legacy Utf8Json serialization path.
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsDateTime(this ref ArraySegment<byte> arraySegment, IJsonFormatterResolver formatterResolver, out DateTime dateTime)
 		{
 			dateTime = default;
 
-			// TODO: Nicer way to do this
 			var reader = new JsonReader(arraySegment.Array, arraySegment.Offset - 1); // include opening quote "
 			try
 			{
@@ -159,6 +161,6 @@ namespace OpenSearch.Net.Extensions
 		internal static string Utf8String(this ref ArraySegment<byte> segment) =>
 			// segment.Array is never null
 			// ReSharper disable once AssignNullToNotNullAttribute
-			StringEncoding.UTF8.GetString(segment.Array, segment.Offset, segment.Count);
+			Encoding.UTF8.GetString(segment.Array, segment.Offset, segment.Count);
 	}
 }

--- a/src/OpenSearch.Net/OpenSearch.Net.csproj
+++ b/src/OpenSearch.Net/OpenSearch.Net.csproj
@@ -24,9 +24,14 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Buffers" Version="4.6.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">      
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>

--- a/src/OpenSearch.Net/Responses/Dynamic/DynamicDictionary.cs
+++ b/src/OpenSearch.Net/Responses/Dynamic/DynamicDictionary.cs
@@ -35,6 +35,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using OpenSearch.Net.Utf8Json;
 
@@ -47,6 +48,7 @@ namespace OpenSearch.Net
 	/// <summary>
 	/// A dictionary that supports dynamic access.
 	/// </summary>
+	[JsonConverter(typeof(DynamicDictionaryConverter))]
 	[JsonFormatter(typeof(DynamicDictionaryFormatter))]
 	public class DynamicDictionary
 		: DynamicObject,

--- a/src/OpenSearch.Net/Responses/ServerException/Error.cs
+++ b/src/OpenSearch.Net/Responses/ServerException/Error.cs
@@ -31,12 +31,14 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
 
 namespace OpenSearch.Net
 {
 	[DataContract]
+	[JsonConverter(typeof(ErrorConverter))]
 	[JsonFormatter(typeof(ErrorFormatter))]
 	public class Error : ErrorCause
 	{

--- a/src/OpenSearch.Net/Responses/ServerException/ErrorCause.cs
+++ b/src/OpenSearch.Net/Responses/ServerException/ErrorCause.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using OpenSearch.Net.Extensions;
 using OpenSearch.Net.Utf8Json;
 using OpenSearch.Net.Utf8Json.Internal;
@@ -38,6 +39,7 @@ using OpenSearch.Net.Utf8Json.Internal;
 namespace OpenSearch.Net
 {
 	[JsonFormatter(typeof(ErrorCauseFormatter))]
+	[JsonConverter(typeof(ErrorCauseConverter))]
 	[DataContract]
 	public class ErrorCause
 	{

--- a/src/OpenSearch.Net/Serialization/Converters/DynamicDictionaryConverter.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/DynamicDictionaryConverter.cs
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="DynamicDictionary"/> that provides
+	/// round-trip serialization support. Replaces the Utf8Json-based <c>DynamicDictionaryFormatter</c>.
+	/// </summary>
+	internal class DynamicDictionaryConverter : JsonConverter<DynamicDictionary>
+	{
+		public override DynamicDictionary Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			// Handle JSON array by indexing elements with their position
+			if (reader.TokenType == JsonTokenType.StartArray)
+			{
+				var arrayDict = new Dictionary<string, object>();
+				var index = 0;
+
+				while (reader.Read())
+				{
+					if (reader.TokenType == JsonTokenType.EndArray)
+						break;
+
+					var value = DynamicValueConverter.ReadValue(ref reader, options);
+					arrayDict[index.ToString(CultureInfo.InvariantCulture)] = new DynamicValue(value);
+					index++;
+				}
+
+				return DynamicDictionary.Create(arrayDict);
+			}
+
+			// Handle JSON object
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException($"Unexpected token type {reader.TokenType} when deserializing DynamicDictionary");
+
+			var dictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					throw new JsonException("Expected property name");
+
+				var key = reader.GetString();
+				reader.Read();
+				var val = DynamicValueConverter.ReadValue(ref reader, options);
+				dictionary[key] = val;
+			}
+
+			return DynamicDictionary.Create(dictionary);
+		}
+
+		public override void Write(Utf8JsonWriter writer, DynamicDictionary value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			foreach (var kvp in (IDictionary<string, DynamicValue>)value)
+			{
+				writer.WritePropertyName(kvp.Key);
+				DynamicValueConverter.WriteValue(writer, kvp.Value?.Value, options);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/DynamicValueConverter.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/DynamicValueConverter.cs
@@ -1,0 +1,225 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="DynamicValue"/> that handles all primitive
+	/// JSON types (string, number, bool, null) as well as nested objects and arrays.
+	/// </summary>
+	internal class DynamicValueConverter : JsonConverter<DynamicValue>
+	{
+		public override DynamicValue Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			var value = ReadValue(ref reader, options);
+			return new DynamicValue(value);
+		}
+
+		public override void Write(Utf8JsonWriter writer, DynamicValue value, JsonSerializerOptions options)
+		{
+			if (value == null || !value.HasValue)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			WriteValue(writer, value.Value, options);
+		}
+
+		internal static object ReadValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+
+				case JsonTokenType.True:
+					return true;
+
+				case JsonTokenType.False:
+					return false;
+
+				case JsonTokenType.String:
+					return reader.GetString();
+
+				case JsonTokenType.Number:
+					// Try long first, then double for floating-point values
+					if (reader.TryGetInt64(out var longValue))
+						return longValue;
+					return reader.GetDouble();
+
+				case JsonTokenType.StartObject:
+					return ReadObject(ref reader, options);
+
+				case JsonTokenType.StartArray:
+					return ReadArray(ref reader, options);
+
+				default:
+					throw new JsonException($"Unexpected token type: {reader.TokenType}");
+			}
+		}
+
+		private static Dictionary<string, object> ReadObject(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			var dict = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					return dict;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					throw new JsonException("Expected property name");
+
+				var key = reader.GetString();
+				reader.Read();
+				dict[key] = ReadValue(ref reader, options);
+			}
+
+			throw new JsonException("Unexpected end of JSON while reading object");
+		}
+
+		private static List<object> ReadArray(ref Utf8JsonReader reader, JsonSerializerOptions options)
+		{
+			var list = new List<object>();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndArray)
+					return list;
+
+				list.Add(ReadValue(ref reader, options));
+			}
+
+			throw new JsonException("Unexpected end of JSON while reading array");
+		}
+
+		internal static void WriteValue(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			switch (value)
+			{
+				case DynamicValue dv:
+					if (!dv.HasValue)
+						writer.WriteNullValue();
+					else
+						WriteValue(writer, dv.Value, options);
+					break;
+
+				case DynamicDictionary dd:
+					JsonSerializer.Serialize(writer, dd, options);
+					break;
+
+				case string s:
+					writer.WriteStringValue(s);
+					break;
+
+				case bool b:
+					writer.WriteBooleanValue(b);
+					break;
+
+				case int i:
+					writer.WriteNumberValue(i);
+					break;
+
+				case long l:
+					writer.WriteNumberValue(l);
+					break;
+
+				case float f:
+					if (!float.IsNaN(f) && !float.IsInfinity(f)
+						&& Math.Floor((double)f) == f && Math.Abs(f) < 1e7)
+						writer.WriteRawValue(f.ToString("0.0", CultureInfo.InvariantCulture), skipInputValidation: true);
+					else
+						writer.WriteNumberValue(f);
+					break;
+
+				case double d:
+					if (!double.IsNaN(d) && !double.IsInfinity(d)
+						&& Math.Floor(d) == d && Math.Abs(d) < 1e16)
+						writer.WriteRawValue(d.ToString("0.0", CultureInfo.InvariantCulture), skipInputValidation: true);
+					else
+						writer.WriteNumberValue(d);
+					break;
+
+				case decimal dec:
+					if (decimal.Truncate(dec) == dec)
+						writer.WriteRawValue(dec.ToString("0.0", CultureInfo.InvariantCulture), skipInputValidation: true);
+					else
+						writer.WriteNumberValue(dec);
+					break;
+
+				case short sh:
+					writer.WriteNumberValue(sh);
+					break;
+
+				case byte by:
+					writer.WriteNumberValue(by);
+					break;
+
+				case uint ui:
+					writer.WriteNumberValue(ui);
+					break;
+
+				case ulong ul:
+					writer.WriteNumberValue(ul);
+					break;
+
+				case DateTime dt:
+					writer.WriteStringValue(dt);
+					break;
+
+				case DateTimeOffset dto:
+					writer.WriteStringValue(dto);
+					break;
+
+				case IDictionary<string, object> dict:
+					writer.WriteStartObject();
+					foreach (var kvp in dict)
+					{
+						writer.WritePropertyName(kvp.Key);
+						WriteValue(writer, kvp.Value, options);
+					}
+					writer.WriteEndObject();
+					break;
+
+				case IDictionary<string, DynamicValue> dvDict:
+					writer.WriteStartObject();
+					foreach (var kvp in dvDict)
+					{
+						writer.WritePropertyName(kvp.Key);
+						WriteValue(writer, kvp.Value?.Value, options);
+					}
+					writer.WriteEndObject();
+					break;
+
+				case IList<object> list:
+					writer.WriteStartArray();
+					foreach (var item in list)
+						WriteValue(writer, item, options);
+					writer.WriteEndArray();
+					break;
+
+				default:
+					// Fallback: use STJ default serialization for unknown types
+					JsonSerializer.Serialize(writer, value, value.GetType(), options);
+					break;
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/EnumMemberConverterFactory.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/EnumMemberConverterFactory.cs
@@ -1,0 +1,239 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JsonConverterFactory"/> that handles serialization of enum types using
+	/// <see cref="EnumMemberAttribute"/> values when present, falling back to the verbatim
+	/// enum member name. Replaces the Utf8Json-based <c>OpenSearchNetEnumResolver</c>.
+	/// <para>
+	/// Only enums explicitly marked <see cref="StringEnumAttribute"/> or <see cref="FlagsAttribute"/>
+	/// are serialized by name; all other enums fall through to the System.Text.Json default (numeric
+	/// underlying value), matching the legacy Utf8Json <c>OpenSearchNetEnumResolver</c> behavior.
+	/// <c>[StringEnum]</c> also works through the attribute channel; this factory is the
+	/// options-registered fallback (and the sole handler for un-attributed <c>[Flags]</c> enums).
+	/// </para>
+	/// </summary>
+	internal sealed class EnumMemberConverterFactory : JsonConverterFactory
+	{
+		// Retained for API/attribute-channel compatibility (see StringEnumAttribute). Naming is now
+		// always verbatim for the enums this factory handles, so the flag no longer alters behavior.
+		private readonly bool _useVerbatimName;
+
+		public EnumMemberConverterFactory(bool useVerbatimName = true) => _useVerbatimName = useVerbatimName;
+
+		public override bool CanConvert(Type typeToConvert)
+		{
+			var enumType = Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert;
+			if (!enumType.IsEnum)
+				return false;
+
+			// Serialize by name for:
+			//  - [StringEnum] enums (explicit opt-in to string form),
+			//  - [Flags] enums (need pipe-joined string output, e.g. "AND|NEAR"),
+			//  - enums that define any [EnumMember] value (their string form is meaningful,
+			//    e.g. GeoOrientation -> "cw"/"ccw").
+			// All other enums (e.g. GeoHashPrecision/GeoTilePrecision, which are bare numeric
+			// levels) fall through to the System.Text.Json numeric default, matching the legacy
+			// Utf8Json OpenSearchNetEnumResolver behavior.
+			return enumType.GetCustomAttribute<StringEnumAttribute>() != null
+				|| enumType.GetCustomAttribute<FlagsAttribute>() != null
+				|| HasAnyEnumMember(enumType);
+		}
+
+		private static bool HasAnyEnumMember(Type enumType)
+		{
+			foreach (var field in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+			{
+				if (field.GetCustomAttribute<EnumMemberAttribute>() != null)
+					return true;
+			}
+			return false;
+		}
+
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			var enumType = Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert;
+			var isNullable = Nullable.GetUnderlyingType(typeToConvert) != null;
+
+			var converterType = isNullable
+				? typeof(NullableEnumMemberConverter<>).MakeGenericType(enumType)
+				: typeof(EnumMemberConverter<>).MakeGenericType(enumType);
+
+			return (JsonConverter)Activator.CreateInstance(converterType, _useVerbatimName);
+		}
+	}
+
+	/// <summary>
+	/// Handles serialization/deserialization of a non-nullable enum type <typeparamref name="TEnum"/>.
+	/// Uses <see cref="EnumMemberAttribute"/> values when available, then <see cref="DataMemberAttribute"/>
+	/// names, falling back to the verbatim enum member name (matching the legacy Utf8Json behavior).
+	/// <see cref="FlagsAttribute"/> enums (de)serialize combined values as a pipe-joined list (e.g.
+	/// <c>"AND|NEAR"</c>). Returns <c>default(TEnum)</c> for unknown string values during deserialization.
+	/// </summary>
+	internal sealed class EnumMemberConverter<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
+	{
+		private readonly Dictionary<TEnum, string> _enumToString;
+		private readonly Dictionary<string, TEnum> _stringToEnum;
+		private readonly bool _isFlags;
+		// Ordered (flag-bits, string) pairs in enum declaration order, used to emit [Flags]
+		// combined values deterministically (e.g. "AND|NEAR").
+		private readonly List<KeyValuePair<long, string>> _orderedFlags;
+
+		public EnumMemberConverter() : this(true) { }
+
+		public EnumMemberConverter(bool useVerbatimName)
+		{
+			var enumType = typeof(TEnum);
+			// Iterate the declared static fields (in declaration order) rather than Enum.GetValues,
+			// so that when multiple members share the same underlying value the LAST-declared member
+			// wins the value→string mapping (matching the Utf8Json EnumFormatter behavior).
+			var fields = enumType.GetFields(BindingFlags.Public | BindingFlags.Static);
+			_isFlags = enumType.GetCustomAttribute<FlagsAttribute>() != null;
+
+			_enumToString = new Dictionary<TEnum, string>(fields.Length);
+			_stringToEnum = new Dictionary<string, TEnum>(fields.Length, StringComparer.OrdinalIgnoreCase);
+			_orderedFlags = _isFlags ? new List<KeyValuePair<long, string>>(fields.Length) : null;
+
+			foreach (var field in fields)
+			{
+				var value = (TEnum)field.GetValue(null);
+				var enumMemberAttr = field.GetCustomAttribute<EnumMemberAttribute>();
+				var dataMemberAttr = field.GetCustomAttribute<DataMemberAttribute>();
+
+				// EnumMember value wins, then DataMember name, then the verbatim CLR member name
+				// (matches the Utf8Json EnumFormatter behavior — no camelCasing).
+				var stringValue = enumMemberAttr?.Value ?? dataMemberAttr?.Name ?? field.Name;
+
+				// Last-declared member wins for the value→string map (duplicate underlying values).
+				_enumToString[value] = stringValue;
+				// First mapping wins for the string→value map (duplicate string values).
+				if (!_stringToEnum.ContainsKey(stringValue))
+					_stringToEnum[stringValue] = value;
+
+				_orderedFlags?.Add(new KeyValuePair<long, string>(Convert.ToInt64(value), stringValue));
+			}
+		}
+
+		public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var stringValue = reader.GetString();
+				if (stringValue == null)
+					return default;
+
+				if (_stringToEnum.TryGetValue(stringValue, out var enumValue))
+					return enumValue;
+
+				// For [Flags] enums, the wire value may be a pipe-joined list (e.g. "AND|NEAR").
+				if (_isFlags && stringValue.IndexOf('|') >= 0)
+				{
+					long combined = 0;
+					foreach (var part in stringValue.Split('|'))
+					{
+						var trimmed = part.Trim();
+						if (trimmed.Length != 0 && _stringToEnum.TryGetValue(trimmed, out var flag))
+							combined |= Convert.ToInt64(flag);
+					}
+					return (TEnum)Enum.ToObject(typeof(TEnum), combined);
+				}
+
+				// Unknown string value: return default (matching Utf8Json behavior)
+				return default;
+			}
+
+			if (reader.TokenType == JsonTokenType.Number)
+			{
+				// Handle numeric enum values
+				if (reader.TryGetInt32(out var intValue))
+					return Enum.IsDefined(typeof(TEnum), intValue)
+						? (TEnum)(object)intValue
+						: default;
+			}
+
+			if (reader.TokenType == JsonTokenType.Null)
+				return default;
+
+			// For any other token type, return default
+			return default;
+		}
+
+		public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+		{
+			if (_enumToString.TryGetValue(value, out var stringValue))
+			{
+				writer.WriteStringValue(stringValue);
+				return;
+			}
+
+			// For [Flags] enums, a combined value that is not a single named member is written as a
+			// pipe-joined list of the individual flag EnumMember values (e.g. "AND|NEAR").
+			if (_isFlags)
+			{
+				var combined = Convert.ToInt64(value);
+				if (combined != 0)
+				{
+					var parts = new List<string>();
+					foreach (var pair in _orderedFlags)
+					{
+						var flag = pair.Key;
+						if (flag != 0 && (combined & flag) == flag)
+							parts.Add(pair.Value);
+					}
+
+					if (parts.Count > 0)
+					{
+						writer.WriteStringValue(string.Join("|", parts));
+						return;
+					}
+				}
+			}
+
+			// Fall back to the verbatim member name (matches legacy Utf8Json behavior).
+			writer.WriteStringValue(value.ToString());
+		}
+	}
+
+	/// <summary>
+	/// Handles serialization/deserialization of nullable enum types (<c>TEnum?</c>).
+	/// Serializes <c>null</c> → JSON null, deserializes JSON null → <c>null</c>.
+	/// </summary>
+	internal sealed class NullableEnumMemberConverter<TEnum> : JsonConverter<TEnum?> where TEnum : struct, Enum
+	{
+		private readonly EnumMemberConverter<TEnum> _innerConverter;
+
+		public NullableEnumMemberConverter() : this(true) { }
+
+		public NullableEnumMemberConverter(bool useVerbatimName) =>
+			_innerConverter = new EnumMemberConverter<TEnum>(useVerbatimName);
+
+		public override TEnum? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			return _innerConverter.Read(ref reader, typeof(TEnum), options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, TEnum? value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				_innerConverter.Write(writer, value.Value, options);
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/ErrorCauseConverter.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/ErrorCauseConverter.cs
@@ -1,0 +1,332 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="ErrorCause"/> that handles the complex
+	/// deserialization logic from the OpenSearch error response format.
+	/// Supports both string format (just reason) and full object format.
+	/// </summary>
+	internal class ErrorCauseConverter : ErrorCauseConverter<ErrorCause>
+	{
+	}
+
+	internal class ErrorCauseConverter<TErrorCause> : JsonConverter<TErrorCause>
+		where TErrorCause : ErrorCause, new()
+	{
+		public override TErrorCause Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				return new TErrorCause { Reason = reader.GetString() };
+			}
+
+			if (reader.TokenType != JsonTokenType.StartObject)
+			{
+				reader.Skip();
+				return null;
+			}
+
+			var errorCause = new TErrorCause();
+			var additionalProperties = new Dictionary<string, object>();
+			errorCause.AdditionalProperties = additionalProperties;
+
+			while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+			{
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					continue;
+
+				var propertyName = reader.GetString();
+				reader.Read();
+
+				if (!DeserializeProperty(ref reader, propertyName, errorCause, options))
+				{
+					// Unknown property — store in AdditionalProperties
+					additionalProperties[propertyName] = ReadValue(ref reader);
+				}
+			}
+
+			return errorCause;
+		}
+
+		protected virtual bool DeserializeProperty(ref Utf8JsonReader reader, string propertyName, TErrorCause errorCause, JsonSerializerOptions options)
+		{
+			return DeserializeErrorCauseProperty(ref reader, propertyName, errorCause, options);
+		}
+
+		protected static bool DeserializeErrorCauseProperty(ref Utf8JsonReader reader, string propertyName, TErrorCause errorCause, JsonSerializerOptions options)
+		{
+			switch (propertyName)
+			{
+				case "bytes_limit":
+					errorCause.BytesLimit = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt64();
+					return true;
+				case "bytes_wanted":
+					errorCause.BytesWanted = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt64();
+					return true;
+				case "caused_by":
+					errorCause.CausedBy = JsonSerializer.Deserialize<ErrorCause>(ref reader, options);
+					return true;
+				case "col":
+					errorCause.Column = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt32();
+					return true;
+				case "failed_shards":
+					errorCause.FailedShards = JsonSerializer.Deserialize<List<ShardFailure>>(ref reader, options);
+					return true;
+				case "grouped":
+					errorCause.Grouped = reader.TokenType == JsonTokenType.Null ? null : reader.GetBoolean();
+					return true;
+				case "index":
+					errorCause.Index = reader.GetString();
+					return true;
+				case "index_uuid":
+					errorCause.IndexUUID = reader.GetString();
+					return true;
+				case "lang":
+					errorCause.Language = reader.GetString();
+					return true;
+				case "line":
+					errorCause.Line = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt32();
+					return true;
+				case "phase":
+					errorCause.Phase = reader.GetString();
+					return true;
+				case "reason":
+					errorCause.Reason = reader.GetString();
+					return true;
+				case "resource.id":
+					errorCause.ResourceId = ReadStringOrStringArray(ref reader);
+					return true;
+				case "resource.type":
+					errorCause.ResourceType = reader.GetString();
+					return true;
+				case "script":
+					errorCause.Script = reader.GetString();
+					return true;
+				case "script_stack":
+					errorCause.ScriptStack = ReadStringOrStringArray(ref reader);
+					return true;
+				case "shard":
+					errorCause.Shard = ReadNullableIntFromStringOrNumber(ref reader);
+					return true;
+				case "stack_trace":
+					errorCause.StackTrace = reader.GetString();
+					return true;
+				case "type":
+					errorCause.Type = reader.GetString();
+					return true;
+				default:
+					return false;
+			}
+		}
+
+		protected static IReadOnlyCollection<string> ReadStringOrStringArray(ref Utf8JsonReader reader)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return Array.Empty<string>();
+
+			if (reader.TokenType == JsonTokenType.String)
+				return new[] { reader.GetString() };
+
+			if (reader.TokenType == JsonTokenType.StartArray)
+			{
+				var list = new List<string>();
+				while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+				{
+					list.Add(reader.GetString());
+				}
+				return list;
+			}
+
+			reader.Skip();
+			return Array.Empty<string>();
+		}
+
+		protected static int? ReadNullableIntFromStringOrNumber(ref Utf8JsonReader reader)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+			if (reader.TokenType == JsonTokenType.Number)
+				return reader.GetInt32();
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var s = reader.GetString();
+				if (int.TryParse(s, out var val))
+					return val;
+				return null;
+			}
+			reader.Skip();
+			return null;
+		}
+
+		protected static object ReadValue(ref Utf8JsonReader reader)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.String:
+					return reader.GetString();
+				case JsonTokenType.Number:
+					if (reader.TryGetInt64(out var l))
+						return l;
+					return reader.GetDouble();
+				case JsonTokenType.True:
+					return true;
+				case JsonTokenType.False:
+					return false;
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.StartArray:
+				case JsonTokenType.StartObject:
+					// Read as JsonElement for complex types
+					using (var doc = JsonDocument.ParseValue(ref reader))
+						return doc.RootElement.Clone();
+				default:
+					reader.Skip();
+					return null;
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, TErrorCause value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			WriteErrorCauseProperties(writer, value, options);
+			WriteAdditionalProperties(writer, value, options);
+
+			writer.WriteEndObject();
+		}
+
+		protected virtual void WriteAdditionalProperties(Utf8JsonWriter writer, TErrorCause value, JsonSerializerOptions options)
+		{
+			if (value.AdditionalProperties != null)
+			{
+				foreach (var kvp in value.AdditionalProperties)
+				{
+					writer.WritePropertyName(kvp.Key);
+					JsonSerializer.Serialize(writer, kvp.Value, options);
+				}
+			}
+		}
+
+		protected static void WriteErrorCauseProperties(Utf8JsonWriter writer, TErrorCause value, JsonSerializerOptions options)
+		{
+			if (value.BytesLimit.HasValue)
+			{
+				writer.WriteNumber("bytes_limit", value.BytesLimit.Value);
+			}
+
+			if (value.BytesWanted.HasValue)
+			{
+				writer.WriteNumber("bytes_wanted", value.BytesWanted.Value);
+			}
+
+			if (value.CausedBy != null)
+			{
+				writer.WritePropertyName("caused_by");
+				JsonSerializer.Serialize(writer, value.CausedBy, options);
+			}
+
+			if (value.Column.HasValue)
+			{
+				writer.WriteNumber("col", value.Column.Value);
+			}
+
+			if (value.FailedShards != null && ((System.Collections.ICollection)value.FailedShards).Count > 0)
+			{
+				writer.WritePropertyName("failed_shards");
+				JsonSerializer.Serialize(writer, value.FailedShards, options);
+			}
+
+			if (value.Grouped.HasValue)
+			{
+				writer.WriteBoolean("grouped", value.Grouped.Value);
+			}
+
+			if (value.Index != null)
+			{
+				writer.WriteString("index", value.Index);
+			}
+
+			if (value.IndexUUID != null)
+			{
+				writer.WriteString("index_uuid", value.IndexUUID);
+			}
+
+			if (value.Language != null)
+			{
+				writer.WriteString("lang", value.Language);
+			}
+
+			if (value.Line.HasValue)
+			{
+				writer.WriteNumber("line", value.Line.Value);
+			}
+
+			if (value.Phase != null)
+			{
+				writer.WriteString("phase", value.Phase);
+			}
+
+			if (value.Reason != null)
+			{
+				writer.WriteString("reason", value.Reason);
+			}
+
+			if (value.ResourceId != null && ((System.Collections.ICollection)value.ResourceId).Count > 0)
+			{
+				writer.WritePropertyName("resource.id");
+				JsonSerializer.Serialize(writer, value.ResourceId, options);
+			}
+
+			if (value.ResourceType != null)
+			{
+				writer.WriteString("resource.type", value.ResourceType);
+			}
+
+			if (value.Script != null)
+			{
+				writer.WriteString("script", value.Script);
+			}
+
+			if (value.ScriptStack != null && ((System.Collections.ICollection)value.ScriptStack).Count > 0)
+			{
+				writer.WritePropertyName("script_stack");
+				JsonSerializer.Serialize(writer, value.ScriptStack, options);
+			}
+
+			if (value.Shard.HasValue)
+			{
+				writer.WriteNumber("shard", value.Shard.Value);
+			}
+
+			if (value.StackTrace != null)
+			{
+				writer.WriteString("stack_trace", value.StackTrace);
+			}
+
+			if (value.Type != null)
+			{
+				writer.WriteString("type", value.Type);
+			}
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/ErrorConverter.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/ErrorConverter.cs
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="Error"/> that handles the complex
+	/// deserialization logic from the OpenSearch error response format.
+	/// Extends the base ErrorCause converter with headers and root_cause fields.
+	/// </summary>
+	internal class ErrorConverter : ErrorCauseConverter<Error>
+	{
+		protected override bool DeserializeProperty(ref Utf8JsonReader reader, string propertyName, Error errorCause, JsonSerializerOptions options)
+		{
+			switch (propertyName)
+			{
+				case "headers":
+					errorCause.Headers = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options)
+						?? new Dictionary<string, string>();
+					return true;
+				case "root_cause":
+					errorCause.RootCause = JsonSerializer.Deserialize<List<ErrorCause>>(ref reader, options);
+					return true;
+				default:
+					return DeserializeErrorCauseProperty(ref reader, propertyName, errorCause, options);
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, Error value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartObject();
+
+			WriteErrorCauseProperties(writer, value, options);
+
+			if (value.Headers != null && value.Headers.Count > 0)
+			{
+				writer.WritePropertyName("headers");
+				JsonSerializer.Serialize(writer, value.Headers, options);
+			}
+
+			if (value.RootCause != null && ((System.Collections.ICollection)value.RootCause).Count > 0)
+			{
+				writer.WritePropertyName("root_cause");
+				JsonSerializer.Serialize(writer, value.RootCause, options);
+			}
+
+			WriteAdditionalProperties(writer, value, options);
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/ExceptionConverter.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/ExceptionConverter.cs
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="Exception"/> that provides safe serialization
+	/// of exception information. Replaces the Utf8Json-based <c>ExceptionFormatter</c>.
+	/// </summary>
+	/// <remarks>
+	/// Serialization writes a JSON array of exception objects (flattened from InnerException chain).
+	/// Each element contains type, message, and stackTrace properties.
+	/// Deserialization is not supported (returns null) as exceptions are rarely deserialized.
+	/// A maximum depth limit of 20 prevents infinite recursion from circular InnerException references.
+	/// </remarks>
+	internal class ExceptionConverter : JsonConverter<Exception>
+	{
+		private const int MaxInnerExceptionDepth = 20;
+
+		public override bool CanConvert(Type typeToConvert) =>
+			typeof(Exception).IsAssignableFrom(typeToConvert);
+
+		public override Exception Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			// Exceptions are rarely deserialized. Skip the JSON tokens and return null.
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			reader.Skip();
+			return null;
+		}
+
+		public override void Write(Utf8JsonWriter writer, Exception value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartArray();
+
+			var depth = 0;
+			var current = value;
+
+			while (current != null && depth < MaxInnerExceptionDepth)
+			{
+				writer.WriteStartObject();
+
+				writer.WriteNumber("Depth", depth);
+				writer.WriteString("ClassName", current.GetType().FullName);
+				writer.WriteString("Message", current.Message);
+				writer.WriteNull("Source");
+				writer.WriteNull("StackTraceString");
+				writer.WriteNull("RemoteStackTraceString");
+				writer.WriteNumber("RemoteStackIndex", 0);
+				writer.WriteNumber("HResult", current.HResult);
+				writer.WriteNull("HelpURL");
+
+				writer.WriteEndObject();
+
+				current = current.InnerException;
+				depth++;
+			}
+
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/FractionalNumberConverters.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/FractionalNumberConverters.cs
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// Serializes <see cref="double"/> so that integral values are written with a trailing
+	/// <c>.0</c> (e.g. <c>1.0</c> rather than <c>1</c>), matching the client's historical
+	/// (Utf8Json) behavior and disambiguating floating-point fields on the wire.
+	/// </summary>
+	internal sealed class DoubleConverter : JsonConverter<double>
+	{
+		public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var s = reader.GetString();
+				return double.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
+			}
+			return reader.GetDouble();
+		}
+
+		public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
+		{
+			if (!double.IsNaN(value) && !double.IsInfinity(value)
+				&& Math.Floor(value) == value && Math.Abs(value) < 1e16)
+			{
+				writer.WriteRawValue(
+					value.ToString("0.0", CultureInfo.InvariantCulture), skipInputValidation: true);
+				return;
+			}
+
+			writer.WriteNumberValue(value);
+		}
+	}
+
+	/// <summary>
+	/// Serializes <see cref="float"/> so that integral values are written with a trailing <c>.0</c>.
+	/// </summary>
+	internal sealed class SingleConverter : JsonConverter<float>
+	{
+		public override float Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var s = reader.GetString();
+				return float.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
+			}
+			return reader.GetSingle();
+		}
+
+		public override void Write(Utf8JsonWriter writer, float value, JsonSerializerOptions options)
+		{
+			if (!float.IsNaN(value) && !float.IsInfinity(value)
+				&& Math.Floor((double)value) == value && Math.Abs(value) < 1e7)
+			{
+				writer.WriteRawValue(
+					value.ToString("0.0", CultureInfo.InvariantCulture), skipInputValidation: true);
+				return;
+			}
+
+			writer.WriteNumberValue(value);
+		}
+	}
+
+	/// <summary>
+	/// Serializes <see cref="decimal"/> so that integral values are written with a trailing <c>.0</c>.
+	/// </summary>
+	internal sealed class DecimalConverter : JsonConverter<decimal>
+	{
+		public override decimal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var s = reader.GetString();
+				return decimal.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
+			}
+			return reader.GetDecimal();
+		}
+
+		public override void Write(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options)
+		{
+			if (decimal.Truncate(value) == value)
+			{
+				writer.WriteRawValue(
+					value.ToString("0.0", CultureInfo.InvariantCulture), skipInputValidation: true);
+				return;
+			}
+
+			writer.WriteNumberValue(value);
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/IsoDateTimeConverters.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/IsoDateTimeConverters.cs
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// Shared ISO-8601 date-string normalization so that the flexible offset and fractional-second
+	/// forms OpenSearch emits round-trip through System.Text.Json (whose built-in DateTime/DateTimeOffset
+	/// readers only accept a stricter subset). Replaces the Utf8Json ISO8601 date formatters.
+	/// </summary>
+	internal static class IsoDateTimeHelper
+	{
+		// Matches a trailing numeric time-zone offset in "basic" form that STJ does not accept:
+		//   +HH, -HH, +HHmm, -HHmm  (but NOT the already-extended +HH:mm).
+		private static readonly Regex BasicOffset =
+			new Regex(@"(?<sign>[+-])(?<hh>\d{2})(?<mm>\d{2})?$", RegexOptions.Compiled);
+
+		// Matches the fractional-seconds group so we can clamp it to the 7 digits DateTime.Parse allows.
+		private static readonly Regex FractionalSeconds =
+			new Regex(@"(?<=T\d{2}:\d{2}:\d{2})\.(?<frac>\d+)", RegexOptions.Compiled);
+
+		/// <summary>
+		/// Normalizes an OpenSearch ISO-8601 date string so <see cref="DateTime.Parse(string, IFormatProvider, DateTimeStyles)"/>
+		/// / <see cref="DateTimeOffset.Parse(string, IFormatProvider, DateTimeStyles)"/> can read it:
+		/// converts a trailing basic-format offset (<c>+1000</c>, <c>+10</c>) to extended form
+		/// (<c>+10:00</c>). Throws <see cref="FormatException"/> for malformed offsets (e.g. <c>+100</c>).
+		/// </summary>
+		public static string Normalize(string value)
+		{
+			if (string.IsNullOrEmpty(value))
+				return value;
+
+			// Only consider the portion after the time component so a date like 2020-07-31 is untouched.
+			var tIndex = value.IndexOf('T');
+			if (tIndex < 0)
+				return value;
+
+			// Clamp fractional seconds to 7 digits (the maximum DateTime/DateTimeOffset.Parse accepts).
+			// OpenSearch may emit more precision than the CLR's 100ns tick resolution can represent.
+			value = FractionalSeconds.Replace(value, m =>
+			{
+				var frac = m.Groups["frac"].Value;
+				return "." + (frac.Length > 7 ? frac.Substring(0, 7) : frac);
+			});
+
+			var timePart = value.Substring(tIndex);
+
+			// Already extended (has a ':' in an offset) or ends in Z → leave as-is.
+			if (timePart.EndsWith("Z", StringComparison.Ordinal))
+				return value;
+
+			// Detect a trailing offset. Guard against malformed lengths like +100 / -10000 which are
+			// neither +HH nor +HHmm; those must throw rather than silently mis-parse.
+			var lastSign = value.LastIndexOfAny(new[] { '+', '-' });
+			if (lastSign > tIndex) // a sign within the time part is an offset
+			{
+				var offset = value.Substring(lastSign); // e.g. "+100", "+1000", "+10"
+				var digits = offset.Length - 1;
+				if (digits != 2 && digits != 4 && !offset.Contains(":"))
+					throw new InvalidOperationException($"Unsupported time-zone offset '{offset}' in date '{value}'.");
+
+				var match = BasicOffset.Match(value);
+				if (match.Success)
+				{
+					var mm = match.Groups["mm"].Success ? match.Groups["mm"].Value : "00";
+					var normalizedOffset = $"{match.Groups["sign"].Value}{match.Groups["hh"].Value}:{mm}";
+					return value.Substring(0, match.Index) + normalizedOffset;
+				}
+			}
+
+			return value;
+		}
+	}
+
+	/// <summary>Reads/writes <see cref="DateTime"/> with OpenSearch-flexible ISO-8601 handling.</summary>
+	internal sealed class IsoDateTimeConverter : JsonConverter<DateTime>
+	{
+		public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var raw = reader.GetString();
+				var normalized = IsoDateTimeHelper.Normalize(raw);
+				return DateTime.Parse(normalized, CultureInfo.InvariantCulture,
+					DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces);
+			}
+
+			return reader.GetDateTime();
+		}
+
+		public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+		{
+			// Round-trip ("o") form, but drop an all-zero fractional-second component so a whole-second
+			// UTC value serializes as e.g. "2016-01-01T01:01:01Z" (matching the historical wire format).
+			var formatted = value.ToString("o", CultureInfo.InvariantCulture);
+			writer.WriteStringValue(StripZeroFractionalSeconds(formatted));
+		}
+
+		internal static string StripZeroFractionalSeconds(string roundTrip) =>
+			roundTrip.Replace(".0000000", string.Empty);
+	}
+
+	/// <summary>Reads/writes <see cref="DateTimeOffset"/> with OpenSearch-flexible ISO-8601 handling.</summary>
+	internal sealed class IsoDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+	{
+		public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var raw = reader.GetString();
+				var normalized = IsoDateTimeHelper.Normalize(raw);
+				return DateTimeOffset.Parse(normalized, CultureInfo.InvariantCulture,
+					DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces);
+			}
+
+			return reader.GetDateTimeOffset();
+		}
+
+		public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options) =>
+			writer.WriteStringValue(value.ToString("o", CultureInfo.InvariantCulture));
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/LenientBoolConverter.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/LenientBoolConverter.cs
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A lenient <see cref="JsonConverter{T}"/> for <see cref="bool"/> that accepts both
+	/// native JSON booleans (<c>true</c>/<c>false</c>) and their string representations
+	/// (<c>"true"</c>/<c>"false"</c>). OpenSearch may return boolean fields as strings
+	/// in certain responses (e.g. <c>"expand": "true"</c>).
+	/// </summary>
+	internal sealed class LenientBoolConverter : JsonConverter<bool>
+	{
+		public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.True:
+					return true;
+				case JsonTokenType.False:
+					return false;
+				case JsonTokenType.String:
+					var str = reader.GetString();
+					if (bool.TryParse(str, out var result))
+						return result;
+					throw new JsonException($"Cannot convert string \"{str}\" to Boolean.");
+				case JsonTokenType.Number:
+					// Some APIs return 0/1 for booleans
+					return reader.GetInt32() != 0;
+				default:
+					throw new JsonException($"Cannot convert token type {reader.TokenType} to Boolean.");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+		{
+			writer.WriteBooleanValue(value);
+		}
+	}
+
+	/// <summary>
+	/// A lenient <see cref="JsonConverter{T}"/> for <see cref="Nullable{Boolean}"/> that accepts
+	/// native JSON booleans, null, and string representations (<c>"true"</c>/<c>"false"</c>).
+	/// </summary>
+	internal sealed class NullableLenientBoolConverter : JsonConverter<bool?>
+	{
+		public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.True:
+					return true;
+				case JsonTokenType.False:
+					return false;
+				case JsonTokenType.String:
+					var str = reader.GetString();
+					if (string.IsNullOrEmpty(str))
+						return null;
+					if (bool.TryParse(str, out var result))
+						return result;
+					throw new JsonException($"Cannot convert string \"{str}\" to Boolean.");
+				case JsonTokenType.Number:
+					return reader.GetInt32() != 0;
+				default:
+					throw new JsonException($"Cannot convert token type {reader.TokenType} to Boolean.");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				writer.WriteBooleanValue(value.Value);
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/ObjectConverter.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/ObjectConverter.cs
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="object"/> that deserializes JSON values
+	/// into .NET primitive types (bool, long, double, string) instead of <see cref="JsonElement"/>.
+	/// This ensures that values stored in <c>IDictionary&lt;string, object&gt;</c> and similar
+	/// collections are compatible with <see cref="Convert"/> and <see cref="IConvertible"/>.
+	/// </summary>
+	internal class ObjectConverter : JsonConverter<object>
+	{
+		public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			return DynamicValueConverter.ReadValue(ref reader, options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+		{
+			DynamicValueConverter.WriteValue(writer, value, options);
+		}
+
+		/// <summary>
+		/// Supports <c>object</c>-keyed dictionaries (e.g. <c>IDictionary&lt;object, object&gt;</c>).
+		/// STJ has no built-in property-name converter for <see cref="object"/>, so a dictionary with
+		/// object keys would otherwise throw <see cref="NotSupportedException"/>. Writes the key's
+		/// verbatim string form (matching the legacy Utf8Json behavior for weakly-typed dictionary keys).
+		/// </summary>
+		public override void WriteAsPropertyName(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				throw new ArgumentNullException(nameof(value), "Dictionary key must not be null.");
+			writer.WritePropertyName(value.ToString());
+		}
+
+		/// <inheritdoc cref="WriteAsPropertyName" />
+		public override object ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+			reader.GetString();
+	}
+}

--- a/src/OpenSearch.Net/Serialization/Converters/TimeSpanTicksConverter.cs
+++ b/src/OpenSearch.Net/Serialization/Converters/TimeSpanTicksConverter.cs
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="TimeSpan"/> that serializes as ticks (a long number)
+	/// and can deserialize from either a number (ticks) or a string representation.
+	/// Replaces the Utf8Json-based <c>TimeSpanTicksFormatter</c> in OpenSearch.Client.
+	/// </summary>
+	internal class TimeSpanTicksConverter : JsonConverter<TimeSpan>
+	{
+		public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.Number:
+					return new TimeSpan(reader.GetInt64());
+				case JsonTokenType.String:
+					var str = reader.GetString();
+					if (long.TryParse(str, out var ticks))
+						return new TimeSpan(ticks);
+					return TimeSpan.Parse(str, System.Globalization.CultureInfo.InvariantCulture);
+				default:
+					throw new JsonException($"Cannot convert token of type {reader.TokenType} to {nameof(TimeSpan)}.");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options) =>
+			writer.WriteNumberValue(value.Ticks);
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for nullable <see cref="TimeSpan"/> that serializes as ticks (a long number).
+	/// Replaces the Utf8Json-based <c>NullableTimeSpanTicksFormatter</c> in OpenSearch.Client.
+	/// </summary>
+	internal class NullableTimeSpanTicksConverter : JsonConverter<TimeSpan?>
+	{
+		private static readonly TimeSpanTicksConverter InnerConverter = new TimeSpanTicksConverter();
+
+		public override TimeSpan? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			return InnerConverter.Read(ref reader, typeof(TimeSpan), options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, TimeSpan? value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteNumberValue(value.Value.Ticks);
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for <see cref="TimeSpan"/> that serializes as its string form
+	/// (e.g. <c>"10.10:38:32"</c>), and reads either a string or a ticks number.
+	/// </summary>
+	internal class TimeSpanStringConverter : JsonConverter<TimeSpan>
+	{
+		public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			switch (reader.TokenType)
+			{
+				case JsonTokenType.String:
+					var str = reader.GetString();
+					if (long.TryParse(str, out var ticks))
+						return new TimeSpan(ticks);
+					return TimeSpan.Parse(str, System.Globalization.CultureInfo.InvariantCulture);
+				case JsonTokenType.Number:
+					return new TimeSpan(reader.GetInt64());
+				default:
+					throw new JsonException($"Cannot convert token of type {reader.TokenType} to {nameof(TimeSpan)}.");
+			}
+		}
+
+		public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options) =>
+			writer.WriteStringValue(value.ToString());
+	}
+
+	/// <summary>
+	/// A <see cref="JsonConverter{T}"/> for nullable <see cref="TimeSpan"/> that serializes as its string form.
+	/// </summary>
+	internal class NullableTimeSpanStringConverter : JsonConverter<TimeSpan?>
+	{
+		private static readonly TimeSpanStringConverter InnerConverter = new TimeSpanStringConverter();
+
+		public override TimeSpan? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+				return null;
+
+			return InnerConverter.Read(ref reader, typeof(TimeSpan), options);
+		}
+
+		public override void Write(Utf8JsonWriter writer, TimeSpan? value, JsonSerializerOptions options)
+		{
+			if (value == null)
+				writer.WriteNullValue();
+			else
+				InnerConverter.Write(writer, value.Value, options);
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/DataMemberModifier.cs
+++ b/src/OpenSearch.Net/Serialization/DataMemberModifier.cs
@@ -1,0 +1,182 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="DefaultJsonTypeInfoResolver"/> modifier that reads
+	/// <see cref="DataMemberAttribute.Name"/> and applies it as the JSON property name,
+	/// and ensures properties with non-public (internal) setters can be deserialized.
+	/// This allows STJ to honor existing [DataMember(Name = "...")] attributes
+	/// without requiring [JsonPropertyName] on every property.
+	/// </summary>
+	internal static class DataMemberPropertyNameModifier
+	{
+		public static void Modify(JsonTypeInfo typeInfo)
+		{
+			if (typeInfo.Kind != JsonTypeInfoKind.Object)
+				return;
+
+			for (var i = typeInfo.Properties.Count - 1; i >= 0; i--)
+			{
+				var property = typeInfo.Properties[i];
+
+				var hasIgnore = property.AttributeProvider?
+					.GetCustomAttributes(typeof(IgnoreDataMemberAttribute), true)
+					.Any() == true;
+
+				if (hasIgnore)
+				{
+					typeInfo.Properties.RemoveAt(i);
+					continue;
+				}
+
+				var dataMemberAttr = property.AttributeProvider?
+					.GetCustomAttributes(typeof(DataMemberAttribute), true)
+					.OfType<DataMemberAttribute>()
+					.FirstOrDefault();
+
+				if (dataMemberAttr?.Name != null)
+				{
+					property.Name = dataMemberAttr.Name;
+				}
+				else if (property.AttributeProvider is PropertyInfo propInfo)
+				{
+					var interfaceName = FindInterfaceDataMemberName(typeInfo.Type, propInfo);
+					if (interfaceName != null)
+						property.Name = interfaceName;
+				}
+
+				// Ensure properties with non-public setters (e.g. internal set) can be deserialized.
+				// STJ by default only writes to public setters; this enables internal/protected setters.
+				if (property.Set == null && property.AttributeProvider is MemberInfo memberInfo)
+				{
+					var propertyInfo = memberInfo as PropertyInfo
+						?? typeInfo.Type.GetProperty(memberInfo.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+					if (propertyInfo?.GetSetMethod(true) != null)
+					{
+						property.Set = (obj, value) => propertyInfo.SetValue(obj, value);
+					}
+				}
+			}
+
+			AddNonPublicDataMembers(typeInfo);
+		}
+
+		// STJ's DefaultJsonTypeInfoResolver surfaces only public properties, so a wholly non-public
+		// (e.g. internal) property carrying [DataMember] is dropped entirely — the pre-STJ Utf8Json resolver
+		// serialized these via AllowPrivate. Re-add any non-public instance property that carries
+		// [DataMember] (and is not [IgnoreDataMember]) which STJ omitted, so members such as
+		// ResponseBase.Error/StatusCode, GetTaskResponse.Response and CatNodesRecord's internal aliases
+		// (de)serialize. Walk the base-type chain with DeclaredOnly so inherited members on derived responses
+		// are also picked up.
+		private static void AddNonPublicDataMembers(JsonTypeInfo typeInfo)
+		{
+			var existingMembers = new System.Collections.Generic.HashSet<string>();
+			// Map each occupied JSON wire name to the property currently holding it, so a non-public
+			// [DataMember] can decide whether to yield (a real settable / [DataMember] property wins) or
+			// take over (a read-only computed alias property, which cannot be a deserialization target).
+			var existingByJsonName = new System.Collections.Generic.Dictionary<string, JsonPropertyInfo>(StringComparer.Ordinal);
+			foreach (var p in typeInfo.Properties)
+			{
+				if (p.AttributeProvider is MemberInfo mi)
+					existingMembers.Add(mi.Name);
+				existingByJsonName[p.Name] = p;
+			}
+
+			for (var t = typeInfo.Type; t != null && t != typeof(object); t = t.BaseType)
+			{
+				foreach (var pi in t.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+				{
+					if (!existingMembers.Add(pi.Name))
+						continue;
+
+					var dm = pi.GetCustomAttribute<DataMemberAttribute>();
+					if (dm == null || pi.GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+						continue;
+
+					var jsonName = dm.Name ?? System.Text.Json.JsonNamingPolicy.CamelCase.ConvertName(pi.Name);
+
+					if (existingByJsonName.TryGetValue(jsonName, out var occupant))
+					{
+						// A read-only computed alias property (no setter, no [DataMember] of its own — e.g.
+						// CatNodesRecord.Build => _b ?? _build) cannot deserialize; the internal [DataMember]
+						// backing member is the real wire target, so replace the occupant. Otherwise (a
+						// settable or [DataMember]-bearing property such as ClusterHealthResponse.Status) the
+						// existing property wins and we skip to avoid an STJ property-name collision.
+						var occupantIsReplaceableAlias = occupant.Set == null
+							&& occupant.AttributeProvider is MemberInfo om
+							&& om.GetCustomAttribute<DataMemberAttribute>() == null;
+
+						if (!occupantIsReplaceableAlias)
+							continue;
+
+						typeInfo.Properties.Remove(occupant);
+						existingByJsonName.Remove(jsonName);
+					}
+
+					var jsonProperty = typeInfo.CreateJsonPropertyInfo(pi.PropertyType, jsonName);
+
+					var getter = pi.GetGetMethod(true);
+					if (getter != null)
+						jsonProperty.Get = obj => getter.Invoke(obj, null);
+
+					var setter = pi.GetSetMethod(true);
+					if (setter != null)
+						jsonProperty.Set = (obj, value) => setter.Invoke(obj, new[] { value });
+
+					typeInfo.Properties.Add(jsonProperty);
+					existingByJsonName[jsonName] = jsonProperty;
+				}
+			}
+		}
+
+		private static string FindInterfaceDataMemberName(Type type, PropertyInfo property)
+		{
+			var getter = property.GetGetMethod(true);
+			if (getter == null) return null;
+
+			foreach (var iface in type.GetInterfaces())
+			{
+				if (iface.Namespace?.StartsWith("System") == true)
+					continue;
+
+				try
+				{
+					var map = type.GetInterfaceMap(iface);
+					for (var i = 0; i < map.TargetMethods.Length; i++)
+					{
+						if (map.TargetMethods[i] == getter)
+						{
+							var ifaceMethod = map.InterfaceMethods[i];
+							var ifaceProp = iface.GetProperties()
+								.FirstOrDefault(p => p.GetGetMethod() == ifaceMethod);
+
+							if (ifaceProp == null) break;
+
+							var attr = ifaceProp.GetCustomAttribute<DataMemberAttribute>();
+							if (attr?.Name != null)
+								return attr.Name;
+
+							break;
+						}
+					}
+				}
+				catch (ArgumentException) { }
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/DiagnosticsSerializerProxy.cs
+++ b/src/OpenSearch.Net/Serialization/DiagnosticsSerializerProxy.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net.Diagnostics;
@@ -66,18 +67,32 @@ namespace OpenSearch.Net
 	internal class DiagnosticsSerializerProxy : IOpenSearchSerializer, IInternalSerializer
 	{
 		private readonly IOpenSearchSerializer _serializer;
-		private readonly bool _wrapsUtf8JsonSerializer;
 		private readonly SerializerRegistrationInformation _state;
+		private readonly JsonSerializerOptions _jsonSerializerOptions;
+		private readonly bool _wrapsStjSerializer;
 		private readonly IJsonFormatterResolver _formatterResolver;
+		private readonly bool _wrapsUtf8JsonSerializer;
 		private static DiagnosticSource DiagnosticSource { get; } = new DiagnosticListener(DiagnosticSources.Serializer.SourceName);
 
 		public DiagnosticsSerializerProxy(IOpenSearchSerializer serializer, string purpose = "request/response")
 		{
 			_serializer = serializer;
 			_state = new SerializerRegistrationInformation(serializer.GetType(), purpose);
-			if (serializer is IInternalSerializer s && s.TryGetJsonFormatter(out var formatterResolver))
+
+			if (serializer is IInternalSerializer s2 && s2.TryGetJsonSerializerOptions(out var jsonOptions))
 			{
-				_formatterResolver = formatterResolver;
+				_jsonSerializerOptions = jsonOptions;
+				_wrapsStjSerializer = true;
+			}
+			else
+			{
+				_jsonSerializerOptions = null;
+				_wrapsStjSerializer = false;
+			}
+
+			if (serializer is IInternalSerializer s3 && s3.TryGetJsonFormatter(out var resolver))
+			{
+				_formatterResolver = resolver;
 				_wrapsUtf8JsonSerializer = true;
 			}
 			else
@@ -85,6 +100,12 @@ namespace OpenSearch.Net
 				_formatterResolver = null;
 				_wrapsUtf8JsonSerializer = false;
 			}
+		}
+
+		public bool TryGetJsonSerializerOptions(out JsonSerializerOptions options)
+		{
+			options = _jsonSerializerOptions;
+			return _wrapsStjSerializer;
 		}
 
 		public bool TryGetJsonFormatter(out IJsonFormatterResolver formatterResolver)

--- a/src/OpenSearch.Net/Serialization/IInternalSerializerWithFormatter.cs
+++ b/src/OpenSearch.Net/Serialization/IInternalSerializerWithFormatter.cs
@@ -26,13 +26,25 @@
 *  under the License.
 */
 
+using System.Text.Json;
 using OpenSearch.Net.Utf8Json;
 
 namespace OpenSearch.Net
 {
 	internal interface IInternalSerializer
 	{
+		/// <summary>
+		/// Exposes the Utf8Json formatter resolver backing this serializer. Returns <c>false</c> when the
+		/// serializer is running on the System.Text.Json engine (in which case <see cref="TryGetJsonSerializerOptions"/>
+		/// yields the options instead).
+		/// </summary>
 		bool TryGetJsonFormatter(out IJsonFormatterResolver formatterResolver);
+
+		/// <summary>
+		/// Exposes the System.Text.Json options backing this serializer. Returns <c>false</c> when the
+		/// serializer is running on the legacy Utf8Json engine.
+		/// </summary>
+		bool TryGetJsonSerializerOptions(out JsonSerializerOptions options);
 	}
 
 }

--- a/src/OpenSearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
+++ b/src/OpenSearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
@@ -31,6 +31,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenSearch.Net.Utf8Json;
+using JsonSerializerOptions = System.Text.Json.JsonSerializerOptions;
 
 namespace OpenSearch.Net
 {
@@ -62,6 +63,12 @@ namespace OpenSearch.Net
 		{
 			formatterResolver = OpenSearchNetFormatterResolver.Instance;
 			return true;
+		}
+
+		bool IInternalSerializer.TryGetJsonSerializerOptions(out JsonSerializerOptions options)
+		{
+			options = null;
+			return false;
 		}
 	}
 }

--- a/src/OpenSearch.Net/Serialization/MinimalJsonEscapingEncoder.cs
+++ b/src/OpenSearch.Net/Serialization/MinimalJsonEscapingEncoder.cs
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Text.Encodings.Web;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// A <see cref="JavaScriptEncoder"/> that escapes only the characters that are strictly required
+	/// by the JSON specification, matching the historical Utf8Json wire behavior (and Newtonsoft.Json's
+	/// default): the C0 control characters (U+0000–U+001F), the quotation mark (<c>"</c>) and reverse
+	/// solidus (<c>\</c>), plus the three characters that are valid in JSON strings but are line
+	/// terminators in ECMAScript (U+0085 NEL, U+2028 LINE SEPARATOR, U+2029 PARAGRAPH SEPARATOR).
+	/// </summary>
+	/// <remarks>
+	/// System.Text.Json's built-in encoders (including <see cref="JavaScriptEncoder.UnsafeRelaxedJsonEscaping"/>)
+	/// additionally escape U+007F and every code point outside their allow-listed Unicode ranges (e.g.
+	/// unassigned code points). That produces a much larger set of <c>\uXXXX</c> escapes than the client
+	/// historically emitted, which is both wasteful and diverges from the previous wire format. This encoder
+	/// leaves all other code points (including non-ASCII and unassigned) as literal UTF-8, exactly like
+	/// Utf8Json did (the only difference being lowercase hex digits, which is irrelevant since JSON escape
+	/// sequences are case-insensitive).
+	/// </remarks>
+	internal sealed class MinimalJsonEscapingEncoder : JavaScriptEncoder
+	{
+		public static readonly MinimalJsonEscapingEncoder Shared = new();
+
+		// A backslash escape is at most 6 chars (\uXXXX).
+		public override int MaxOutputCharactersPerInputCharacter => 6;
+
+		public override bool WillEncode(int unicodeScalar) =>
+			unicodeScalar < 0x20
+			|| unicodeScalar == '"'
+			|| unicodeScalar == '\\'
+			|| unicodeScalar == 0x85
+			|| unicodeScalar == 0x2028
+			|| unicodeScalar == 0x2029;
+
+		public override unsafe int FindFirstCharacterToEncode(char* text, int textLength)
+		{
+			for (var i = 0; i < textLength; i++)
+			{
+				if (WillEncode(text[i]))
+					return i;
+			}
+			return -1;
+		}
+
+		public override unsafe bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
+		{
+			string escaped;
+			switch (unicodeScalar)
+			{
+				case '"': escaped = "\\\""; break;
+				case '\\': escaped = "\\\\"; break;
+				case 0x08: escaped = "\\b"; break;
+				case 0x09: escaped = "\\t"; break;
+				case 0x0A: escaped = "\\n"; break;
+				case 0x0C: escaped = "\\f"; break;
+				case 0x0D: escaped = "\\r"; break;
+				default: escaped = "\\u" + unicodeScalar.ToString("x4"); break;
+			}
+
+			if (escaped.Length > bufferLength)
+			{
+				numberOfCharactersWritten = 0;
+				return false;
+			}
+
+			for (var i = 0; i < escaped.Length; i++)
+				buffer[i] = escaped[i];
+
+			numberOfCharactersWritten = escaped.Length;
+			return true;
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/OpenSearchNetSerializerOptions.cs
+++ b/src/OpenSearch.Net/Serialization/OpenSearchNetSerializerOptions.cs
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace OpenSearch.Net
+{
+	/// <summary>
+	/// Provides pre-configured <see cref="JsonSerializerOptions"/> instances for the low-level
+	/// OpenSearch.Net serializer. Replaces the Utf8Json-based <c>OpenSearchNetFormatterResolver</c>.
+	/// </summary>
+	internal static class OpenSearchNetSerializerOptions
+	{
+		/// <summary>
+		/// The default <see cref="JsonSerializerOptions"/> instance used for compact (non-indented) serialization.
+		/// This instance is reused across all serialization calls for performance.
+		/// </summary>
+		public static JsonSerializerOptions Instance { get; } = Create(writeIndented: false);
+
+		/// <summary>
+		/// A <see cref="JsonSerializerOptions"/> instance configured with <c>WriteIndented = true</c>,
+		/// used when <see cref="SerializationFormatting.Indented"/> is requested.
+		/// </summary>
+		public static JsonSerializerOptions Indented { get; } = Create(writeIndented: true);
+
+		private static JsonSerializerOptions Create(bool writeIndented)
+		{
+			var options = new JsonSerializerOptions
+			{
+				PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+				DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+				NumberHandling = JsonNumberHandling.AllowReadingFromString,
+				PropertyNameCaseInsensitive = true,
+				Encoder = MinimalJsonEscapingEncoder.Shared,
+				WriteIndented = writeIndented,
+				TypeInfoResolver = new DefaultJsonTypeInfoResolver
+				{
+					Modifiers = { DataMemberPropertyNameModifier.Modify }
+				}
+			};
+
+			// Converters registered in precedence order (first match wins).
+			// Lenient bool converters: accept string "true"/"false" in addition to native
+			// JSON booleans. OpenSearch may return boolean fields as strings in some responses.
+			options.Converters.Add(new LenientBoolConverter());
+			options.Converters.Add(new NullableLenientBoolConverter());
+			// Fractional number converters: emit integral doubles/floats/decimals with a
+			// trailing ".0" (e.g. 1.0 not 1), matching the client's historical wire format.
+			options.Converters.Add(new DoubleConverter());
+			options.Converters.Add(new SingleConverter());
+			options.Converters.Add(new DecimalConverter());
+			// ISO-8601 date converters: accept OpenSearch's flexible offset (+1000/+10) and
+			// variable fractional-second forms that STJ's built-in readers reject.
+			options.Converters.Add(new IsoDateTimeConverter());
+			options.Converters.Add(new IsoDateTimeOffsetConverter());
+			// TimeSpan serialized as ticks (a long), matching the client's historical wire format.
+			options.Converters.Add(new TimeSpanTicksConverter());
+			options.Converters.Add(new NullableTimeSpanTicksConverter());
+			options.Converters.Add(new ErrorConverter());
+			options.Converters.Add(new ErrorCauseConverter());
+			options.Converters.Add(new DynamicDictionaryConverter());
+			options.Converters.Add(new DynamicValueConverter());
+			options.Converters.Add(new ObjectConverter());
+			options.Converters.Add(new EnumMemberConverterFactory());
+			options.Converters.Add(new ExceptionConverter());
+
+			return options;
+		}
+	}
+}

--- a/src/OpenSearch.Net/Serialization/StringEnumAttribute.cs
+++ b/src/OpenSearch.Net/Serialization/StringEnumAttribute.cs
@@ -27,9 +27,32 @@
 */
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace OpenSearch.Net
 {
+	/// <summary>
+	/// Marks an enum (or a property) as serializing to its <see cref="System.Runtime.Serialization.EnumMemberAttribute"/>
+	/// string form. By inheriting <see cref="JsonConverterAttribute"/>, the enum-member converter is attached via
+	/// the System.Text.Json attribute/contract channel, so it is honored in every nesting context — including
+	/// collection elements and union members — where an options-registered converter factory would be skipped.
+	/// </summary>
 	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Enum)]
-	public class StringEnumAttribute : Attribute { }
+	public class StringEnumAttribute : JsonConverterAttribute
+	{
+		private static readonly EnumMemberConverterFactory Factory = new EnumMemberConverterFactory(useVerbatimName: true);
+
+		public override JsonConverter CreateConverter(Type typeToConvert)
+		{
+			// The attribute's presence is the explicit opt-in to string-enum serialization, so build
+			// the converter for ANY enum (or nullable enum) type — even framework enums like
+			// HttpStatusCode that the factory's type-level CanConvert heuristic would not claim on
+			// its own. Returning null here would make STJ throw "converter not compatible".
+			var underlying = Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert;
+			return underlying.IsEnum
+				? Factory.CreateConverter(typeToConvert, JsonSerializerOptions.Default)
+				: null;
+		}
+	}
 }

--- a/tests/Tests.Reproduce/GitHubIssue4573.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4573.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Text;
+using System.Text.RegularExpressions;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using OpenSearch.Client;
@@ -56,7 +57,9 @@ namespace Tests.Reproduce
 			var response = action();
 
 			var json = Encoding.UTF8.GetString(response.ApiCall.RequestBodyInBytes);
-			json.Should().Contain("\"percentage\":{}");
+			// TestClient.DefaultInMemoryClient enables PrettyJson, so allow whitespace between the
+			// property name and value regardless of which serialization engine is active.
+			Regex.IsMatch(json, "\"percentage\"\\s*:\\s*{\\s*}").Should().BeTrue();
 		}
 	}
 }

--- a/tests/Tests.Reproduce/GithubIssue4228.cs
+++ b/tests/Tests.Reproduce/GithubIssue4228.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Text;
+using System.Text.Json;
 using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Tests.Core.Client;
@@ -49,8 +50,12 @@ namespace Tests.Reproduce
 				)
 			);
 
-			Encoding.UTF8.GetString(searchResponse.ApiCall.RequestBodyInBytes)
-				.Should().Be("{\"query\":{\"range\":{\"date\":{\"gte\":\"0001-01-01T00:00:00\"}}}}");
+			// TestClient.DefaultInMemoryClient enables PrettyJson, so compare parsed structure rather
+			// than the exact (indented) byte layout, which differs by serialization engine.
+			var json = Encoding.UTF8.GetString(searchResponse.ApiCall.RequestBodyInBytes);
+			using var actual = JsonDocument.Parse(json);
+			using var expected = JsonDocument.Parse("{\"query\":{\"range\":{\"date\":{\"gte\":\"0001-01-01T00:00:00\"}}}}");
+			JsonSerializer.Serialize(actual.RootElement).Should().Be(JsonSerializer.Serialize(expected.RootElement));
 		}
 	}
 }

--- a/tests/Tests/CodeStandards/NamingConventions.doc.cs
+++ b/tests/Tests/CodeStandards/NamingConventions.doc.cs
@@ -196,7 +196,9 @@ namespace Tests.CodeStandards
 				oscAssembly.GetType("System.ComponentModel.Browsable", throwOnError: false),
 				oscAssembly.GetType("Microsoft.CodeAnalysis.EmbeddedAttribute", throwOnError: false),
 				oscAssembly.GetType("System.Runtime.CompilerServices.IsReadOnlyAttribute", throwOnError: false),
-                oscAssembly.GetType("System.Runtime.CompilerServices.RefSafetyRulesAttribute", throwOnError: false)
+                oscAssembly.GetType("System.Runtime.CompilerServices.RefSafetyRulesAttribute", throwOnError: false),
+                oscAssembly.GetType("System.Runtime.CompilerServices.NullableAttribute", throwOnError: false),
+                oscAssembly.GetType("System.Runtime.CompilerServices.NullableContextAttribute", throwOnError: false)
 			};
 
 			var types = oscAssembly.GetTypes();

--- a/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardAttributeTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+using OpenSearch.Client;
+
+namespace Tests.Mapping.Types.Specialized.Wildcard;
+
+public class WildcardTest
+{
+    [Wildcard(NullValue = "NULL", Normalizer = "my_normalizer")]
+    public string Full { get; set; }
+
+    [Wildcard]
+    public string Minimal { get; set; }
+}
+
+public class WildcardAttributeTests : AttributeTestsBase<WildcardTest>
+{
+    protected override object ExpectJson => new
+    {
+        properties = new
+        {
+            full = new
+            {
+                type = "wildcard",
+                null_value = "NULL",
+                normalizer = "my_normalizer",
+            },
+            minimal = new
+            {
+                type = "wildcard"
+            }
+        }
+    };
+}

--- a/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardPropertyTests.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+using System;
+using OpenSearch.Client;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
+using Tests.Core.ManagedOpenSearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Specialized.Wildcard;
+
+[SkipVersion("<2.15.0", "Wildcard field type was added in OpenSearch 2.15.0")]
+public class WildcardPropertyTests : PropertyTestsBase
+{
+    public WildcardPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+    protected override object ExpectJson => new
+    {
+        properties = new
+        {
+            name = new
+            {
+                type = "wildcard",
+                null_value = "NULL",
+                normalizer = "my_normalizer",
+                doc_values = true,
+            }
+        }
+    };
+
+    protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+        .Wildcard(s => s
+            .Name(p => p.Name)
+            .NullValue("NULL")
+            .Normalizer("my_normalizer")
+            .DocValues()
+        );
+
+    protected override IProperties InitializerProperties => new Properties
+    {
+        {
+            "name", new WildcardProperty
+            {
+                NullValue = "NULL",
+                Normalizer = "my_normalizer",
+                DocValues = true,
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Description

Adds support for the [wildcard field type](https://opensearch.org/docs/latest/field-types/supported-field-types/wildcard/) introduced in OpenSearch 2.15.0.

Resolves #802

## Changes

- `FieldType.Wildcard` enum value (`"wildcard"`)
- `IWildcardProperty` / `WildcardProperty` / `WildcardPropertyDescriptor<T>` with `NullValue` and `Normalizer` properties (per the [API spec](https://github.com/opensearch-project/opensearch-api-specification/blob/main/spec/schemas/_common.mapping.yaml))
- `[Wildcard]` attribute for use on C# model properties
- `PropertyFormatter` deserialization and serialization cases
- `SingleMappingSelector` implementation for dynamic template support
- `PropertiesDescriptor.Wildcard()` fluent method

## Tests

- `WildcardAttributeTests` — unit tests for attribute-based mapping serialization
- `WildcardPropertyTests` — integration tests (fluent + initializer), skipped on `<2.15.0`

## Example

```csharp
// Fluent
client.Indices.Create("my-index", c => c
    .Map<MyDoc>(m => m
        .Properties(p => p
            .Wildcard(w => w
                .Name(d => d.Tags)
                .NullValue("N/A")
            )
        )
    )
);

// Initializer
new CreateIndexRequest("my-index")
{
    Mappings = new TypeMapping
    {
        Properties = new Properties
        {
            { "tags", new WildcardProperty { NullValue = "N/A" } }
        }
    }
};

// Attribute
public class MyDoc
{
    [Wildcard(NullValue = "N/A")]
    public string Tags { get; set; }
}
```