### PR TITLE
Remove EOL net6.0 target from OpenSearch.Net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for `data_type` (byte vectors), `space_type`, `mode`, and `compression_level` on the `knn_vector` field mapping ([#994](https://github.com/opensearch-project/opensearch-net/issues/994))
 - Added support for `method_parameters`, `rescore`, and `expand_nested_docs` on `KnnQuery` ([#994](https://github.com/opensearch-project/opensearch-net/issues/994))
 ### Removed
+- Removed support for the `net6.0` target as .NET 6 is EOL ([#1008](https://github.com/opensearch-project/opensearch-net/pull/1008))
 ### Fixed
 - Fixed `MaxTimeoutReached`, `MaxRetriesReached`, and `FailedOverAllNodes` audit events having `Ended` stuck at `default(DateTime)` due to undisposed `Auditable` instances in `RequestPipeline.CreateClientException` ([#998](https://github.com/opensearch-project/opensearch-net/issues/998))
 - Fixed flaky `MovingAverageHoltWintersUsageTests` integration test which asserted moving-average values are non-negative; Holt-Winters forecasts can legitimately be negative, so the assertion now only checks the values deserialize to finite numbers ([#1000](https://github.com/opensearch-project/opensearch-net/issues/1000))

--- a/src/OpenSearch.Net/OpenSearch.Net.csproj
+++ b/src/OpenSearch.Net/OpenSearch.Net.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## Summary

Based on migration guide to 2.0 https://github.com/opensearch-project/opensearch-net/blob/37c43ea4b9290ec495846c2682ae0e7a7e644b56/UPGRADING.md?plain=1#L61


- Drops `net6.0` from `TargetFrameworks` in `OpenSearch.Net.csproj` — .NET 6 reached end-of-life in November 2023
- Remaining targets: `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`

## Test plan

- [ ] `dotnet build src/OpenSearch.Net/OpenSearch.Net.csproj` succeeds with 0 warnings across the 4 remaining TFMs
- [ ] CI compile and unit-test workflows pass