### PR TITLE
ci: bump peter-evans/create-pull-request to v7

### DIFF
--- a/.github/workflows/code-gen.yml
+++ b/.github/workflows/code-gen.yml
@@ -77,7 +77,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           push-to-fork: opensearch-ci-bot/opensearch-net
           token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed `SerializeAsync` and `DeserializeAsync` diagnostic spans measuring only Task creation time instead of actual execution time ([#950](https://github.com/opensearch-project/opensearch-net/issues/950))
 - Replaced the GitHub App token with the `opensearch-ci-bot` PAT in the Code Generation workflow ([#1035](https://github.com/opensearch-project/opensearch-net/pull/1035))
+- Fixed the Code Generation workflow failing to open its regeneration pull request with `remote: Duplicate header: "Authorization"` (git exit 128), by bumping `peter-evans/create-pull-request` to v7 ([#1042](https://github.com/opensearch-project/opensearch-net/pull/1042))
 
 ### Dependencies
 


### PR DESCRIPTION
## Problem / Motivation

The scheduled **Code Generation** workflow (`.github/workflows/code-gen.yml`) fails at the **Create Pull Request** step. Failed run: https://github.com/opensearch-project/opensearch-net/actions/runs/34070887129/job/101587882168

```
remote: Duplicate header: "Authorization"
The process '/usr/bin/git' failed with exit code 128
```

## Why it matters

This is the job that pulls the latest OpenSearch API spec and re-generates the client every Monday. While it is broken, the .NET client silently stops tracking the spec — no regen PR is opened, and the drift is invisible until someone notices by hand.


