### PR TITLE
test: disable k-NN derived source to fix flaky MultiGetParentApiTests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for `method_parameters`, `rescore`, and `expand_nested_docs` on `KnnQuery` ([#994](https://github.com/opensearch-project/opensearch-net/issues/994))
 ### Removed
 ### Fixed
+- Fixed flaky `MultiGetParentApiTests` integration test on 3.x by disabling k-NN derived source on the `project` test index, avoiding a server-side `AlreadyClosedException` race between segment merges and `_mget` ([#988](https://github.com/opensearch-project/opensearch-net/issues/988))
 - Fixed `MaxTimeoutReached`, `MaxRetriesReached`, and `FailedOverAllNodes` audit events having `Ended` stuck at `default(DateTime)` due to undisposed `Auditable` instances in `RequestPipeline.CreateClientException` ([#998](https://github.com/opensearch-project/opensearch-net/issues/998))
 - Fixed flaky `MovingAverageHoltWintersUsageTests` integration test which asserted moving-average values are non-negative; Holt-Winters forecasts can legitimately be negative, so the assertion now only checks the values deserialize to finite numbers ([#1000](https://github.com/opensearch-project/opensearch-net/issues/1000))
 - Fixed `DeleteByQueryResponse.IsValid` and `UpdateByQueryResponse.IsValid` returning `true` on transport-level failures (no HTTP response) by restoring the `ApiCall.Success` check that the overrides had dropped ([#997](https://github.com/opensearch-project/opensearch-net/issues/997))

--- a/tests/Tests.Core/ManagedOpenSearch/NodeSeeders/DefaultSeeder.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/NodeSeeders/DefaultSeeder.cs
@@ -235,11 +235,26 @@ public class DefaultSeeder
         return mapping;
     }
 
-    public static IndexSettingsDescriptor ProjectIndexSettings(IndexSettingsDescriptor settings) =>
+    public static IndexSettingsDescriptor ProjectIndexSettings(IndexSettingsDescriptor settings)
+    {
         settings
             .Analysis(ProjectAnalysisSettings)
             .Setting("index.knn", true)
             .Setting("index.knn.algo_param.ef_search", 100);
+
+        // On OpenSearch 3.x the k-NN plugin serves the vector field from "derived source"
+        // (the vector is reconstructed from the vector index on read instead of being stored
+        // in _source). Concurrently, segment merges can close the vector file a get/_mget is
+        // still reading, surfacing as an AlreadyClosedException -> no_shard_available and
+        // flaking MultiGetParentApiTests. Disable derived source so the vector is stored in
+        // _source and this server-side race is avoided. The setting only exists on k-NN >= 2.19
+        // (added alongside derived source), so guard it by major version to avoid rejecting
+        // index creation on older clusters. See opensearch-net issue #988.
+        if (TestConfiguration.Instance.OpenSearchVersion.Major >= 3)
+            settings.Setting("index.knn.derived_source.enabled", false);
+
+        return settings;
+    }
 
     public static IAnalysis ProjectAnalysisSettings(AnalysisDescriptor analysis)
     {


### PR DESCRIPTION
 ## Description
  
  Fixes the flaky test `Tests.Document.Multiple.MultiGet.MultiGetParentApiTests.ReturnsExpectedIsValid` (#988).
  
  ### What this bug is
  
  The `project` test index (created in `DefaultSeeder.ProjectIndexSettings`) maps a `knn_vector` field. On OpenSearch **3.x**, the k-NN plugin serves that field via **derived source**:
  instead of storing the vector in `_source`, it reconstructs the vector from the vector index at read time.
  
  So when `_mget` loads a document's stored fields, k-NN reaches into the HNSW vector file to rebuild the vector. Meanwhile a **segment merge** can close that vector file out from under the
  read, which then hits:

  org.apache.lucene.store.AlreadyClosedException: Already closed:
    MemorySegmentIndexInput(... _1.cfs) [slice=_1_Lucene99HnswVectorsFormat_0.vec]
      at org.opensearch.knn.index.codec.derivedsource.DerivedSourceStoredFieldVisitor.binaryField
      at org.opensearch.index.get.ShardGetService.innerGetLoadFromStoredFields
      at org.opensearch.action.get.TransportShardMultiGetAction.shardOperation

  That bubbles up as `no_shard_available_action_exception` for **one of the 10 requested docs**. The other 9 succeed, but that one doc carries an `error`, so the client marks the whole
  response `IsValid == false` and the test fails.

  **Why it's flaky:** it's a pure timing race between "read the doc" and "merge the segment". Most runs they don't collide → all 10 docs return → green. Occasionally they collide → one doc
  errors → red.
  
  **This is a server-side k-NN race, not a client bug** — the client faithfully reports the per-doc error the server returned. The underlying defect (a merge closing a vector file a
  `get`/`_mget` is still reading) really belongs upstream in `opensearch-project/k-NN`.

  ## Changes
  
  Disable derived source on the `project` test index so the vector is stored in `_source` and the merge-vs-read race can't occur:

 
  - Version-guarded because index.knn.derived_source.enabled only exists on k-NN ≥ 2.19 (verified against the 2.16 / 2.19 / 3.0 branches). Adding it unconditionally would break index creation on 2.16 and older.
  - Client test coverage is unchanged — derived source is a transparent storage optimization, so the request bytes and the returned _source are identical whether it's on or off. This test verifies the client's _mget + routing behavior, not the server's k-NN storage internals.

  Testing / limitation

  I couldn't run the integration suite locally: the harness downloads a Linux-only server bundle, so the macos-* download URLs return 403 on my machine (verified via curl -I; linux-* return 200). Locally I verified only that dotnet build passes (0 warnings, 0 errors), and confirmed the changed code is only reached during integration seeding (so unit tests are unaffected).

  The flakiness is timing-dependent and reproduces on CI (Linux, multi-version matrix), not reliably on a single local run.

  🙏 Could a maintainer approve a CI run so the 3.x integration tests can validate this against real clusters? Happy to iterate on anything.

  Issues Resolved
  
  Related to #988.

  Check List

  - [x] Commits are signed per the DCO using --signoff.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.