### PR TITLE
Bump Microsoft.SourceLink.GitHub to 10.0.111 to fix CVE-2026-62900

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed flaky `MovingAverageHoltWintersUsageTests` integration test which asserted moving-average values are non-negative; Holt-Winters forecasts can legitimately be negative, so the assertion now only checks the values deserialize to finite numbers ([#1000](https://github.com/opensearch-project/opensearch-net/issues/1000))
 - Fixed `DeleteByQueryResponse.IsValid` and `UpdateByQueryResponse.IsValid` returning `true` on transport-level failures (no HTTP response) by restoring the `ApiCall.Success` check that the overrides had dropped ([#997](https://github.com/opensearch-project/opensearch-net/issues/997))
 ### Dependencies
+- Bumps `Microsoft.SourceLink.GitHub` from 8.0.0 to 10.0.111 to resolve CVE-2026-62900 in the transitive `Microsoft.Build.Tasks.Git` dependency ([#1021](https://github.com/opensearch-project/opensearch-net/issues/1021))
 
 ## [2.0.0]
 

--- a/src/_PublishArtifacts.Build.props
+++ b/src/_PublishArtifacts.Build.props
@@ -7,7 +7,7 @@
     <PackageIcon>nuget-icon.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.111" PrivateAssets="All" />
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

`Microsoft.SourceLink.GitHub` 8.0.0 (referenced in `src/_PublishArtifacts.Build.props`) pulls in the transitive dependency `Microsoft.Build.Tasks.Git` 8.0.0, which is affected by [CVE-2026-62900](https://www.mend.io/vulnerability-database/CVE-2026-62900) (improper removal of sensitive information before storage or transfer, CVSS 5.9).

This bumps `Microsoft.SourceLink.GitHub` to `10.0.111`, resolving the vulnerability.

`Microsoft.SourceLink.GitHub` is a build-time-only, `PrivateAssets="All"` dependency used solely to embed source link metadata into published symbols/packages — it has no runtime or public API surface, so this change carries no behavioral risk.

## Issues Resolved

Fixes #1021

## Check List
- [x] Adding a changelog entry (`### Dependencies` under `[Unreleased]`)
- [ ] New functionality includes testing (n/a — dependency version bump only)
- [ ] New functionality has been documented (n/a)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.