### PR TITLE
add Hailong-am as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @anirudha @joshuali925 @Xtansia @VachaShah @MaxKsyunz @Yury-Fridlyand @SamuelCox
+*   @anirudha @joshuali925 @Xtansia @VachaShah @SamuelCox @Hailong-am

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @anirudha @joshuali925 @Xtansia @VachaShah @SamuelCox @Hailong-am
+*   @anirudha @joshuali925 @Xtansia @SamuelCox @Hailong-am

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Anirudha Jadhav | [anirudha](https://github.com/anirudha)             | Amazon      |
 | Joshua Li       | [joshuali925](https://github.com/joshuali925)       | Amazon      |
 | Thomas Farr     | [Xtansia](https://github.com/Xtansia)               | Independent |
-| Vacha Shah      | [VachaShah](https://github.com/VachaShah)           | Amazon      |
 | Samuel Cox      | [SamuelCox](https://github.com/SamuelCox)           | Independent |
 | Hailong Cui     | [Hailong-am](https://github.com/Hailong-am)         | Amazon      |
 
@@ -20,3 +19,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Daniel Doubrovkine | [dblock](https://github.com/dblock)                 | Independent |
 | Max Ksyunz         | [MaxKsyunz](https://github.com/MaxKsyunz)           | Bit Quill   |
 | Yury Fridlyand     | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Bit Quill   |
+| Vacha Shah         | [VachaShah](https://github.com/VachaShah)           | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,12 +10,13 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Joshua Li       | [joshuali925](https://github.com/joshuali925)       | Amazon      |
 | Thomas Farr     | [Xtansia](https://github.com/Xtansia)               | Independent |
 | Vacha Shah      | [VachaShah](https://github.com/VachaShah)           | Amazon      |
-| Max Ksyunz      | [MaxKsyunz](https://github.com/MaxKsyunz)           | Bit Quill   |
-| Yury Fridlyand  | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Bit Quill   |
 | Samuel Cox      | [SamuelCox](https://github.com/SamuelCox)           | Independent |
+| Hailong Cui     | [Hailong-am](https://github.com/Hailong-am)         | Amazon      |
 
 ## Emeritus
 
-| Maintainer         | GitHub ID                               | Affiliation |
-| ------------------ | --------------------------------------- | ----------- |
-| Daniel Doubrovkine | [dblock](https://github.com/dblock)     | Independent |
+| Maintainer         | GitHub ID                                           | Affiliation |
+| ------------------ | --------------------------------------------------- | ----------- |
+| Daniel Doubrovkine | [dblock](https://github.com/dblock)                 | Independent |
+| Max Ksyunz         | [MaxKsyunz](https://github.com/MaxKsyunz)           | Bit Quill   |
+| Yury Fridlyand     | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Bit Quill   |


### PR DESCRIPTION
### Description

We have received upvotes from `SamuelCox`, `anirudha`, and myself in the nomination email. This PR adds @Hailong-am as a maintainer.

We also lost contact to Max and Yury as they left Bit Quill, moving them to Emeritus maintainers.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
