### PR TITLE
Add OpenSearch 3.8.0 to CI integration test matrix

### DIFF
--- a/.github/workflows/integration-yaml-tests.yml
+++ b/.github/workflows/integration-yaml-tests.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 3.8.0
           - 3.6.0
           - 3.4.0
           - 3.2.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 3.8.0
           - 3.6.0
           - 3.4.0
           - 3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### ⚠️ Breaking Changes ⚠️
 ### Changed
+- Added OpenSearch 3.8.0 to the CI integration test matrix ([#1014](https://github.com/opensearch-project/opensearch-net/pull/1014))
 ### Added
 - Added support for `wildcard` field type ([#1004](https://github.com/opensearch-project/opensearch-net/pull/1004))
 - Added support for `data_type` (byte vectors), `space_type`, `mode`, and `compression_level` on the `knn_vector` field mapping ([#994](https://github.com/opensearch-project/opensearch-net/issues/994))


### PR DESCRIPTION
### Description

Adds OpenSearch 3.8.0 to the CI integration test matrix so that both the integration tests and YAML tests run against the latest released minor version.

### Changes

- `.github/workflows/integration.yml`: added `3.8.0` to the released version matrix
- `.github/workflows/integration-yaml-tests.yml`: added `3.8.0` to the released version matrix

### Testing / verification

- CI will validate by running the full integration and YAML test suites against OpenSearch 3.8.0.

### Check List

- [x] New functionality includes testing (CI matrix entry is the test).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.