### PR TITLE
Add support for wildcard field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### ⚠️ Breaking Changes ⚠️
 ### Changed
 ### Added
+- Added support for `wildcard` field type ([#1004](https://github.com/opensearch-project/opensearch-net/pull/1004))
 ### Removed
 ### Fixed
 ### Dependencies

--- a/src/OpenSearch.Client/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/OpenSearch.Client/Mapping/DynamicTemplate/SingleMapping.cs
@@ -153,6 +153,10 @@ namespace OpenSearch.Client
 		public IProperty KnnVector(Func<KnnVectorPropertyDescriptor<T>, IKnnVectorProperty> selector) =>
 			selector?.Invoke(new KnnVectorPropertyDescriptor<T>());
 
+		/// <inheritdoc />
+		public IProperty Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector) =>
+			selector?.Invoke(new WildcardPropertyDescriptor<T>());
+
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public IProperty Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector = null) =>
 			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));

--- a/src/OpenSearch.Client/Mapping/Types/FieldType.cs
+++ b/src/OpenSearch.Client/Mapping/Types/FieldType.cs
@@ -162,6 +162,12 @@ namespace OpenSearch.Client
 		RankFeatures,
 
 		[EnumMember(Value = "knn_vector")]
-		KnnVector
+		KnnVector,
+
+		/// <summary>
+		/// A wildcard field stores values optimised for wildcard grep-like queries.
+		/// </summary>
+		[EnumMember(Value = "wildcard")]
+		Wildcard
 	}
 }

--- a/src/OpenSearch.Client/Mapping/Types/Properties.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Properties.cs
@@ -160,6 +160,9 @@ namespace OpenSearch.Client
 
 		/// <inheritdoc cref="IKnnVectorProperty" />
 		TReturnType KnnVector(Func<KnnVectorPropertyDescriptor<T>, IKnnVectorProperty> selector);
+
+		/// <inheritdoc cref="IWildcardProperty"/>
+		TReturnType Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector);
 	}
 
 	public partial class PropertiesDescriptor<T> where T : class
@@ -257,6 +260,9 @@ namespace OpenSearch.Client
 
 		/// <inheritdoc cref="IKnnVectorProperty" />
 		public PropertiesDescriptor<T> KnnVector(Func<KnnVectorPropertyDescriptor<T>, IKnnVectorProperty> selector) => SetProperty(selector);
+
+		/// <inheritdoc cref="IWildcardProperty"/>
+		public PropertiesDescriptor<T> Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector) => SetProperty(selector);
 
 		/// <summary>
 		/// Map a custom property.

--- a/src/OpenSearch.Client/Mapping/Types/PropertyFormatter.cs
+++ b/src/OpenSearch.Client/Mapping/Types/PropertyFormatter.cs
@@ -119,6 +119,7 @@ namespace OpenSearch.Client
 				case FieldType.RankFeature: return Deserialize<RankFeatureProperty>(ref segmentReader, formatterResolver);
 				case FieldType.RankFeatures: return Deserialize<RankFeaturesProperty>(ref segmentReader, formatterResolver);
 				case FieldType.KnnVector: return Deserialize<KnnVectorProperty>(ref segmentReader, formatterResolver);
+				case FieldType.Wildcard: return Deserialize<WildcardProperty>(ref segmentReader, formatterResolver);
 				case FieldType.None:
 					// no "type" field in the property mapping, or FieldType enum could not be parsed from typeString
 					return Deserialize<ObjectProperty>(ref segmentReader, formatterResolver);
@@ -220,6 +221,9 @@ namespace OpenSearch.Client
 					break;
 				case IKnnVectorProperty knnVectorProperty:
 					Serialize(ref writer, knnVectorProperty, formatterResolver);
+					break;
+				case IWildcardProperty wildcardProperty:
+					Serialize(ref writer, wildcardProperty, formatterResolver);
 					break;
 				case IGenericProperty genericProperty:
 					Serialize(ref writer, genericProperty, formatterResolver);

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardAttribute.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+namespace OpenSearch.Client
+{
+	public class WildcardAttribute : OpenSearchDocValuesPropertyAttributeBase, IWildcardProperty
+	{
+		public WildcardAttribute() : base(FieldType.Wildcard) { }
+
+		public string NullValue
+		{
+			get => Self.NullValue;
+			set => Self.NullValue = value;
+		}
+
+		public string Normalizer
+		{
+			get => Self.Normalizer;
+			set => Self.Normalizer = value;
+		}
+
+		string IWildcardProperty.NullValue { get; set; }
+		string IWildcardProperty.Normalizer { get; set; }
+		private IWildcardProperty Self => this;
+	}
+}

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardAttribute.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardAttribute.cs
@@ -1,8 +1,9 @@
-// SPDX-License-Identifier: Apache-2.0
-//
-// The OpenSearch Contributors require contributions made to
-// this file be licensed under the Apache-2.0 license or a
-// compatible open source license.
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
 
 namespace OpenSearch.Client
 {

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardProperty.cs
@@ -1,8 +1,9 @@
-// SPDX-License-Identifier: Apache-2.0
-//
-// The OpenSearch Contributors require contributions made to
-// this file be licensed under the Apache-2.0 license or a
-// compatible open source license.
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
 
 using System.Diagnostics;
 using System.Runtime.Serialization;

--- a/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardProperty.cs
+++ b/src/OpenSearch.Client/Mapping/Types/Specialized/Wildcard/WildcardProperty.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using OpenSearch.Net.Utf8Json;
+
+namespace OpenSearch.Client
+{
+	/// <summary>
+	/// A wildcard field stores values optimised for wildcard grep-like queries.
+	/// </summary>
+	[InterfaceDataContract]
+	[ReadAs(typeof(WildcardProperty))]
+	public interface IWildcardProperty : IDocValuesProperty
+	{
+		/// <summary>
+		/// Accepts a string value which is substituted for any explicit null values.
+		/// </summary>
+		[DataMember(Name = "null_value")]
+		string NullValue { get; set; }
+
+		/// <summary>
+		/// The name of the normalizer to use for normalizing the wildcard value.
+		/// </summary>
+		[DataMember(Name = "normalizer")]
+		string Normalizer { get; set; }
+	}
+
+	/// <inheritdoc cref="IWildcardProperty"/>
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class WildcardProperty : DocValuesPropertyBase, IWildcardProperty
+	{
+		public WildcardProperty() : base(FieldType.Wildcard) { }
+
+		/// <inheritdoc />
+		public string NullValue { get; set; }
+
+		/// <inheritdoc />
+		public string Normalizer { get; set; }
+	}
+
+	/// <inheritdoc cref="IWildcardProperty"/>
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class WildcardPropertyDescriptor<T>
+		: DocValuesPropertyDescriptorBase<WildcardPropertyDescriptor<T>, IWildcardProperty, T>, IWildcardProperty
+		where T : class
+	{
+		public WildcardPropertyDescriptor() : base(FieldType.Wildcard) { }
+
+		string IWildcardProperty.NullValue { get; set; }
+		string IWildcardProperty.Normalizer { get; set; }
+
+		/// <inheritdoc cref="IWildcardProperty.NullValue"/>
+		public WildcardPropertyDescriptor<T> NullValue(string nullValue) =>
+			Assign(nullValue, (a, v) => a.NullValue = v);
+
+		/// <inheritdoc cref="IWildcardProperty.Normalizer"/>
+		public WildcardPropertyDescriptor<T> Normalizer(string normalizer) =>
+			Assign(normalizer, (a, v) => a.Normalizer = v);
+	}
+}

--- a/src/OpenSearch.Client/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/OpenSearch.Client/Mapping/Visitor/IPropertyVisitor.cs
@@ -90,6 +90,8 @@ namespace OpenSearch.Client
 
 		void Visit(IKnnVectorProperty type, PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute);
 
+		void Visit(IWildcardProperty type, PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute);
+
 		IProperty Visit(PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute);
 
 		bool SkipProperty(PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute);

--- a/src/OpenSearch.Client/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/OpenSearch.Client/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -91,6 +91,8 @@ namespace OpenSearch.Client
 
 		public virtual void Visit(IKnnVectorProperty type, PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute) { }
 
+		public virtual void Visit(IWildcardProperty type, PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute) { }
+
 		public virtual IProperty Visit(PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute) => null;
 
 		public void Visit(IProperty type, PropertyInfo propertyInfo, OpenSearchPropertyAttributeBase attribute)
@@ -180,6 +182,9 @@ namespace OpenSearch.Client
 					break;
 				case IKnnVectorProperty knnVector:
 					Visit(knnVector, propertyInfo, attribute);
+					break;
+				case IWildcardProperty wildcard:
+					Visit(wildcard, propertyInfo, attribute);
 					break;
 			}
 		}

--- a/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardAttributeTests.cs
@@ -1,8 +1,9 @@
-// SPDX-License-Identifier: Apache-2.0
-//
-// The OpenSearch Contributors require contributions made to
-// this file be licensed under the Apache-2.0 license or a
-// compatible open source license.
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
 
 using OpenSearch.Client;
 

--- a/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardAttributeTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+using OpenSearch.Client;
+
+namespace Tests.Mapping.Types.Specialized.Wildcard;
+
+public class WildcardTest
+{
+    [Wildcard(NullValue = "NULL", Normalizer = "my_normalizer")]
+    public string Full { get; set; }
+
+    [Wildcard]
+    public string Minimal { get; set; }
+}
+
+public class WildcardAttributeTests : AttributeTestsBase<WildcardTest>
+{
+    protected override object ExpectJson => new
+    {
+        properties = new
+        {
+            full = new
+            {
+                type = "wildcard",
+                null_value = "NULL",
+                normalizer = "my_normalizer",
+            },
+            minimal = new
+            {
+                type = "wildcard"
+            }
+        }
+    };
+}

--- a/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardPropertyTests.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+using System;
+using OpenSearch.Client;
+using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
+using Tests.Core.ManagedOpenSearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Specialized.Wildcard;
+
+[SkipVersion("<2.15.0", "Wildcard field type was added in OpenSearch 2.15.0")]
+public class WildcardPropertyTests : PropertyTestsBase
+{
+    public WildcardPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+    protected override object ExpectJson => new
+    {
+        properties = new
+        {
+            name = new
+            {
+                type = "wildcard",
+                null_value = "NULL",
+                normalizer = "my_normalizer",
+                doc_values = true,
+            }
+        }
+    };
+
+    protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+        .Wildcard(s => s
+            .Name(p => p.Name)
+            .NullValue("NULL")
+            .Normalizer("my_normalizer")
+            .DocValues()
+        );
+
+    protected override IProperties InitializerProperties => new Properties
+    {
+        {
+            "name", new WildcardProperty
+            {
+                NullValue = "NULL",
+                Normalizer = "my_normalizer",
+                DocValues = true,
+            }
+        }
+    };
+}

--- a/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Wildcard/WildcardPropertyTests.cs
@@ -1,8 +1,9 @@
-// SPDX-License-Identifier: Apache-2.0
-//
-// The OpenSearch Contributors require contributions made to
-// this file be licensed under the Apache-2.0 license or a
-// compatible open source license.
+/* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
 
 using System;
 using OpenSearch.Client;


### PR DESCRIPTION
## Description

Adds support for the [wildcard field type](https://opensearch.org/docs/latest/field-types/supported-field-types/wildcard/) introduced in OpenSearch 2.15.0.

Resolves #802

## Changes

- `FieldType.Wildcard` enum value (`"wildcard"`)
- `IWildcardProperty` / `WildcardProperty` / `WildcardPropertyDescriptor<T>` with `NullValue` and `Normalizer` properties (per the [API spec](https://github.com/opensearch-project/opensearch-api-specification/blob/main/spec/schemas/_common.mapping.yaml))
- `[Wildcard]` attribute for use on C# model properties
- `PropertyFormatter` deserialization and serialization cases
- `SingleMappingSelector` implementation for dynamic template support
- `PropertiesDescriptor.Wildcard()` fluent method

## Tests

- `WildcardAttributeTests` — unit tests for attribute-based mapping serialization
- `WildcardPropertyTests` — integration tests (fluent + initializer), skipped on `<2.15.0`

## Example

```csharp
// Fluent
client.Indices.Create("my-index", c => c
    .Map<MyDoc>(m => m
        .Properties(p => p
            .Wildcard(w => w
                .Name(d => d.Tags)
                .NullValue("N/A")
            )
        )
    )
);

// Initializer
new CreateIndexRequest("my-index")
{
    Mappings = new TypeMapping
    {
        Properties = new Properties
        {
            { "tags", new WildcardProperty { NullValue = "N/A" } }
        }
    }
};

// Attribute
public class MyDoc
{
    [Wildcard(NullValue = "N/A")]
    public string Tags { get; set; }
}
```