### PR TITLE
ci: use opensearch-ci-bot PAT in Code Generation workflow

### DIFF
--- a/.github/workflows/code-gen.yml
+++ b/.github/workflows/code-gen.yml
@@ -76,17 +76,11 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      - name: Generate GitHub App Token
-        id: github_app_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
-          token: ${{ steps.github_app_token.outputs.token }}
+          push-to-fork: opensearch-ci-bot/opensearch-net
+          token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           commit-message: Re-generate client code using latest OpenSearch API specification (${{ steps.date.outputs.date }})
           title: Re-generated client code using latest OpenSearch API specification
           body: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fixed `SerializeAsync` and `DeserializeAsync` diagnostic spans measuring only Task creation time instead of actual execution time ([#950](https://github.com/opensearch-project/opensearch-net/issues/950))
+- Replaced the GitHub App token with the `opensearch-ci-bot` PAT in the Code Generation workflow ([#1035](https://github.com/opensearch-project/opensearch-net/pull/1035))
 
 ### Dependencies
 


### PR DESCRIPTION
### Problem / Motivation

The **Code Generation** workflow's scheduled/dispatch `update_spec` job fails at the *Generate GitHub App Token* step:

> The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.

`actions/create-github-app-token` is invoked with `app-id: ${{ secrets.APP_ID }}` and `private-key: ${{ secrets.APP_PRIVATE_KEY }}`, but those secrets are not configured in this repository, so the action receives empty inputs and fails. This blocks the automated "re-generate client code from the latest OpenSearch API spec" PR from ever being opened.

Failing run: https://github.com/opensearch-project/opensearch-net/actions/runs/33855081412

### Why it matters

The weekly (and on-demand) spec-update automation cannot open its PR, so generated client code silently drifts from the published OpenSearch API spec until someone regenerates it by hand.

### What changed

- Removed the *Generate GitHub App Token* step (`actions/create-github-app-token`) that depended on the unset `APP_ID` / `APP_PRIVATE_KEY` secrets.
- Switched `peter-evans/create-pull-request` to authenticate with the `OPENSEARCH_CI_BOT_TOKEN` PAT and push the generated branch to the bot's fork via `push-to-fork: opensearch-ci-bot/opensearch-net`.

This mirrors the equivalent fix in opensearch-js ([PR #1130](https://github.com/opensearch-project/opensearch-js/pull/1130)).



