### PR TITLE
Update API spec download to use api-spec.opensearch.org

### DIFF
--- a/.github/workflows/code-gen.yml
+++ b/.github/workflows/code-gen.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Run Code Generator
-        run: ./build.sh codegen --branch main --include-high-level
+        run: ./build.sh codegen --include-high-level
 
       - name: Check For Uncommitted Changes
         shell: bash -eo pipefail {0}
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Download Latest Spec && Run Code Generator
-        run: ./build.sh codegen --branch main --include-high-level --download
+        run: ./build.sh codegen --include-high-level --download
 
       - name: Get Current Date
         id: date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### ⚠️ Breaking Changes ⚠️
 ### Changed
+
+- Updated API spec downloader to fetch from `https://api-spec.opensearch.org/opensearch-openapi.yaml` instead of the branch-pinned GitHub releases URL; removed the `--branch` CLI parameter from the ApiGenerator ([#1030](https://github.com/opensearch-project/opensearch-net/pull/1030))
+
 ### Added
 
 - Added initial support for the bulk streaming API ([#935](https://github.com/opensearch-project/opensearch-net/pull/935))

--- a/src/ApiGenerator/Program.cs
+++ b/src/ApiGenerator/Program.cs
@@ -44,7 +44,6 @@ namespace ApiGenerator
         /// <summary>
         /// A main function can also take <see cref="CancellationToken"/> which is hooked up to support termination (e.g CTRL+C)
         /// </summary>
-        /// <param name="branch">The stack's branch we are targeting the generation for</param>
         /// <param name="interactive">Run the generation interactively, this will ignore all flags</param>
         /// <param name="download">Whether to download the specs or use an already downloaded copy</param>
         /// <param name="includeHighLevel">Also generate the high level client (OpenSearch.Client)</param>
@@ -52,18 +51,13 @@ namespace ApiGenerator
         /// <param name="token"></param>
         /// <returns></returns>
         private static async Task<int> Main(
-            string branch, bool interactive = false, bool download = false, bool includeHighLevel = false, bool skipGenerate = false
+            bool interactive = false, bool download = false, bool includeHighLevel = false, bool skipGenerate = false
             , CancellationToken token = default)
         {
             Interactive = interactive;
             try
             {
-                if (string.IsNullOrEmpty(branch))
-                {
-
-                    throw new ArgumentException("--branch can not be null");
-                }
-                await Generate(download, branch, includeHighLevel, skipGenerate, token);
+                await Generate(download, includeHighLevel, skipGenerate, token);
             }
             catch (OperationCanceledException)
             {
@@ -83,21 +77,9 @@ namespace ApiGenerator
             return 0;
         }
 
-        private static async Task<int> Generate(bool download, string branch, bool includeHighLevel, bool skipGenerate, CancellationToken token = default)
+        private static async Task<int> Generate(bool download, bool includeHighLevel, bool skipGenerate, CancellationToken token = default)
         {
             var redownloadCoreSpecification = Ask("Download online rest specifications?", download);
-
-            var downloadBranch = branch;
-            if (Interactive && redownloadCoreSpecification)
-            {
-                Console.Write($"Branch to download specification from (default {downloadBranch}): ");
-                var readBranch = Console.ReadLine()?.Trim();
-                if (!string.IsNullOrEmpty(readBranch))
-                    downloadBranch = readBranch;
-            }
-
-            if (string.IsNullOrEmpty(downloadBranch))
-                throw new Exception($"Branch to download from is null or empty");
 
             var generateCode = Ask("Generate code from the specification files on disk?", !skipGenerate);
             var lowLevelOnly = generateCode && Ask("Generate low level client only?", !includeHighLevel);
@@ -107,7 +89,6 @@ namespace ApiGenerator
                 .AddColumn(new GridColumn().PadRight(4))
                 .AddColumn()
                 .AddRow("[b]Download specification[/]", $"{YesNo(download)}")
-                .AddRow("[b]Download branch[/]", $"{downloadBranch}")
                 .AddRow("[b]Generate code from specification[/]", $"{YesNo(generateCode)}")
                 .AddRow("[b]Include high level client[/]", $"{YesNo(!lowLevelOnly)}");
 
@@ -123,7 +104,7 @@ namespace ApiGenerator
                 Console.WriteLine();
                 AnsiConsole.Write(new Rule("[b white on chartreuse4] Downloading specification [/]").LeftJustified());
                 Console.WriteLine();
-                await RestSpecDownloader.DownloadAsync(downloadBranch, token);
+                await RestSpecDownloader.DownloadAsync(token);
             }
 
             if (!generateCode) return 0;

--- a/src/ApiGenerator/RestSpecDownloader.cs
+++ b/src/ApiGenerator/RestSpecDownloader.cs
@@ -39,13 +39,14 @@ namespace ApiGenerator
     {
 		private static readonly HttpClient Http = new();
 
-		public static async Task DownloadAsync(string branch, CancellationToken token)
+		private const string SpecUrl = "https://api-spec.opensearch.org/opensearch-openapi.yaml";
+
+	public static async Task DownloadAsync(CancellationToken token)
 		{
-			var githubUrl = $"https://github.com/opensearch-project/opensearch-api-specification/releases/download/{branch}-latest/opensearch-openapi.yaml";
-			Console.WriteLine($"Downloading OpenAPI spec for branch {branch}");
-			var spec = await Http.GetStringAsync(githubUrl, token);
+			Console.WriteLine($"Downloading OpenAPI spec from {SpecUrl}");
+			var spec = await Http.GetStringAsync(SpecUrl, token);
 			await File.WriteAllTextAsync(GeneratorLocations.OpenApiSpecFile, spec, token);
-            Console.WriteLine($"Downloaded OpenAPI spec for branch {branch}");
+            Console.WriteLine("Downloaded OpenAPI spec");
         }
 	}
 }


### PR DESCRIPTION
## Description

Coming from  https://github.com/opensearch-project/opensearch-api-specification/pull/1200

Replace the branch-parameterized GitHub releases URL with the stable endpoint at `https://api-spec.opensearch.org/opensearch-openapi.yaml`.

Previously the downloader constructed a URL like:
```
https://github.com/opensearch-project/opensearch-api-specification/releases/download/{branch}-latest/opensearch-openapi.yaml
```
This required callers to pass `--branch <name>`, which was only used to build that URL.

## Changes

- `RestSpecDownloader`: use fixed URL `https://api-spec.opensearch.org/opensearch-openapi.yaml`; remove `branch` parameter from `DownloadAsync`
- `Program.cs`: remove `--branch` CLI parameter and all branch-download scaffolding
- `.github/workflows/code-gen.yml`: drop `--branch main` from both codegen invocations

## Testing

Manually verified the new URL is reachable and returns a valid OpenAPI spec (v0.3.0, API version 2.16.0).

## Checklist

- [x] Commits are signed off (`-s`)
- [x] No breaking changes to generated output (URL change only affects the download step)