### PR TITLE
test: fix flaky MovingAverageHoltWintersUsageTests negative forecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fixed `MaxTimeoutReached`, `MaxRetriesReached`, and `FailedOverAllNodes` audit events having `Ended` stuck at `default(DateTime)` due to undisposed `Auditable` instances in `RequestPipeline.CreateClientException` ([#998](https://github.com/opensearch-project/opensearch-net/issues/998))
+- Fixed flaky `MovingAverageHoltWintersUsageTests` integration test which asserted moving-average values are non-negative; Holt-Winters forecasts can legitimately be negative, so the assertion now only checks the values deserialize to finite numbers ([#1000](https://github.com/opensearch-project/opensearch-net/issues/1000))
 ### Dependencies
 
 ## [2.0.0]

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs
@@ -157,8 +157,8 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 			}
 
 			// Verify the moving-average values that ARE present (from the 5th bucket onwards) deserialize
-			// as valid non-negative numbers; a window of empty months can legitimately be 0 or absent, so
-			// we don't require a value in every bucket, which made this test seed/date-dependent.
+			// as valid numbers; a window of empty months can legitimately be 0 or absent, so we don't
+			// require a value in every bucket, which made this test seed/date-dependent.
 			var movingAverages = projectsPerMonth.Buckets
 				.Skip(4)
 				.Select(b => b.MovingAverage("commits_moving_avg"))
@@ -167,11 +167,20 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 				.ToList();
 
 			// Unlike the other pipeline tests this intentionally omits a NotBeEmpty() check: the
-			// multiplicative Holt-Winters model (Period = 2) can legitimately emit no values when the
-			// seeded date distribution leaves empty months in the seasonal window, so requiring at least
-			// one value would reintroduce the flakiness. Deserialization of the moving-average value type
-			// is still guarded by the EWMA and Holt-Linear tests, which do assert NotBeEmpty().
-			movingAverages.Should().OnlyContain(v => v >= 0);
+			// multiplicative Holt-Winters model (Period = 2) divides by the seasonal component, and
+			// min_doc_count:0 empty months produce zero-valued buckets. When a seasonal period is all
+			// zeros the divisor is 0, so OpenSearch emits null for that bucket rather than a number.
+			// A sparse seeded date distribution can therefore null out every post-window bucket, so
+			// requiring at least one value would reintroduce the flakiness. When values ARE present this
+			// test still guards their deserialization below; the EWMA and Holt-Linear tests additionally
+			// assert NotBeEmpty() to guarantee the moving-average value type is exercised every run.
+			//
+			// We also do NOT assert v >= 0: unlike the simple/linear/EWMA models (weighted averages of
+			// non-negative inputs), Holt-Winters *forecasts* by projecting level + trend + seasonal
+			// components forward. A declining trend over a sparse, seasonal window can legitimately yield
+			// a negative forecast even though every input bucket is non-negative, so a sign check is
+			// seed-dependent and flaky (see #1000). We only assert the values deserialized to finite numbers.
+			movingAverages.Should().OnlyContain(v => !double.IsNaN(v) && !double.IsInfinity(v));
 		}
 	}
 }


### PR DESCRIPTION
### Description

Fixes the flaky `Tests.Aggregations.Pipeline.MovingAverage.MovingAverageHoltWintersUsageTests` integration test.

#992 stabilized this test by relaxing the per-bucket assertion to `OnlyContain(v => v >= 0)`, on the assumption that a moving average of a non-negative series is always non-negative. That holds for the `simple`/`linear`/`ewma` models (weighted averages of observed values) but **not** for Holt-Winters, which *forecasts* by projecting level + trend + seasonal components forward. A declining trend over a sparse, seasonal window (`Period = 2`, `min_doc_count:0` empty months) can legitimately yield a **negative** forecast even when every input bucket is non-negative.

Because `Project.StartedOn` is randomly seeded, this only trips on some seeds/versions — a `-608.36` value was observed on the `2.12.0` integration job while all 13 other versions passed the identical test (see run [29941619855](https://github.com/opensearch-project/opensearch-net/actions/runs/29941619855)).

### Change

- Drop the `v >= 0` sign constraint; assert only that present moving-average values deserialize to finite numbers (`!IsNaN && !IsInfinity`), which was the test's real purpose.
- Correct the comment on the intentionally-omitted `NotBeEmpty()` check: the null buckets come from the multiplicative model dividing by a zero seasonal component (an all-empty seasonal period), not merely from empty months in the window.

Test-only; no client behavior change.

### Issues Resolved

Closes #1000

### Check List
- [x] New functionality includes testing. (test-only fix)
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Changelog updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.