### PR TITLE
Bump version to 2.1.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### ⚠️ Breaking Changes ⚠️
 ### Changed
+### Added
+### Removed
+### Fixed
+### Dependencies
+
+## [2.1.0]
+### ⚠️ Breaking Changes ⚠️
+### Changed
 - Added OpenSearch 3.8.0 to the CI integration test matrix ([#1014](https://github.com/opensearch-project/opensearch-net/pull/1014))
 ### Added
 - Added a `System.Text.Json` opt-in for the low-level client (`ConnectionConfiguration.UseSystemTextJson()`, plus the `OSC_USE_STJ` environment variable), mirroring the existing high-level `ConnectionSettings.UseSystemTextJson()` switch, so a standalone low-level client can select the same engine independently of a high-level one ([#388](https://github.com/opensearch-project/opensearch-net/issues/388))
@@ -23,6 +31,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `DeleteByQueryResponse.IsValid` and `UpdateByQueryResponse.IsValid` returning `true` on transport-level failures (no HTTP response) by restoring the `ApiCall.Success` check that the overrides had dropped ([#997](https://github.com/opensearch-project/opensearch-net/issues/997))
 ### Dependencies
 - Bumps `Microsoft.SourceLink.GitHub` from 8.0.0 to 10.0.111 to resolve CVE-2026-62900 in the transitive `Microsoft.Build.Tasks.Git` dependency ([#1021](https://github.com/opensearch-project/opensearch-net/issues/1021))
+- Bumps `AWSSDK.Core` from 4.0.7.1 to 4.0.100.4 ([#993](https://github.com/opensearch-project/opensearch-net/pull/993))
+- Bumps `Bogus` from 35.6.3 to 35.6.5 ([#972](https://github.com/opensearch-project/opensearch-net/pull/972))
+- Bumps `Bullseye` from 5.0.0 to 6.1.0 ([#973](https://github.com/opensearch-project/opensearch-net/pull/973))
 
 ## [2.0.0]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <!-- Default Version numbers -->
   <PropertyGroup>
-    <CurrentVersion>2.0.0</CurrentVersion>
-    <CurrentAssemblyVersion>2.0.0</CurrentAssemblyVersion>
-    <CurrentAssemblyFileVersion>2.0.0</CurrentAssemblyFileVersion>
+    <CurrentVersion>2.1.0</CurrentVersion>
+    <CurrentAssemblyVersion>2.1.0</CurrentAssemblyVersion>
+    <CurrentAssemblyFileVersion>2.1.0</CurrentAssemblyFileVersion>
     <!-- Version and Informational reflect actual version -->
     <Version>$(CurrentVersion)</Version>
     <InformationalVersion>$(CurrentVersion)</InformationalVersion>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 **OpenSearch.Client** is [a community-driven, open source fork](https://aws.amazon.com/blogs/opensource/introducing-opensearch/) of elasticsearch-net high level client NEST licensed under the [Apache v2.0 License](LICENSE.txt). For more information, see [opensearch.org](https://opensearch.org/).
 
 ## Stable Release
-You're reading the documentation for the next release of opensearch-net, which should be **2.0.0**.
+You're reading the documentation for the next release of opensearch-net, which should be **2.1.0**.
 Please read [UPGRADING](UPGRADING.md) when upgrading from a previous version.
 The current stable release is [1.7.1](https://github.com/opensearch-project/opensearch-net/blob/v1.7.1/README.md).
 

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "rollForward": "latestFeature",
     "allowPrerelease": false
   },
-  "version": "2.0.0",
-  "doc_current": "2.0",
+  "version": "2.1.0",
+  "doc_current": "2.1",
   "doc_branch": "2.x"
 }


### PR DESCRIPTION
### Description
Bump version to 2.1.0 for 2.1.0 release by running `.github/bump-version.sh 2.1.0`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
